### PR TITLE
Add permission can_delete_own_sets

### DIFF
--- a/app/conf/access_restrictions.conf
+++ b/app/conf/access_restrictions.conf
@@ -1337,7 +1337,8 @@ access_restrictions = {
 	},
 	manage/sets/SetEditorController/Delete = {
 		default = {
-			actions = { can_delete_sets }
+		  operator = OR,
+			actions = { can_delete_sets, can_delete_own_sets }
 		}
 	},
 	manage/TagsController = {

--- a/app/conf/user_actions.conf
+++ b/app/conf/user_actions.conf
@@ -147,6 +147,10 @@ user_actions = {
 				label = _("Delete sets and set content"),
 				description = _("Allow user to delete sets for which they have access privileges")
 			},
+      can_delete_own_sets = {
+        label = _("Delete own sets and set content"),
+        description = _("Allow user to delete sets which they created")
+      },
 			can_view_sets = {
 				label = _("View sets"),
 				description = _("Allow user to view sets of objects or authority items for which they have access privileges")

--- a/app/controllers/manage/SetController.php
+++ b/app/controllers/manage/SetController.php
@@ -35,7 +35,13 @@
  			JavascriptLoadManager::register('tableList');
  			$t_set = new ca_sets();
  			$this->view->setVar('t_set', $t_set);
- 			$this->view->setVar('set_list', $va_set_list = caExtractValuesByUserLocale($t_set->getSets(array('user_id' => $this->request->getUserID(), 'access' => __CA_SET_EDIT_ACCESS__)), null, null, array()));
+      $va_set_list = caExtractValuesByUserLocale($t_set->getSets(array('user_id' => $this->request->getUserID(), 'access' => __CA_SET_EDIT_ACCESS__)), null, null, array());
+ 			if ($va_set_list) {
+        foreach ($va_set_list as $id => $va_set) {
+          $va_set_list[$id]['can_delete'] = $this->UserCanDeleteSet($va_set['user_id']);
+        }
+      }
+      $this->view->setVar('set_list', $va_set_list);
  			
  			// get content types for sets
  			$this->view->setVar('table_list', caFilterTableList($t_set->getFieldInfo('table_num', 'BOUNDS_CHOICE_LIST')));
@@ -48,6 +54,22 @@
 				
  			$this->render('set_list_html.php');
  		}
+ 		# -------------------------------------------------------
+    private function UserCanDeleteSet($user_id) {
+      $can_delete = FALSE;
+      // If users can delete all sets, show Delete button
+      if ($this->request->user->canDoAction('can_delete_sets')) {
+        $can_delete = TRUE;
+      }
+
+      // If users can delete own sets, and this set belongs to them, show Delete button
+      if ($this->request->user->canDoAction('can_delete_own_sets')) {
+        if ($user_id == $this->request->getUserID()) {
+          $can_delete = TRUE;
+        }
+      }
+      return $can_delete;
+    }
  		# -------------------------------------------------------
  		/**
  		 * 

--- a/app/controllers/manage/sets/SetEditorController.php
+++ b/app/controllers/manage/sets/SetEditorController.php
@@ -55,9 +55,39 @@
  			return $va_init;
  		}
  		# -------------------------------------------------------
- 		public function Edit() {
+ 		public function Edit($pa_values=null, $pa_options=null) {
+      list($vn_subject_id, $t_subject, $t_ui, $vn_parent_id, $vn_above_id) = $this->_initView($pa_options);
+      $this->view->setVar('can_delete', $this->UserCanDeleteSet($t_subject->get('user_id')));
  			parent::Edit();
  		}
+ 		# -------------------------------------------------------
+ 		public function Delete($pa_options=null) {
+ 			list($vn_subject_id, $t_subject, $t_ui) = $this->_initView($pa_options);
+
+ 			if (!$vn_subject_id) { return; }
+      if (!$this->UserCanDeleteSet($t_subject->get('user_id'))) {
+        $this->postError(2320, _t("Access denied here"), "RequestDispatcher->dispatch()");
+      }
+      else {
+        parent::Delete($pa_options);
+      }
+    }
+    # -------------------------------------------------------
+    private function UserCanDeleteSet($user_id) {
+      $can_delete = FALSE;
+      // If users can delete all sets, show Delete button
+      if ($this->request->user->canDoAction('can_delete_sets')) {
+        $can_delete = TRUE;
+      }
+
+      // If users can delete own sets, and this set belongs to them, show Delete button
+      if ($this->request->user->canDoAction('can_delete_own_sets')) {
+        if ($user_id == $this->request->getUserID()) {
+          $can_delete = TRUE;
+        }
+      }
+      return $can_delete;
+    }
  		# -------------------------------------------------------
  		# Ajax handlers
  		# -------------------------------------------------------

--- a/themes/default/views/manage/set_list_html.php
+++ b/themes/default/views/manage/set_list_html.php
@@ -114,7 +114,7 @@
 				<td width="50">
 					<?php print caNavButton($this->request, __CA_NAV_BUTTON_EDIT__, _t("Edit"), 'manage/sets', 'SetEditor', 'Edit', array('set_id' => $va_set['set_id']), array(), array('icon_position' => __CA_NAV_BUTTON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)); ?>
 					
-					<?php print caNavButton($this->request, __CA_NAV_BUTTON_DELETE__, _t("Delete"), 'manage/sets', 'SetEditor', 'Delete', array('set_id' => $va_set['set_id']), array(), array('icon_position' => __CA_NAV_BUTTON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)); ?>
+					<?php ($va_set['can_delete'] == TRUE) ? print caNavButton($this->request, __CA_NAV_BUTTON_DELETE__, _t("Delete"), 'manage/sets', 'SetEditor', 'Delete', array('set_id' => $va_set['set_id']), array(), array('icon_position' => __CA_NAV_BUTTON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)) : ''; ?>
 				</td>
 			</tr>
 <?php

--- a/themes/default/views/manage/sets/screen_html.php
+++ b/themes/default/views/manage/sets/screen_html.php
@@ -27,6 +27,7 @@
  */
  	$t_set = $this->getVar('t_subject');
 	$vn_set_id = $this->getVar('subject_id');
+	$can_delete = $this->getVar('can_delete');
 	
 	$t_ui = $this->getVar('t_ui');	
 ?>
@@ -36,7 +37,7 @@
 			caFormSubmitButton($this->request, __CA_NAV_BUTTON_SAVE__, _t("Save"), 'SetEditorForm').' '.
 			caNavButton($this->request, __CA_NAV_BUTTON_CANCEL__, _t("Cancel"), 'manage/sets', 'SetEditor', 'Edit/'.$this->request->getActionExtra(), array('set_id' => $vn_set_id)), 
 			'', 
-			((intval($vn_set_id) > 0) && ($this->request->user->canDoAction('can_delete_sets'))) ? caNavButton($this->request, __CA_NAV_BUTTON_DELETE__, _t("Delete"), 'manage/sets', 'SetEditor', 'Delete/'.$this->request->getActionExtra(), array('set_id' => $vn_set_id)) : ''
+			((intval($vn_set_id) > 0) && ($can_delete)) ? caNavButton($this->request, __CA_NAV_BUTTON_DELETE__, _t("Delete"), 'manage/sets', 'SetEditor', 'Delete/'.$this->request->getActionExtra(), array('set_id' => $vn_set_id)) : ''
 		);
 		
 			print caFormTag($this->request, 'Save/'.$this->request->getActionExtra().'/set_id/'.$vn_set_id, 'SetEditorForm', null, 'POST', 'multipart/form-data');


### PR DESCRIPTION
This allows for users to collaborate on shared sets, without having the ability to delete each others set.
This permission does not impact users who have permission to can_delete_sets, which overrules the can_delete_own_sets permission.
