### PR TITLE
Bundle default cataloguing locale selection doesn't save locale-id for single-language installations

### DIFF
--- a/js/ca/ca.genericbundle.js
+++ b/js/ca/ca.genericbundle.js
@@ -263,10 +263,16 @@ var caUI = caUI || {};
 						// No locale drop-down, or it somehow doesn't include the locale we want
 						jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n).after("<input type='hidden' name='" + this.fieldNamePrefix + "locale_id_" + templateValues.n + "' value='" + that.defaultLocaleID + "'/>");
 						jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n).remove();
-						
 					}
 				} else {
-				  jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n +" option[value=" + that.defaultLocaleID + "]").attr('selected', true);
+					if (jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n +" option[value=" + that.defaultLocaleID + "]").length) {
+						// There's a locale drop-dow to mess with
+						jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n +" option[value=" + that.defaultLocaleID + "]").attr('selected', true);
+					} else {
+						// No locale drop-down, or it somehow doesn't include the locale we want
+						jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n).after("<input type='hidden' name='" + this.fieldNamePrefix + "locale_id_" + templateValues.n + "' value='" + that.defaultLocaleID + "'/>");
+						jQuery(this.container + " #" + this.fieldNamePrefix + "locale_id_" + templateValues.n).remove();
+					}
 				}
 			}
 			


### PR DESCRIPTION
As per PROV-417 the ca.genericbundle.js file was altered to select the default cataloguing language in a locale selection dropdown, rather than the default English.

However there was still some code missing to make this also work for single-locale installations. With the current code, attributes get saved in the database without a locale_id set.
Given that the installation is single-language anyway, this isn't a huge issue.

However, the problems arise when you enable an extra cataloguing locale on an install which previously only had one. The attributes that were saved earlier still have no locale_id, causing all sorts of problems.

This is easily fixed by adding some extra logic, as provided by this pull request.

I have tested this code on both a single-locale installation & multi-locale installation, and both work fine and as expected.
