### PR TITLE
Fix: wrong field-name used 

### DIFF
--- a/app/controllers/administrate/access/UsersController.php
+++ b/app/controllers/administrate/access/UsersController.php
@@ -282,8 +282,9 @@
 							break;
 							# -----------------------
 							case "last_login":
-								if (!is_array($va_vars = $qr_users->getVars('vars'))) { $va_vars = array(); }
-
+								//if (!is_array($va_vars = $qr_users->getVars('vars'))) { $va_vars = array(); }
+                                                                if (!is_array($va_vars = $qr_users->getVars('volatile_vars'))) { $va_vars = array(); }
+                                                                
 								if ($va_vars['last_login'] > 0) {
 									$o_tep->setUnixTimestamps($va_vars['last_login'], $va_vars['last_login']);
 									$va_row[] = $o_tep->getText();


### PR DESCRIPTION
last_login information is contained in 'volatile_vars' field  and not in 'vars' field of ca_users table
