### PR TITLE
Added feature requested in PROV-485

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -945,6 +945,11 @@ sms_api_key = MY_SENDHUB_API_KEY
 # Ex. CDN = Canadian dollars
 default_dollar_currency = USD
 
+# Set this to a standard 3-letter currency code if you want this currency
+# to be added to 'currency-less' values in all Currency attributes
+# Ex. EUR = Euros
+default_currency = 0
+
 # -------------------------
 # User generated content
 # -------------------------

--- a/app/lib/ca/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/CurrencyAttributeValue.php
@@ -176,8 +176,20 @@
  					$vs_currency_specifier = trim($va_matches[2]);
  					$vs_value = preg_replace('/[^\d\.\-]/', '', trim($va_matches[1]));
  				} else {
- 					$this->postError(1970, _t('%1 is not a valid currency value; be sure to include a currency symbol', $pa_element_info['displayLabel']), 'CurrencyAttributeValue->parseValue()');
-					return false;
+ 					// try plain old decimal without currency, if default currency is set
+ 					$o_config = Configuration::load();
+ 					if(($vs_default_currency = $o_config->get('default_currency')) && (strlen($vs_default_currency) == 3)){
+ 						if (preg_match("!^([\d\.]+)$!", trim($ps_value), $va_matches)){
+ 							$vs_currency_specifier = $vs_default_currency;
+ 							$vs_value = preg_replace('/[^\d\.\-]/', '', trim($va_matches[1]));
+						} else {
+							$this->postError(1970, _t('%1 is not a valid currency value; be sure to include a currency symbol', $pa_element_info['displayLabel']), 'CurrencyAttributeValue->parseValue()');
+							return false;
+						}
+ 					} else {
+ 						$this->postError(1970, _t('%1 is not a valid currency value; be sure to include a currency symbol', $pa_element_info['displayLabel']), 'CurrencyAttributeValue->parseValue()');
+						return false;
+ 					}
  				}
  			}
  				 				


### PR DESCRIPTION
There is now a setting in app.conf that allows setting a default
currency for Currency attribute values. This is only used if the new
setting is set to non-zero value and for values that are plain old
decimal. You can still override the currency.

Pull request for quick review. This feature makes sense to me but maybe it actually doesn't ;-)
