### PR TITLE
Added feature requested in PROV-503

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1155,6 +1155,13 @@ require_once(__CA_LIB_DIR__."/ca/ApplicationPluginManager.php");
 
 				$vs_buf .= "<strong>"._t("Number of rules")."</strong>: ".$t_item->getRuleCount()."<br/>\n";
 			}
+
+			//
+			// Output configurable additional info from config, if set
+			// 
+			if ($vs_additional_info = $po_view->request->config->get("{$vs_table_name}_inspector_additional_info")) {
+				$vs_buf .= "<br/>".caProcessTemplateForIDs($vs_additional_info, $vs_table_name, array($t_item->getPrimaryKey()))."<br/>\n";
+			}
 			
 		// -------------------------------------------------------------------------------------
 		// Hierarchies


### PR DESCRIPTION
We talked about this: A customer wants to be able to output additional info about the current record in the inspector. The record title is already configurable via display template but that's not quite what they need, so I added this.

By adding something like this to your local config:

ca_objects_inspector_additional_info = <ifdef code="ca_collections.preferred_labels"><strong>Part of</strong>: ^ca_collections.preferred_labels (^ca_collections.type_id)</ifdef>

You can now get something like this:

![bildschirmfoto 2013-07-17 um 13 02 05](https://f.cloud.github.com/assets/1188614/811322/ace9bf60-eed0-11e2-9790-17d6e3463000.png)

Running this through a pull request to make sure it makes sense as a general feature.
