### PR TITLE
PROV-632 Fix Mattress Factory installation profile no longer installs

### DIFF
--- a/install/profiles/xml/mattress.xml
+++ b/install/profiles/xml/mattress.xml
@@ -3334,14 +3334,6 @@
             <setting name="minimumAttributeBundlesToDisplay">1</setting>
           </settings>
         </restriction>
-        <restriction code="r7">
-          <table>ca_object_events</table>
-          <settings>
-            <setting name="minAttributesPerRow">0</setting>
-            <setting name="maxAttributesPerRow">100</setting>
-            <setting name="minimumAttributeBundlesToDisplay">1</setting>
-          </settings>
-        </restriction>
       </typeRestrictions>
     </metadataElement>
     <metadataElement code="view" datatype="Container">


### PR DESCRIPTION
Remove ca_object_events from the type restrictions.
