### PR TITLE
NO-JIRA : added a hook inside caEditorInspector to allow plugin interaction

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1439,8 +1439,14 @@ require_once(__CA_LIB_DIR__."/ca/ApplicationPluginManager.php");
 
 			$vs_buf .= "</script>\n";
 		}
-		
-		return $vs_buf;
+
+        $o_app_plugin_manager = new ApplicationPluginManager();
+        $va_hookAppend = $o_app_plugin_manager->hookAppendToEditorInspector(array("t_item"=>$t_item));
+        if (is_string($va_hookAppend["caEditorInspectorAppend"])) {
+            $vs_buf .= $va_hookAppend["caEditorInspectorAppend"];
+        }
+
+        return $vs_buf;
 	}
 	# ------------------------------------------------------------------------------------------------
 	/**


### PR DESCRIPTION
New hook is called hookAppendToEditorInspector, it requires an array as parameter (as usual), containing the object shown by the editor (object, entity, set...) as "t_item" ; it returns its parameter array augmented with a "caEditorInspectorAppend" with html to add under the inspector.
That allows to add side contextual function buttons through plugins.
