### PR TITLE
Updating measurements with 'comma' issue

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -805,9 +805,11 @@ function caFileIsIncludable($ps_file) {
 	 * @return float The converted value
 	 */
 	function caConvertLocaleSpecificFloat($ps_value, $locale = "en_US") {
-		if (!function_exists("NumberFormatter")) { return $ps_value; }
 		$fmt = new NumberFormatter($locale, NumberFormatter::DECIMAL );
-		return (float)$fmt->parse($ps_value);
+        if (strpos($ps_value,'.') !== false)
+            return floatval($ps_value);
+        else
+		    return (float)$fmt->parse($ps_value);
 	}
 	# ---------------------------------------
 	/**

--- a/app/lib/ca/Attributes/Values/LengthAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/LengthAttributeValue.php
@@ -191,12 +191,15 @@
  					if ($vs_expression = trim(str_replace($va_matches[0], '', $vs_expression))) {
  						array_unshift($pa_values, $vs_expression);
  					}
- 					
- 					$vs_value  = 0;
- 					foreach($va_values as $vs_v) {
- 						$vs_value += caConvertLocaleSpecificFloat(trim($vs_v), $g_ui_locale);
-					}
-					
+                    $vs_value  = 0;
+                    if (class_exists("NumberFormatter")) {
+                        foreach($va_values as $vs_v) {
+                            $vs_value += caConvertLocaleSpecificFloat(trim($vs_v), $g_ui_locale);
+                        }
+                    }
+                    else
+                        $vs_value = floatval(str_replace(",", ".", $va_values[0]));
+
 					switch($vs_unit_expression) {
 						case "'":
 						case "’":


### PR DESCRIPTION
While editing/updating object measurements with comma the decimal part
of the value is lost;
For example when we try to update object height to 2,3 cm, the value is converted into 2.0 cm and stored in the database. 

This is caused when caConvertLocaleSpecificFloat returns string value instead of a floating number value, to function LengthAttributeValue::parseValue. 
The caConvertLocaleSpecificFloat function converts a string value into float only if function_exists("NumberFormatter") returns true. In case of false, it returns with a string value;

In this fix we check if "NumberFormatter" function exists(function_exists("NumberFormatter")) one level higher. We call caConvertLocaleSpecificFloat only if the check is positive, otherwise we convert the string value into the corresponding float value.
