### PR TITLE
Default value for lookup fields removed.

### DIFF
--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1342,7 +1342,6 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 					array(
 						'width' => (isset($pa_options['width']) && $pa_options['width'] > 0) ? $pa_options['width']: 300, 
 						'height' => (isset($pa_options['height']) && $pa_options['height'] > 0) ? $pa_options['height'] : 1, 
-						'value' => "{".$pa_options['element_id']."_label}", 
 						'maxlength' => 512,
 						'id' => $ps_name."_autocomplete",
 						'class' => 'lookupBg'
@@ -1351,7 +1350,6 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 				caHTMLHiddenInput(
 					$ps_name,
 					array(
-						'value' => "{".$pa_options['element_id']."}", 
 						'id' => $ps_name
 					)
 				);


### PR DESCRIPTION
Unlike other elements lookup field and its corresponding hidden field are filled with a default value. Advance search does not work if there is a lookup field on the search form, because both the lookup field and its corresponding hidden fields are initialized with a default value. Resetting or deleting default value only works for the lookup field not for the hidden field, therefor the search query in advance search will always contain the default value of the hidden field. This fix removes the assignment of default values for the lookup field and corresponding hidden field.
