### PR TITLE
Solr schema creation datatype issue fixed.

### DIFF
--- a/app/lib/core/Search/Solr/SolrConfiguration.php
+++ b/app/lib/core/Search/Solr/SolrConfiguration.php
@@ -178,11 +178,19 @@ class SolrConfiguration {
 						}
 					}
 					
-					if (is_array($va_attributes)) {
-						foreach($va_attributes as $vn_element_id => $va_element_info) {
-							$va_table_fields += SolrConfiguration::getElementType($va_element_info);
-						}
-					}
+                    if (is_array($va_attributes)) {
+                        $va_metadata_fields = array();
+                        foreach($va_attributes as $vn_element_id => $va_element_info) {
+                            $va_metadata_fields += SolrConfiguration::getElementType($va_element_info);
+                        }
+
+                        /*set datatype for metadata elements in $va_table_fields array*/
+                        foreach($va_metadata_fields as $key => $value){
+                            if (array_key_exists($key, $va_table_fields))
+                                unset($va_table_fields[$key]);
+                            $va_table_fields[$key] = $value;
+                        }
+                    }
 
 					/* we now have the current configuration */
 


### PR DESCRIPTION
Metadata elements have wrong data types in generated solr schema. For example, elements with data type 'geocode' and 'daterange' always have 'Text' data type in generated solr schema. The SolrConfiguration::getElementType function, which is used to get data type of each metadata element, returns correct data types but on the receiving side these types are not being handled in an appropriate way. This fix makes sure that correct data types are set for each metadata element before the schema generation.
