### PR TITLE
Search result navigation

### DIFF
--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -355,7 +355,6 @@
  				}
  			} else {
 				$this->notification->addNotification($vs_message, __NOTIFICATION_TYPE_INFO__);	
- 				$this->opo_result_context->invalidateCache();
   				$this->opo_result_context->saveContext();
  			}
  			# trigger "SaveItem" hook 


### PR DESCRIPTION
There is an issue while navigating among the search result pages. After updating a record on a certain page always takes back to the first page. An example scenario to understand this issue is:
a) Make a multipage basic search.
b) Move to another page, let say page 4.
c) Open a record on page 4 for editing.
d) Edit and save.
e) Return back to the results by using the RESULTS link on the left top side of the page.

The return request should take back to page 4 whereas it returns to page 1. We found that this is caused because cache is being invalidated while performing save operation. The fix we provide in this pull request solves this problem. 

We had another pull request with a fix for the same issue previously, but fix in this new pull request is better than the old one.
