### PR TITLE
Remove lookup field default value in advance search form

### DIFF
--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1342,7 +1342,7 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 					array(
 						'width' => (isset($pa_options['width']) && $pa_options['width'] > 0) ? $pa_options['width']: 300, 
 						'height' => (isset($pa_options['height']) && $pa_options['height'] > 0) ? $pa_options['height'] : 1, 
-						'value' => "{".$pa_options['element_id']."_label}", 
+						'value' => ($pa_options['request']->getController() === 'SearchObjectsAdvanced') ? "" : "{".$pa_options['element_id']."_label}",
 						'maxlength' => 512,
 						'id' => $ps_name."_autocomplete",
 						'class' => 'lookupBg'
@@ -1351,7 +1351,7 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 				caHTMLHiddenInput(
 					$ps_name,
 					array(
-						'value' => "{".$pa_options['element_id']."}", 
+						'value' => ($pa_options['request']->getController() === 'SearchObjectsAdvanced') ? "" : "{".$pa_options['element_id']."}",
 						'id' => $ps_name
 					)
 				);


### PR DESCRIPTION
In advance search 'lookup field' and its associated hidden field always have a default value. Default value is needed for 'lookup field' at other places in CA but in advance search it should not be. This fix identifies the request for drawing a 'lookup field', if it comes from advance search no default value is assigned to the lookup field and its associated hidden field.
