### PR TITLE
PROV-911 Prevent type error in foreach() loop.

### DIFF
--- a/app/models/ca_objects.php
+++ b/app/models/ca_objects.php
@@ -447,14 +447,16 @@ class ca_objects extends RepresentableBaseModel implements IBundleProvider {
 	# ------------------------------------------------------
 	public function delete($pb_delete_related=false, $pa_options=null, $pa_fields=null, $pa_table_list=null){
 		// nuke related representations
-		foreach($this->getRepresentations() as $va_rep){
-			// check if representation is in use anywhere else 
-			$qr_res = $this->getDb()->query("SELECT count(*) c FROM ca_objects_x_object_representations WHERE object_id <> ? AND representation_id = ?", (int)$this->getPrimaryKey(), (int)$va_rep["representation_id"]);
-			if ($qr_res->nextRow() && ($qr_res->get('c') == 0)) {
-				$this->removeRepresentation($va_rep["representation_id"], array('dontCheckPrimaryValue' => true));
+		$va_representations = $this->getRepresentations();
+		if (is_array($va_representations)) {
+			foreach ($va_representations as $va_rep){
+				// check if representation is in use anywhere else
+				$qr_res = $this->getDb()->query("SELECT count(*) c FROM ca_objects_x_object_representations WHERE object_id <> ? AND representation_id = ?", (int)$this->getPrimaryKey(), (int)$va_rep["representation_id"]);
+				if ($qr_res->nextRow() && ($qr_res->get('c') == 0)) {
+					$this->removeRepresentation($va_rep["representation_id"], array('dontCheckPrimaryValue' => true));
+				}
 			}
 		}
-
 		return parent::delete($pb_delete_related, $pa_options, $pa_fields, $pa_table_list);
 	}
 	# ------------------------------------------------------


### PR DESCRIPTION
It is possible that getRepresentations() returns null, so we need to ensure that the return value is
actually an array before attempting to loop over it.
