### PR TITLE
PROV-914 Fix GeocodeAttributeValueTest

### DIFF
--- a/support/tests/lib/ca/AttributeValues/GeocodeAttributeValueTest.php
+++ b/support/tests/lib/ca/AttributeValues/GeocodeAttributeValueTest.php
@@ -38,10 +38,10 @@ class GeocodeAttributeValueTest extends PHPUnit_Framework_TestCase {
 		$o_val = new GeocodeAttributeValue();
 
 		$va_return = $o_val->parseValue('[52.52000660000002,13.404954]',array());
-		$this->assertEquals($va_return['value_decimal1'],'52.52000660000002');
-		$this->assertEquals($va_return['value_decimal2'],'13.404954');
+		$this->assertEquals('52.52000660000002', $va_return['value_decimal1'], 'The correct latitude is returned from a lat/long pair');
+		$this->assertEquals('13.404954', $va_return['value_decimal2'], 'The correct latitude is returned from a lat/long pair');
 		// they do get rounded a bit in this format
-		$this->assertEquals($va_return['value_longtext2'],'52.5200066,13.404954');
+		$this->assertEquals('52.5200066,13.404954', $va_return['value_longtext2'], 'The correct latitude,longitude text value is returned from a lat/long pair');
 	}
 
 	public function testWithAddresses(){
@@ -49,16 +49,16 @@ class GeocodeAttributeValueTest extends PHPUnit_Framework_TestCase {
 
 		// google use this as example in their API docs, so let's hope it doesn't move ;-)
 		$va_return = $o_val->parseValue('1600 Amphitheatre Parkway, Mountain View, CA',array());
-		$this->assertEquals($va_return['value_decimal1'],'37.4219985');
-		$this->assertEquals($va_return['value_decimal2'],'-122.0839544');
-		$this->assertEquals($va_return['value_longtext2'],'37.4219985,-122.0839544');
+		$this->assertEquals('37.4219985', $va_return['value_decimal1'], 'The correct latitude is returned from an address lookup', 0.00001);
+		$this->assertEquals('-122.0839544', $va_return['value_decimal2'], 'The correct longitude is returned from an address lookup', 0.00001);
+		$this->assertRegExp('/^37.4219\d*,-122.0839\d*$/', $va_return['value_longtext2'], 'The correct latitude,longitude text value is returned from an address lookup');
 	}
 
 	public function testWithGarbage(){
 		$o_val = new GeocodeAttributeValue();
 
 		$vm_return = $o_val->parseValue('thisshouldntgiveusanyresultsfromgoogle',array());
-		$this->assertFalse($vm_return);
+		$this->assertFalse($vm_return, 'False is returned with garbage input');
 	}
 
 }


### PR DESCRIPTION
- Pass $delta to numeric comparison in address lookup where accuracy is not perfect.
- Use regexp match for string comparison in address lookup where accuracy is not perfect.
- Swap $expected and $actual around to the right order (expected first, then actual).
- Add test messages.
