### PR TITLE
interstitual information display

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3001,13 +3001,11 @@ $ca_relationship_lookup_parse_cache = array();
 					$va_items[$va_relation[$vs_rel_pk]][$vs_rel_pk] = $va_items[$va_relation[$vs_rel_pk]]['id'] = $va_relation[$vs_rel_pk];
 				}
 				
-				if (!isset($va_items[$va_relation[$vs_rel_pk]]['_display']) || !$va_items[$va_relation[$vs_rel_pk]]['_display']) {
-					if ($vs_template) {
-						$va_items[$va_relation[$vs_rel_pk]]['_display'] = caProcessTemplateForIDs($vs_template, $vs_rel_table, array($va_relation[$vs_rel_pk]), array('returnAsArray' => false, 'returnAsLink' => true, 'delimiter' => caGetOption('delimiter', $pa_options, $vs_display_delimiter), 'resolveLinksUsing' => $vs_rel_table));
-					} else {
-						$va_items[$va_relation[$vs_rel_pk]]['_display'] = $va_items[$va_relation[$vs_rel_pk]]['label'];
-					}
-				}
+                if ($vs_template) {
+                    $va_items[$va_relation[$vs_rel_pk]]['_display'] = caProcessTemplateForIDs($vs_template, $vs_rel_table, array($va_relation[$vs_rel_pk]), array('returnAsArray' => false, 'returnAsLink' => true, 'delimiter' => caGetOption('delimiter', $pa_options, $vs_display_delimiter), 'resolveLinksUsing' => $vs_rel_table));
+                } else {
+                    $va_items[$va_relation[$vs_rel_pk]]['_display'] = $va_items[$va_relation[$vs_rel_pk]]['label'];
+                }
 				
 				$va_tmp[$vn_relation_id] = $va_items[$va_relation[$vs_rel_pk]];
 			}


### PR DESCRIPTION
This pull request contains a fix for the following described issue about showing interstitual information:

Currently, information shown in interstitual relationship links in editors is not correct. Information from the first relationship type of a particular relationship is repeated in all other types of that relationship. An example is given in the following shown 'As it is' image. The repeated values are highlighted in red color.

As it is:
![wrong](https://cloud.githubusercontent.com/assets/3896702/2970926/5cc4025e-db63-11e3-8a36-2f2d7d12bc08.jpg)

Whereas, correct behavior is shown in the following 'As should be' image. Correct values are highlighted in green color.

As should be:
![correct](https://cloud.githubusercontent.com/assets/3896702/2970925/5cc1d092-db63-11e3-8864-354a06ef404a.jpg)

The problem is being caused by the following check:
"if (!isset($va_items[$va_relation[$vs_rel_pk]]['_display']) || !$va_items[$va_relation[$vs_rel_pk]]['_display']) "

Control passes this check successfully for the first time but for subsequent iterations it fails, consequently the old value is used again and again. Control should be passed to fetch new values. Removing this check solves the problem.

Contextual information about this issue can be found at the following CA forum thread:
http://www.collectiveaccess.org/support/forum/index.php?p=/discussion/comment/311534#Comment_311534
