### PR TITLE
PROV-913: (Follow-up bugfix) Add missing returns.

### DIFF
--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -124,12 +124,14 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 		if ($this->opo_config->getBoolean('process_on_insert') && $this->_isRelevantInstance($pa_params['instance'])) {
 			$this->_process($pa_params);
 		}
+		return $pa_params;
 	}
 
 	public function hookAfterBundleUpdate(&$pa_params) {
 		if ($this->opo_config->getBoolean('process_on_update') && $this->_isRelevantInstance($pa_params['instance'])) {
 			$this->_process($pa_params);
 		}
+		return $pa_params;
 	}
 
 	/**


### PR DESCRIPTION
Hook methods weren't returning anything, which was preventing other plugins
from executing.  Returning the passed-in parameters (or true) fixes this.
