### PR TITLE
 PROV-913 follow up enhancements

### DIFF
--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -244,11 +244,14 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 			$va_trigger = array_merge($va_default_match_options, $va_trigger);
 			$vs_value_combination_operator = isset($va_trigger['value_combination_operator']) ? self::_getOperatorMethodName($va_trigger['value_combination_operator']) : $vs_default_value_combination_operator;
 			$vs_match_type = isset($va_trigger['match_type']) ? self::_getMatchTypeMethodName($va_trigger['match_type']) : $vs_default_match_type;
-			$va_values = self::_getValues($pa_params['table_name'], $pa_params['id'], $vs_field);
+			$vs_value_converter = isset($va_trigger['value_converter']) && function_exists($va_trigger['value_converter']) ? $va_trigger['value_converter'] : null;
 
 			// Track match status
 			$vb_field_matches = self::$vs_value_combination_operator();
-			foreach ($va_values as $vm_value) {
+			foreach (self::_getValues($pa_params['table_name'], $pa_params['id'], $vs_field) as $vm_value) {
+				if (!is_null($vs_value_converter)) {
+					$vm_value = call_user_func($vs_value_converter, $vm_value);
+				}
 				$vb_field_matches = self::$vs_value_combination_operator($vb_field_matches, self::$vs_match_type($vm_value, $va_trigger));
 			}
 			$vb_matches = self::$vs_field_combination_operator($vb_matches, $vb_field_matches);
@@ -320,7 +323,7 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 		$va_values = $vo_object->get($ps_field, array( 'returnAsArray' => true ));
 		if (is_array($va_values)) {
 			foreach ($va_values as $va_v) {
-				$va_result = array_merge($va_result, $va_v);
+				$va_result = array_merge($va_result, is_array($va_v) ? $va_v : array( $va_v ));
 			}
 		}
 		return $va_result;

--- a/support/tests/plugins/AbstractPluginIntegrationTest.php
+++ b/support/tests/plugins/AbstractPluginIntegrationTest.php
@@ -1,0 +1,214 @@
+<?php
+/** ---------------------------------------------------------------------
+ * support/tests/plugins/AbstractPluginIntegrationTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2009-2012 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage tests
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ * This is an abstract base class for "plugin integration tests", which work by injecting data into the database,
+ * exercising a particular plugin, and then restoring the database to its original state (with the exception of
+ * sequences).  Such tests should use the following template:
+ *
+ * ------------------
+ *
+ * // Force initial setup of plugins so it isn't called later, which will overwrite our manually set up plugin
+ * ApplicationPluginManager::initPlugins();
+ *
+ * class FancyPantsPluginIntegrationTest extend AbstractPluginIntegrationTest {
+ *     public static function setUpBeforeTest() {
+ *         self::_init();
+ *         self::_processConfiguration(__DIR__ . '/conf/integration', 'conf/fancyPants.conf.template', 'conf/fancyPants.conf');
+ *         self::_switchInTestPlugin('fancyPants', new fancyPantsPlugin(__DIR__ . '/conf/integration'));
+ *         // Now create the reference data you need for the test, for example:
+ *         $vo_test_collection = new ca_collections();
+ *         $vo_test_collection->setMode(ACCESS_WRITE);
+ *         $vo_test_collection->set(array( 'idno' => self::_getIdno('test_collection'), 'name' => 'test collection' )); // and perform any other object setup
+ *         $vo_test_collection->insert();
+ *         self::_recordCreatedInstance($vo_test_collection, 'test_collection');
+ *     }
+ *     public static function tearDownAfterTest() {
+ *         self::_switchOutTestPlugin();
+ *         self::_cleanup();
+ *     }
+ * }
+ *
+ * ------------------
+ */
+abstract class AbstractPluginIntegrationTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * The timestamp when the test was initialised, used for generating unique reference data.
+	 * @var string
+	 */
+	private static $s_timestamp;
+
+	/**
+	 * A random number created when the test was initialised, used for generating unique reference data.
+	 * @var int
+	 */
+	private static $s_random_number;
+
+	/**
+	 * The original instance of the plugin, stored here so that _switchOutTestPlugin() can restore it.
+	 * @var BaseApplicationPlugin
+	 */
+	private static $s_original_plugin_instance;
+
+	/**
+	 * Hash of model class name to a hash of base idno values to model instances.  Stored here so that _cleanup() can
+	 * delete them all.
+	 * @var array
+	 */
+	private static $s_created_instances;
+
+	/**
+	 * Perform base initialisation of the test.  This should be the first call in setUpBeforeClass().
+	 */
+	protected static function _init() {
+		self::$s_timestamp = date('YmdHis');
+		self::$s_random_number = mt_rand(100000, 1000000);
+		self::$s_created_instances = array();
+	}
+
+	/**
+	 * Store the instance of the plugin with the given name currently known by the plugin manager, and replace it with
+	 * the given instance (which is expected to be of the same type, with a different configuration).  This should be
+	 * called during setUpBeforeClass(), after _init() is called.  The _switchOutTestPlugin() should also be called in
+	 * tearDownAfterClass().  This is somewhat hacky, beware!
+	 * @param $ps_name
+	 * @param $po_plugin BaseApplicationPlugin
+	 */
+	protected static function _switchInTestPlugin($ps_name, $po_plugin) {
+		self::$s_original_plugin_instance = ApplicationPluginManager::$s_application_plugin_instances[$ps_name];
+		ApplicationPluginManager::$s_application_plugin_instances[$ps_name] = $po_plugin;
+	}
+
+	/**
+	 * Restore the original plugin with the given name that was present in the plugin manager before the
+	 * _switchInTestPlugin() method was called.  This should be called in tearDownAfterClass(), before _cleanup().
+	 * @param $ps_name
+	 */
+	protected static function _switchOutTestPlugin($ps_name) {
+		// HACK Restore old instance of the plugin
+		ApplicationPluginManager::$s_application_plugin_instances[$ps_name] = self::$s_original_plugin_instance;
+		// END HACK
+	}
+
+	/**
+	 * Delete all the data that was generated during this test run.  This should be the last method called in
+	 * tearDownAfterClass(), after _switchOutTestPlugin().
+	 */
+	protected static function _cleanup() {
+		foreach (self::$s_created_instances as $va_instances) {
+			/** @var BundlableLabelableBaseModelWithAttributes $vo_instance */
+			foreach ($va_instances as $vo_instance) {
+				$vo_instance->setMode(ACCESS_WRITE);
+				$vo_instance->delete(true, array( 'hard' => true ));
+			}
+		}
+	}
+
+	/**
+	 * Convert the given "base" idno (or code in some cases) to a value unique to this test run.  For a given test run,
+	 * calling this method twice with the same parameter value will result in the same return value.
+	 * @param $ps_idno_base string
+	 * @return string
+	 */
+	protected static function _getIdno($ps_idno_base) {
+		return sprintf('%s_%s_%s', self::$s_timestamp, self::$s_random_number, $ps_idno_base);
+	}
+
+	/**
+	 * Convert the configuration file template containing placeholders into a ready-to-use configuration file
+	 * containing generated idno values.
+	 * @param $ps_dir
+	 * @param $ps_template
+	 * @param $ps_outfile
+	 */
+	protected static function _processConfiguration($ps_dir, $ps_template, $ps_outfile) {
+		if (file_exists($ps_dir . DIRECTORY_SEPARATOR . $ps_outfile)) {
+			unlink($ps_dir . DIRECTORY_SEPARATOR . $ps_outfile);
+		}
+		$va_parsed = array();
+		foreach (file($ps_dir . DIRECTORY_SEPARATOR . $ps_template) as $vs_line) {
+			// Skip comment lines
+			if ($vs_line[0] === '#') {
+				continue;
+			}
+
+			// Replace placeholders with generated (unique) values
+			while (strpos($vs_line, '%%') !== false) {
+				$vs_line = preg_replace_callback(
+					'/%%(.*?)%%/',
+					function ($pa_match) {
+						return sizeof($pa_match) > 1 ? self::_getIdno($pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
+					},
+					$vs_line
+				);
+			}
+
+			// Add the resulting (processed) line to the output
+			$va_parsed[] = $vs_line;
+		}
+		file_put_contents($ps_dir . DIRECTORY_SEPARATOR . $ps_outfile, join('', $va_parsed));
+	}
+
+	/**
+	 * Store a model instance that has been created by the test, so that it can be later retrieved or deleted.
+	 * @param $po_instance BaseModelWithAttributes
+	 * @param $ps_key
+	 */
+	protected static function _recordCreatedInstance($po_instance, $ps_key) {
+		if (!isset(self::$s_created_instances[get_class($po_instance)])) {
+			self::$s_created_instances[get_class($po_instance)] = array();
+		}
+		self::$s_created_instances[get_class($po_instance)][$ps_key] = $po_instance;
+	}
+
+	/**
+	 * Retrieve all the model instances of the given class that have been created by the test.  This is an empty array
+	 * if no models of the given class have been recorded.
+	 * @param $ps_class
+	 * @return BaseModelWithAttributes[]
+	 */
+	protected static function _retrieveCreatedInstancesByClass($ps_class) {
+		return isset(self::$s_created_instances[$ps_class]) ? self::$s_created_instances[$ps_class] : array();
+	}
+
+	/**
+	 * Retrieve the single model instance of the given class, with the given key, that was created by the test, or null
+	 * if no such models have been recorded.
+	 * @param $ps_class
+	 * @param $ps_key
+	 * @return BaseModelWithAttributes|null
+	 */
+	protected static function _retrieveCreatedInstance($ps_class, $ps_key) {
+		return isset(self::$s_created_instances[$ps_class]) && isset(self::$s_created_instances[$ps_class][$ps_key]) ? self::$s_created_instances[$ps_class][$ps_key] : null;
+	}
+}

--- a/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginConfigurationTest.php
+++ b/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
 /** ---------------------------------------------------------------------
- * support/tests/plugins/RelationshipGeneratorPluginConfigurationTest.php
+ * support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginConfigurationTest.php
  * ----------------------------------------------------------------------
  * CollectiveAccess
  * Open-source collections management software
@@ -46,7 +46,7 @@ class RelationshipGeneratorConfigurationPluginTest extends PHPUnit_Framework_Tes
 		$this->assertEmpty($va_plugin_status['errors'], 'The default configuration does not produce any errors');
 	}
 
-	public function testDisabledConfigurationIsDisabled() {
+	public function testDisabledConfigurationIsDisabledAndValid() {
 		$vo_plugin = new relationshipGeneratorPlugin(__DIR__ . '/conf/disabled-plugin');
 		$va_plugin_status = $vo_plugin->checkStatus();
 		$this->assertFalse($va_plugin_status['available'], 'The plugin can be disabled by configuration');

--- a/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
+++ b/support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 /** ---------------------------------------------------------------------
- * support/tests/plugins/RelationshipGeneratorPluginIntegrationTest.php
+ * support/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
  * ----------------------------------------------------------------------
  * CollectiveAccess
  * Open-source collections management software
@@ -31,6 +31,7 @@
  */
 
 require_once 'PHPUnit/Autoload.php';
+require_once(__CA_BASE_DIR__ . '/support/tests/plugins/AbstractPluginIntegrationTest.php');
 require_once(__CA_LIB_DIR__ . '/ca/ApplicationPluginManager.php');
 require_once __CA_APP_DIR__ . '/plugins/relationshipGenerator/relationshipGeneratorPlugin.php';
 require_once __CA_APP_DIR__ . '/models/ca_collections.php';
@@ -41,62 +42,21 @@ ApplicationPluginManager::initPlugins();
 /**
  * Performs an integration test of sorts for the RelationshipGeneratorPlugin.
  *
- * Data (including all required reference data) is created via the model classes, the tests are run, and then all
- * inserted data is removed (hard deleted).  This leaves the database in an equivalent state at the end of the test
- * compared to before the test, with the exception that database auto-increment ID values will have skipped ahead due
- * to records being created and destroyed.  Values used in the tests are generated to be unique to a given test run.
- *
- * This test hacks the ApplicationPluginManager, in order to override the default-configured plugin with a plugin
- * configured by a generated configuration file (see _generateConfiguration() for details about configuration file
- * generation),  The original plugin instance is restored at the end of the test run.
- *
- * This test relies on the presence and correct setting of the __CA_DEFAULT_LOCALE__ constant in setup.php.
+ * See AbstractPluginIntegrationTest for details of the generic cycle of switching in a plugin with test configuration,
+ * creating reference data for the tests, running the tests, then deleting all data generated for the tests.
  */
-class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestCase {
-
-	private static $s_timestamp;
-	private static $s_random_number;
-	private static $s_original_plugin_instance;
-
-	/** @var ca_locales */
-	private static $s_locale;
-
-	/** @var ca_relationship_types[] */
-	private static $s_relationship_types;
-
-	/** @var ca_list_items[] */
-	private static $s_list_items;
-
-	/** @var ca_collections[] */
-	private static $s_collections;
-
-	/** @var ca_metadata_elements[] */
-	private static $s_metadata_elements;
-
-	/** @var ca_objects[] */
-	private static $s_objects;
+class RelationshipGeneratorPluginIntegrationTest extends AbstractPluginIntegrationTest {
 
 	public static function setUpBeforeClass() {
-		self::$s_timestamp = date('YmdHis');
-		self::$s_random_number = mt_rand(100000, 1000000);
-		self::_processConfiguration(__DIR__ . '/conf/integration');
-
-		// HACK Store old instance of the plugin, and replace with one of our own with known configuration
-		self::$s_original_plugin_instance = ApplicationPluginManager::$s_application_plugin_instances['relationshipGenerator'];
-		ApplicationPluginManager::$s_application_plugin_instances['relationshipGenerator'] = new relationshipGeneratorPlugin(__DIR__ . '/conf/integration');
-		// END HACK
-
-		self::$s_locale = new ca_locales();
-		self::$s_locale->loadLocaleByCode(__CA_DEFAULT_LOCALE__);
-
-		self::$s_list_items = array();
-		self::$s_collections = array();
-		self::$s_objects = array();
+		self::_init();
+		self::_processConfiguration(__DIR__ . '/conf/integration', 'conf/relationshipGenerator.conf.template', 'conf/relationshipGenerator.conf');
+		self::_switchInTestPlugin('relationshipGenerator', new relationshipGeneratorPlugin(__DIR__ . '/conf/integration'));
 
 		self::_createRelationshipType('part', 'ca_objects_x_collections');
 
-		self::_createListItem('test_collection', BaseModel::$s_ca_models_definitions['ca_collections']['FIELDS']['type_id']['LIST_CODE']);
-		self::_createListItem('test_object', BaseModel::$s_ca_models_definitions['ca_objects']['FIELDS']['type_id']['LIST_CODE']);
+		self::_createListItem('test_collection_type', BaseModel::$s_ca_models_definitions['ca_collections']['FIELDS']['type_id']['LIST_CODE']);
+		self::_createListItem('test_object_type1', BaseModel::$s_ca_models_definitions['ca_objects']['FIELDS']['type_id']['LIST_CODE']);
+		self::_createListItem('test_object_type2', BaseModel::$s_ca_models_definitions['ca_objects']['FIELDS']['type_id']['LIST_CODE']);
 
 		self::_createMetadataElement('element1');
 		self::_createMetadataElement('element2');
@@ -106,33 +66,12 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		self::_createCollection('collection2');
 		self::_createCollection('collection3');
 		self::_createCollection('collection4');
+		self::_createCollection('collection5');
 	}
 
 	public static function tearDownAfterClass() {
-		foreach (self::$s_objects as $vo_object) {
-			$vo_object->setMode(ACCESS_WRITE);
-			$vo_object->delete(true, array( 'hard' => true ));
-		}
-		foreach (self::$s_metadata_elements as $vo_metadata_element) {
-			$vo_metadata_element->setMode(ACCESS_WRITE);
-			$vo_metadata_element->delete(true, array( 'hard' => true ));
-		}
-		foreach (self::$s_collections as $vo_collection) {
-			$vo_collection->setMode(ACCESS_WRITE);
-			$vo_collection->delete(true, array( 'hard' => true ));
-		}
-		foreach (self::$s_list_items as $vo_list_item) {
-			$vo_list_item->setMode(ACCESS_WRITE);
-			$vo_list_item->delete(true, array( 'hard' => true ));
-		}
-		foreach (self::$s_relationship_types as $vo_relationship_type) {
-			$vo_relationship_type->setMode(ACCESS_WRITE);
-			$vo_relationship_type->delete(true, array( 'hard' => true ));
-		}
-
-		// HACK Restore old instance of the plugin
-		ApplicationPluginManager::$s_application_plugin_instances['relationshipGenerator'] = self::$s_original_plugin_instance;
-		// END HACK
+		self::_switchOutTestPlugin('relationshipGenerator');
+		self::_cleanup();
 	}
 
 	public function testInsertedRecordNotMatchingAnyRule() {
@@ -141,6 +80,7 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testInsertedRecordMatchingSingleExactMatchRule() {
@@ -149,6 +89,7 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testInsertedRecordMatchingSingleRegexRule() {
@@ -157,6 +98,7 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object has a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testInsertedRecordMatchingMultipleRules() {
@@ -165,6 +107,7 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object has a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasNotMatchingAnyRuleStillNotMatchingAnyRule() {
@@ -173,11 +116,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasNotMatchingAnyRuleNowStillNotMatchingAnyRule', array( 'element1' => 'this value also does not match' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasNotMatchingAnyRuleNowMatchingSingleRule() {
@@ -186,11 +131,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasNotMatchingAnyRuleNowMatchingSingleRule', array( 'element1' => 'EXACT MATCH' ));
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object has a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasNotMatchingAnyRuleNowMatchingMultipleRules() {
@@ -199,11 +146,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasNotMatchingAnyRuleNowMatchingMultipleRules', array( 'element1' => '42', 'element2' => 'XyZZy' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object has a relationship with collection2 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object has a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingSingleRuleNowMatchingMultipleRules() {
@@ -212,11 +161,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasWasMatchingSingleRuleNowMatchingMultipleRules', array( 'element2' => 'XYZZY' ));
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object has a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object has a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingSingleRuleNowMatchingDifferentSingleRule() {
@@ -225,11 +176,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasMatchingSingleRuleNowMatchingDifferentSingleRule', array( 'element1' => 'no longer matching', 'element2' => 'Xyzzy' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object has a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingSingleRuleNowNotMatchingAnyRule() {
@@ -238,11 +191,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not initially have a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasMatchingSingleRuleNowNotMatchingAnyRule', array( 'element1' => 'no longer matching' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingMultipleRulesNowMatchingSingleRule() {
@@ -251,11 +206,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object initially has a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasMatchingMultipleRulesNowMatchingSingleRule', array( 'element1' => 'no longer matching' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object has a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingMultipleRulesNowMatchingDifferentSingleRule() {
@@ -264,11 +221,13 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object initially has a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasMatchingMultipleRulesNowNotMatchingDifferentSingleRule', array( 'element1' => 'no longer matching NO LONGER', 'element2' => 'foo', 'element3' => 'barBBBBBBBBBBBBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAARRRRRRRRRRRRRRRRRRRRRRRRRRRRRR' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3 after update');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object has a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
 	public function testUpdatedRecordWasMatchingMultipleRulesNowNotMatchingAnyRule() {
@@ -277,55 +236,22 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not initially have a relationship with collection2');
 		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object initially has a relationship with collection3');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not initially have a relationship with collection4');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 		$vo_object = self::_updateObject('wasMatchingMultipleRulesNowNotMatchingAnyRule', array( 'element1' => 'no longer matching', 'element2' => 'yzxxz' ));
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3 after update');
 		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4 after update');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object does not have a relationship with collection5');
 	}
 
-	/**
-	 * Convert the given "base" idno (or code in some cases) to a value unique to this test run.  For a given test run,
-	 * calling this method twice with the same parameter value will result in the same return value.
-	 * @param $ps_idno_base string
-	 * @return string
-	 */
-	private static function _getIdno($ps_idno_base) {
-		return sprintf('%s_%s_%s', self::$s_timestamp, self::$s_random_number, $ps_idno_base);
-	}
-
-	/**
-	 * Convert the configuration file template containing placeholders into a ready-to-use configuration file
-	 * containing generated idno values.
-	 * @param $ps_path string
-	 */
-	private static function _processConfiguration($ps_path) {
-		$vs_outfile = $ps_path . '/conf/relationshipGenerator.conf';
-		if (file_exists($vs_outfile)) {
-			unlink($vs_outfile);
-		}
-		$va_parsed = array();
-		foreach (file($ps_path . '/conf/relationshipGenerator.conf.template') as $vs_line) {
-			// Skip comment lines
-			if ($vs_line[0] === '#') {
-				continue;
-			}
-
-			// Replace placeholders with generated (unique) values
-			while (strpos($vs_line, '%%') !== false) {
-				$vs_line = preg_replace_callback(
-					'/%%(.*?)%%/',
-					function ($pa_match) {
-						return sizeof($pa_match) > 1 ? self::_getIdno($pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
-					},
-					$vs_line
-				);
-			}
-
-			// Add the resulting (processed) line to the output
-			$va_parsed[] = $vs_line;
-		}
-		file_put_contents($vs_outfile, join('', $va_parsed));
+	public function testValueConverterAppliedCorrectly() {
+		$vo_object = self::_createObject('valueConverterAppliedCorrectly', array(), 'test_object_type2');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection1'), 'Object does not have a relationship with collection1');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection2'), 'Object does not have a relationship with collection2');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection3'), 'Object does not have a relationship with collection3');
+		$this->assertEquals(0, self::_getCollectionRelationshipCount($vo_object, 'collection4'), 'Object does not have a relationship with collection4');
+		$this->assertEquals(1, self::_getCollectionRelationshipCount($vo_object, 'collection5'), 'Object has a relationship with collection5');
 	}
 
 	private static function _createRelationshipType($ps_code_base, $ps_table_name) {
@@ -341,11 +267,11 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 				'typename' => $ps_code_base,
 				'typename_reverse' => $ps_code_base . ' reverse'
 			),
-			self::$s_locale->getPrimaryKey(),
+			ca_locales::getDefaultCataloguingLocaleID(),
 			null,
 			true
 		);
-		self::$s_relationship_types[$ps_code_base] = $vo_relationship_type;
+		self::_recordCreatedInstance($vo_relationship_type, $ps_code_base);
 		return $vo_relationship_type;
 	}
 
@@ -363,11 +289,11 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 				'name_singular' => $ps_idno_base,
 				'name_plural' => $ps_idno_base
 			),
-			self::$s_locale->getPrimaryKey(),
+			ca_locales::getDefaultCataloguingLocaleID(),
 			null,
 			true
 		);
-		self::$s_list_items[$ps_idno_base] = $vo_list_item;
+		self::_recordCreatedInstance($vo_list_item, $ps_idno_base);
 		return $vo_list_item;
 	}
 
@@ -379,19 +305,19 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 			'datatype' => 1
 		));
 		$vo_metadata_element->insert();
-		self::$s_metadata_elements[$ps_code_base] = $vo_metadata_element;
+		self::_recordCreatedInstance($vo_metadata_element, $ps_code_base);
 		return $vo_metadata_element;
 	}
 
 	private static function _createCollection($ps_idno_base) {
 		$vo_collection = new ca_collections();
 		$vo_collection->setMode(ACCESS_WRITE);
+		$vn_test_collection_list_item_id = self::_retrieveCreatedInstance('ca_list_items', 'test_collection_type')->getPrimaryKey();
 		$vo_collection->set(array(
 			'idno' => self::_getIdno($ps_idno_base),
-			'type_id' => self::$s_list_items['test_collection']->getPrimaryKey()
+			'type_id' => $vn_test_collection_list_item_id
 		));
-		$vn_test_collection_list_item_id = self::$s_list_items['test_collection']->getPrimaryKey();
-		foreach (self::$s_metadata_elements as $vo_metadata_element) {
+		foreach (self::_retrieveCreatedInstancesByClass('ca_metadata_elements') as $vo_metadata_element) {
 			$vo_collection->addMetadataElementToType($vo_metadata_element->get('element_code'), $vn_test_collection_list_item_id);
 		}
 		$vo_collection->insert();
@@ -399,41 +325,41 @@ class RelationshipGeneratorPluginIntegrationTest extends PHPUnit_Framework_TestC
 			array(
 				'name' => $ps_idno_base
 			),
-			self::$s_locale->getPrimaryKey(),
+			ca_locales::getDefaultCataloguingLocaleID(),
 			null,
 			true
 		);
-		self::$s_collections[$ps_idno_base] = $vo_collection;
+		self::_recordCreatedInstance($vo_collection, $ps_idno_base);
 		return $vo_collection;
 	}
 
-	private static function _createObject($ps_idno_base, $pa_attributes) {
+	private static function _createObject($ps_idno_base, $pa_attributes, $ps_type_code = 'test_object_type1') {
+		$pn_type_id = self::_retrieveCreatedInstance('ca_list_items', $ps_type_code)->getPrimaryKey();
 		$vo_object = new ca_objects();
 		$vo_object->setMode(ACCESS_WRITE);
-		$vn_test_object_list_item_id = self::$s_list_items['test_object']->getPrimaryKey();
 		$vo_object->set(array(
 			'idno' => self::_getIdno($ps_idno_base),
-			'type_id' => $vn_test_object_list_item_id
+			'type_id' => $pn_type_id
 		));
 		foreach ($pa_attributes as $vs_code_base => $vs_value) {
 			$vs_code = self::_getIdno($vs_code_base);
-			$vo_object->addMetadataElementToType($vs_code, $vn_test_object_list_item_id);
+			$vo_object->addMetadataElementToType($vs_code, $pn_type_id);
 			$vo_object->addAttribute(array( $vs_code => $vs_value ), $vs_code);
 		}
 		$vo_object->insert();
-		self::$s_objects[$ps_idno_base] = $vo_object;
+		self::_recordCreatedInstance($vo_object, $ps_idno_base);
 		return $vo_object;
 	}
 
 	private static function _updateObject($ps_idno_base, $pa_attributes) {
 		/** @var BundlableLabelableBaseModelWithAttributes $vo_object */
-		$vo_object = self::$s_objects[$ps_idno_base];
+		$vo_object = self::_retrieveCreatedInstance('ca_objects', $ps_idno_base);
 		foreach ($pa_attributes as $vs_code_base => $vs_value) {
 			$vs_code = self::_getIdno($vs_code_base);
 			$vo_object->replaceAttribute(array( $vs_code => $vs_value ), $vs_code);
 		}
 		$vo_object->update();
-		self::$s_objects[$ps_idno_base] = $vo_object;
+		self::_recordCreatedInstance($vo_object, $ps_idno_base);
 		return $vo_object;
 	}
 

--- a/support/tests/plugins/relationshipGenerator/conf/integration/conf/relationshipGenerator.conf.template
+++ b/support/tests/plugins/relationshipGenerator/conf/integration/conf/relationshipGenerator.conf.template
@@ -78,5 +78,18 @@ rules = {
 		related_table = ca_collections,
 		related_record = %%collectionDoesNotExist%%,
 		relationship_type = %%part%%
+	},
+	5 = {
+		source_tables = [ ca_objects ],
+		triggers = {
+			type_id = {
+				value_converter = caGetListItemIdno,
+				match_type = exact,
+				value = %%test_object_type2%%
+			}
+		},
+		related_table = ca_collections,
+		related_record = %%collection5%%,
+		relationship_type = %%part%%
 	}
 }


### PR DESCRIPTION
- Relationship generator plugin: added support for per-field `value_converter`
  configuration items, which gives the name of a function that the value is passed
  through before being matched against the trigger.  This could be a `trim()` or
  a call to `caGetListItemIdno()` to match against idno instead of numeric id.
- Added test for `value_converter`.
- Separated out an AbstractPluginIntegrationTest abstract class, which gives some
  basic infrastructure useful for unit / integration tests on plugins, specifically
  the utility to store objects created during a test run and clean them up
  automatically.
