### PR TITLE
PROV-932: Continuous Integration (Travis CI)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "js/jquery/jquery-handsontable-src"]
 	path = js/jquery/jquery-handsontable-src
-	url = git@github.com:collectiveaccess/jquery-handsontable.git
+	url = https://github.com/collectiveaccess/jquery-handsontable.git

--- a/.travis.setup.php
+++ b/.travis.setup.php
@@ -1,0 +1,21 @@
+<?php
+
+# Define test-specific constants.
+if (!defined("__CA_DB_HOST__")) {
+	define("__CA_DB_HOST__", 'localhost');
+}
+if (!defined("__CA_DB_USER__")) {
+	define("__CA_DB_USER__", 'ca_test');
+}
+if (!defined("__CA_DB_PASSWORD__")) {
+	define("__CA_DB_PASSWORD__", 'password');
+}
+if (!defined("__CA_DB_DATABASE__")) {
+	define("__CA_DB_DATABASE__", 'ca_test');
+}
+if (!defined("__CA_APP_DISPLAY_NAME__")) {
+	define("__CA_APP_DISPLAY_NAME__", 'CollectiveAccess Unit Tests');
+}
+
+# Include the defaults.
+require_once('setup.php-dist');

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: php
+
+php:
+  # Test against current PHP and previous version
+  - 5.4
+  - 5.5
+
+env:
+  # Here we list the profiles that we want to test, each one will be tested, per version of PHP, in parallel
+  - PROFILE=default
+  - PROFILE=darwincore
+  - PROFILE=dublincore
+
+install:
+  # Initialise the database instance for the test
+  - mysqladmin -uroot create ca_test
+  - mysql -uroot -e "create user 'ca_test'@'localhost' identified by 'password';"
+  - mysql -uroot -e "grant all on ca_test.* to 'ca_test'@'localhost';"
+  # Set environment variables
+  - export COLLECTIVEACCESS_HOME="$(pwd)"
+  - export PATH="$PATH:$COLLECTIVEACCESS_HOME/support/bin"
+  # Create setup.php
+  - ln -s .travis.setup.php setup.php
+  # Install the WAM CMIS profile
+  - support/bin/caUtils install --hostname=localhost --setup="$(pwd)/tests/setup-tests.php" --profile-name=$PROFILE --admin-email=dev@gaiaresources.com.au >install.log
+
+before_script:
+  # Go into the tests directory to run the tests
+  - cd tests/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CollectiveAccess README
 -----------------------
 
+[![Build Status](https://secure.travis-ci.org/collectiveaccess/providence.png?branch=develop)](http://travis-ci.org/collectiveaccess/providence)
+
 Thank you for downloading Providence version 1.5! 
  
 Providence is the “back-end” cataloging component of CollectiveAccess, a web-based suite of applications providing a framework for management, description, and discovery of complex digital and physical collections.  Providence is highly configurable and supports a variety of metadata standards, data types, and media formats.  

--- a/app/lib/ca/Utils/CLIUtils.php
+++ b/app/lib/ca/Utils/CLIUtils.php
@@ -41,6 +41,158 @@
 		# CLI utility implementations
 		# -------------------------------------------------------
 		/**
+		 * Create a fresh installation of CollectiveAccess based on contents of setup.php.  This is essentially a CLI
+		 * command wrapper for the installation process, as /install/inc/page2.php is a web wrapper.
+		 */
+		public static function install($po_opts=null) {
+			require_once(__CA_BASE_DIR__ . '/install/inc/Installer.php');
+
+			if (!$po_opts->getOption('profile-name')) {
+				CLIUtils::addError(_t("Missing required parameter: profile-name"));
+				return false;
+			}
+			if (!$po_opts->getOption('admin-email')) {
+				CLIUtils::addError(_t("Missing required parameter: admin-email"));
+				return false;
+			}
+
+			$t_total = new Timer();
+			$vo_installer = new Installer(
+				__CA_BASE_DIR__ . '/install/profiles/xml',
+				$po_opts->getOption('profile-name'),
+				$po_opts->getOption('admin-email'),
+				$po_opts->getOption('overwrite'),
+				$po_opts->getOption('debug')
+			);
+			$vb_quiet = $po_opts->getOption('quiet');
+
+			// if profile validation against XSD failed, we already have an error here
+			if($vo_installer->numErrors()){
+				CLIUtils::addError(_t(
+					"There were errors parsing the profile(s): %1",
+					"\n * " . join("\n * ", $vo_installer->getErrors())
+				));
+				return false;
+			}
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Performing preinstall tasks")); }
+			$vo_installer->performPreInstallTasks();
+			
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Loading schema")); }
+			$vo_installer->loadSchema();
+			
+			if($vo_installer->numErrors()){
+				CLIUtils::addError(_t(
+					"There were errors loading the database schema: %1",
+					"\n * " . join("\n * ", $vo_installer->getErrors())
+				));
+				return false;
+			}
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing locales")); }
+			$vo_installer->processLocales();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing lists")); }
+			$vo_installer->processLists();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing relationship types")); }
+			$vo_installer->processRelationshipTypes();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing metadata elements")); }
+			$vo_installer->processMetadataElements();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing access roles")); }
+			$vo_installer->processRoles();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing user groups")); }
+			$vo_installer->processGroups();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing user logins")); }
+			$va_login_info = $vo_installer->processLogins();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing user interfaces")); }
+			$vo_installer->processUserInterfaces();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing displays")); }
+			$vo_installer->processDisplays();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing search forms")); }
+			$vo_installer->processSearchForms();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Setting up hierarchies")); }
+			$vo_installer->processMiscHierarchicalSetup();
+
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Installation complete")); }
+
+			$vs_time = _t("Installation took %1 seconds", $t_total->getTime(0));
+
+			if($vo_installer->numErrors()){
+				CLIUtils::addError(_t(
+					"There were errors during installation: %1\n(%2)",
+					"\n * " . join("\n * ", $vo_installer->getErrors()),
+					$vs_time
+				));
+				return false;
+			}
+
+			CLIUtils::addMessage(_t(
+				"Installation was successful!\n\nYou can now login with the following logins: %1\nMake a note of these passwords!",
+				"\n * " . join(
+					"\n * ",
+					array_map(
+						function ($username, $password) {
+							return _t("username %1 and password %2", $username, $password);
+						},
+						array_keys($va_login_info),
+						array_values($va_login_info)
+					)
+				)
+			));
+
+			CLIUtils::addMessage($vs_time);
+			return true;
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function installParamList() {
+			return array(
+				"profile-name|n=s" => _t('Name of the profile to install (filename in profiles directory, minus the .xml extension).'),
+				"admin-email|e=s" => _t('Email address of the system administrator (user@domain.tld).'),
+				"overwrite" => _t('Flag must be set in order to overwrite an existing installation.  Also, the __CA_ALLOW_INSTALLER_TO_OVERWRITE_EXISTING_INSTALLS__ global must be set to a true value.'),
+				"debug|d" => _t('Debug flag for installer.'),
+				"quiet|q" => _t('Suppress progress messages.')
+			);
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function installUtilityClass() {
+			return _t('Configuration');
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function installHelp() {
+			return _t("Performs a fresh installation of CollectiveAccess using the configured values in setup.php.
+
+\tThe profile name and administrator email address must be given as per the web-based installer.
+
+\tIf the database schema already exists, this operation will fail, unless the --overwrite flag is set, in which case all existing data will be deleted (use with caution!).");
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function installShortHelp() {
+			return _t("Performs a fresh installation of CollectiveAccess using the configured values in setup.php.");
+		}
+
+		# -------------------------------------------------------
+		/**
 		 * Rebuild search indices
 		 */
 		public static function rebuild_search_index($po_opts=null) {

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -185,7 +185,7 @@ if (!defined("__CA_APP_NAME__")) {
 # 		For Windows hosts, use a notation similar to "C:/PATH/TO/COLLECTIVEACCESS"; do NOT use backslashes
 #
 if (!defined("__CA_BASE_DIR__")) {
-	define("__CA_BASE_DIR__", pathinfo(preg_replace("!/install|/viewers/apps!", "", $_SERVER['SCRIPT_FILENAME']), PATHINFO_DIRNAME));
+	define("__CA_BASE_DIR__", pathinfo(preg_replace("!/install|/viewers/apps|/tests|support/bin/!", "", isset($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : __FILE__), PATHINFO_DIRNAME));
 }
 
 
@@ -203,7 +203,7 @@ if (!defined("__CA_BASE_DIR__")) {
 # 		Example: If CollectiveAccess will be accessed via http://www.mysite.org/apps/ca then __CA_URL_ROOT__ would be set to /apps/ca
 #
 if (!defined("__CA_URL_ROOT__")) {
-	define("__CA_URL_ROOT__", str_replace($_SERVER['DOCUMENT_ROOT'], '', __CA_BASE_DIR__));
+	define("__CA_URL_ROOT__", str_replace(isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '', '', __CA_BASE_DIR__));
 }
 
 
@@ -216,9 +216,8 @@ if (!defined("__CA_URL_ROOT__")) {
 #		If you must set this manually, it must be the full host name. Do not include http:// or any other prefixes.
 #
 if (!defined("__CA_SITE_HOSTNAME__")) {
-	define("__CA_SITE_HOSTNAME__", $_SERVER['HTTP_HOST']);
+	define("__CA_SITE_HOSTNAME__", isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
 }
-
 
 #
 # If you use PayPal for e-commerce payments then you can set your account information 
@@ -286,8 +285,8 @@ if (!isset($_SERVER['HTTP_HOST']) || !isset($_CA_INSTANCE_CONFIG_FILES[$_SERVER[
 } 
 
 if (!(file_exists($_CA_CONFIG_PATH))) {
-	$opa_error_messages = array("Configuration files are missing for hostname '".$_SERVER['HTTP_HOST']."'!<br/>Please check the <em>__CA_BASE_DIR__</em> configuration setting in your <em>setup.php</em> file.");
-	if (!include_once("./themes/default/views/system/configuration_error_html.php")) {
+	$opa_error_messages = array("Configuration files are missing for hostname '".(isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '[unknown]')."'!<br/>Please check the <em>__CA_BASE_DIR__</em> configuration setting in your <em>setup.php</em> file.");
+	if (!include_once(__CA_BASE_DIR__ . "/themes/default/views/system/configuration_error_html.php")) {
 		die("Fatal error: Configuration files are missing for hostname '".$_SERVER['HTTP_HOST']."'! Please check the __CA_BASE_DIR__ configuration setting in your setup.php file.");
 	}
 	exit();

--- a/support/bin/caUtils
+++ b/support/bin/caUtils
@@ -48,7 +48,7 @@
 	$o_config = Configuration::load();
 	$g_ui_locale = $o_config->get('locale_default');
 	$t_locale = new ca_locales();
-	$g_ui_locale_id = $t_locale->localeCodeToID($g_ui_locale);		// get current UI locale as locale_id	  (available as global)
+	$g_ui_locale_id = $t_locale->getDb()->getFieldsFromTable('ca_locales') ? $t_locale->localeCodeToID($g_ui_locale) : -1; // get current UI locale as locale_id (available as global)
 	initializeLocale($g_ui_locale);
 	
  	$o_app_plugin_manager = new ApplicationPluginManager();
@@ -76,6 +76,7 @@
 	
 	$va_available_cli_opts = array_merge(array(
 			"hostname|h-s" => 'Hostname of installation. If omitted default installation is used.',
+			"setup-s" => 'Specify the path to an alternate setup.php.',
 			"help" => "Displays available commands with descriptions."
 		), $va_command_opts);
 	
@@ -219,12 +220,18 @@
 	 * @return bool True if setup.php is located and loaded, false if setup.php could not be found.
 	 */
 	function _caUtilsLoadSetupPHP() {
-		
+		$vs_setup_path = 'setup.php';
+
 		// try to get hostname off of argv since we need that before anything else in a multi-database installation
+		// also detect the --setup flag, which accepts a path to an alternate setup.php
 		if (isset($_SERVER['argv']) && is_array($_SERVER['argv'])) {
 			foreach($_SERVER['argv'] as $vs_opt) {
 				if (preg_match("!^\-\-hostname\=([A-Za-z0-9_\-\.]+)!", $vs_opt, $va_matches) || preg_match("!^\-h\=([A-Za-z0-9_\-\.]+)!", $vs_opt, $va_matches)) {
 					$_SERVER['HTTP_HOST'] = $va_matches[1];
+					break;
+				}
+				if (preg_match('!^\-\-setup\=([A-Za-z0-9_\-\/\.]+)$!', $vs_opt, $va_matches)) {
+					$vs_setup_path = $va_matches[1];
 					break;
 				}
 			}
@@ -232,16 +239,17 @@
 		
 		// Look for environment variable
 		$vs_path = getenv("COLLECTIVEACCESS_HOME");
-		if (file_exists("{$vs_path}/setup.php")) {
-			require_once("{$vs_path}/setup.php");
+		if (file_exists("{$vs_path}/{$vs_setup_path}")) {
+			require_once("{$vs_path}/{$vs_setup_path}");
 			return true;
 		}
-		
+
 		// Look in current directory and then in parent directories
 		$vs_cwd = getcwd();
 		$va_cwd = explode("/", $vs_cwd);
 		while(sizeof($va_cwd) > 0) {
-			if (file_exists("/".join("/", $va_cwd)."/setup.php")) {
+			$vs_setup_path_fallback = "/".join("/", $va_cwd)."/".$vs_setup_path;
+			if (file_exists($vs_setup_path_fallback)) {
 				// Rewrite $_SERVER with paths that setup.php can use
 				//print_R($_SERVER);
 					// try to load pre-save paths
@@ -251,14 +259,14 @@
 					if (!isset($_SERVER['HTTP_HOST'])) { $_SERVER['HTTP_HOST'] = $va_hints['HTTP_HOST']; }
 				} else {
 					// Guess paths based upon location of setup.php (*should* work)
-					if (!isset($_SERVER['DOCUMENT_ROOT']) && !$_SERVER['DOCUMENT_ROOT']) { $_SERVER['DOCUMENT_ROOT'] = join("/", $va_cwd); }
-					if (!isset($_SERVER['SCRIPT_FILENAME']) && !$_SERVER['SCRIPT_FILENAME']) { $_SERVER['SCRIPT_FILENAME'] = join("/", $va_cwd)."/index.php"; }
-					if (!isset($_SERVER['HTTP_HOST']) && !$_SERVER['HTTP_HOST']) { $_SERVER['HTTP_HOST'] = 'localhost'; }
+					if (!isset($_SERVER['DOCUMENT_ROOT']) || !$_SERVER['DOCUMENT_ROOT']) { $_SERVER['DOCUMENT_ROOT'] = join("/", $va_cwd); }
+					if (!isset($_SERVER['SCRIPT_FILENAME']) || !$_SERVER['SCRIPT_FILENAME']) { $_SERVER['SCRIPT_FILENAME'] = join("/", $va_cwd)."/index.php"; }
+					if (!isset($_SERVER['HTTP_HOST']) || !$_SERVER['HTTP_HOST']) { $_SERVER['HTTP_HOST'] = 'localhost'; }
 					
 					print "[\033[1;33mWARNING\033[0m] Guessing base path and hostname because configuration is not available. Loading any CollectiveAccess screen (except for the installer) in a web browser will cache configuration details and resolve this issue.\n\n";
 				}
 				
-				require_once("/".join("/", $va_cwd)."/setup.php");
+				require_once($vs_setup_path_fallback);
 				return true;
 			}
 			array_pop($va_cwd);

--- a/tests/helpers/UtilityHelpersTest.php
+++ b/tests/helpers/UtilityHelpersTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once('PHPUnit/Autoload.php');
 require_once(__CA_APP_DIR__."/helpers/utilityHelpers.php");
 
 class UtilityHelpersTest extends PHPUnit_Framework_TestCase {

--- a/tests/lib/ca/AttributeValues/GeocodeAttributeValueTest.php
+++ b/tests/lib/ca/AttributeValues/GeocodeAttributeValueTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once('PHPUnit/Autoload.php');
 require_once(__CA_LIB_DIR__."/ca/Attributes/Values/GeocodeAttributeValue.php");
 
 class GeocodeAttributeValueTest extends PHPUnit_Framework_TestCase {

--- a/tests/lib/ca/BundlableLabelableBaseModelWithAttributesTest.php
+++ b/tests/lib/ca/BundlableLabelableBaseModelWithAttributesTest.php
@@ -29,94 +29,93 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_MODELS_DIR__.'/ca_objects.php');
-	require_once(__CA_MODELS_DIR__.'/ca_lists.php');
-	require_once(__CA_LIB_DIR__.'/ca/Search/ObjectSearch.php');
-	
-	class BundlableLabelableBaseModelWithAttributesTest extends PHPUnit_Framework_TestCase {
-	
-		//
-		// Test attempts to insert a ca_object record, then loads it and compares retrieved values to what was originally stored,
-		// then executes a search for the object via ObjectSearch(), and finally deletes the object.
-		//
-		// This simulates very roughly the life-cycle of a typical bundleable-labelable database object (well not quite... additional
-		// actions, such as relating objects to other database rows, verifying that instrinsic fields work, simulating a form
-		// save, etc. should probably be added... but this does cover the low-level basics)
-		//
-		public function testInsertLoadAndDeleteCycleWithCaObjectsModel() {
-			$t_list = new ca_lists();
-			$va_object_types = $t_list->getItemsForList('object_types');
-			$this->assertGreaterThan(0, sizeof($va_object_types), "No object types available");
-			$va_object_types = caExtractValuesByUserLocale($va_object_types);
-			$this->assertGreaterThan(0, sizeof($va_object_types), "No locale-filtered object types available");
-			
-			$vn_locale_id = 1;
-			
-			$t_object = new ca_objects();
-			$t_object->setMode(ACCESS_WRITE);
-			
-			$vn_item_id = 0;
-			foreach($va_object_types as $va_object_type) {
-				if (intval($va_object_type['is_enabled']) === 1) {
-					$vn_item_id = $va_object_type['item_id'];
-				}
+require_once(__CA_MODELS_DIR__.'/ca_objects.php');
+require_once(__CA_MODELS_DIR__.'/ca_lists.php');
+require_once(__CA_LIB_DIR__.'/ca/Search/ObjectSearch.php');
+
+class BundlableLabelableBaseModelWithAttributesTest extends PHPUnit_Framework_TestCase {
+
+	//
+	// Test attempts to insert a ca_object record, then loads it and compares retrieved values to what was originally stored,
+	// then executes a search for the object via ObjectSearch(), and finally deletes the object.
+	//
+	// This simulates very roughly the life-cycle of a typical bundleable-labelable database object (well not quite... additional
+	// actions, such as relating objects to other database rows, verifying that instrinsic fields work, simulating a form
+	// save, etc. should probably be added... but this does cover the low-level basics)
+	//
+	public function testInsertLoadAndDeleteCycleWithCaObjectsModel() {
+		$t_list = new ca_lists();
+		$va_object_types = $t_list->getItemsForList('object_types');
+		$this->assertGreaterThan(0, sizeof($va_object_types), "No object types available");
+		$va_object_types = caExtractValuesByUserLocale($va_object_types);
+		$this->assertGreaterThan(0, sizeof($va_object_types), "No locale-filtered object types available");
+
+		$vn_locale_id = 1;
+
+		$t_object = new ca_objects();
+		$t_object->setMode(ACCESS_WRITE);
+
+		$vn_item_id = 0;
+		foreach($va_object_types as $va_object_type) {
+			if (intval($va_object_type['is_enabled']) === 1) {
+				$vn_item_id = $va_object_type['item_id'];
 			}
-			
-			$this->assertGreaterThan(0, $vn_item_id, 'No enabled object type found');
-			
-			$t_object->set('type_id', $vn_item_id);
-			$t_object->set('locale_id', $vn_locale_id);
-			$t_object->set('idno', time());
-			
-			$t_object->addAttribute(array(
-				'description' => 'Test description',
-				'locale_id' => $vn_locale_id
-			), 'description');
-			
-			$vb_res = $t_object->insert();
-			$this->assertTrue($vb_res !== false, 'Insert returned non-true value'); // insert() returns false OR the primary key, therefore simply asserting $vb_res being true doesn't cut it
-			$this->assertEquals($t_object->numErrors(), 0, "Errors on insert: ".join('; ', $t_object->getErrors()));
-			
-			$vb_res = $t_object->addLabel(
-				array('name' => 'Unit test object'), $vn_locale_id, null, true
-			);
-			$this->assertGreaterThan(0, $vb_res, 'AddLabel returned zero value but should return non-zero label_id: '.join('; ', $t_object->getErrors()));
-			
-			$t_object2 = new ca_objects();
-			$vb_res = $t_object2->load($t_object->getPrimaryKey());
-			$this->assertTrue($vb_res, 'Load of newly created record failed [record does not seem to exist or return row id was invalid?]');
-			
-			$this->assertEquals($t_object2->getLabelForDisplay(), 'Unit test object', 'Retrieved row label does not match');
-			$this->assertEquals($t_object2->getAttributesForDisplay('description'), 'Test description', 'Retrieved value for attribute "description" does not match expected value');
-		
-			// try to search for it
-			$o_search = new ObjectSearch();
-			$qr_hits = $o_search->search("Unit test object");
-			$this->assertGreaterThan(0, $qr_hits->numHits(), 'Search for ca_object by label found no results');
-			$vb_found_object = false;
-			while($qr_hits->nextHit()) {
-				if ($qr_hits->get('object_id') == $t_object->getPrimaryKey()) {
-					$vb_found_object = true;
-					break;
-				}
+		}
+
+		$this->assertGreaterThan(0, $vn_item_id, 'No enabled object type found');
+
+		$t_object->set('type_id', $vn_item_id);
+		$t_object->set('locale_id', $vn_locale_id);
+		$t_object->set('idno', time());
+
+		$t_object->addAttribute(array(
+			'description' => 'Test description',
+			'locale_id' => $vn_locale_id
+		), 'description');
+
+		$vb_res = $t_object->insert();
+		$this->assertTrue($vb_res !== false, 'Insert returned non-true value'); // insert() returns false OR the primary key, therefore simply asserting $vb_res being true doesn't cut it
+		$this->assertEquals($t_object->numErrors(), 0, "Errors on insert: ".join('; ', $t_object->getErrors()));
+
+		$vb_res = $t_object->addLabel(
+			array('name' => 'Unit test object'), $vn_locale_id, null, true
+		);
+		$this->assertGreaterThan(0, $vb_res, 'AddLabel returned zero value but should return non-zero label_id: '.join('; ', $t_object->getErrors()));
+
+		$t_object2 = new ca_objects();
+		$vb_res = $t_object2->load($t_object->getPrimaryKey());
+		$this->assertTrue($vb_res, 'Load of newly created record failed [record does not seem to exist or return row id was invalid?]');
+
+		$this->assertEquals($t_object2->getLabelForDisplay(), 'Unit test object', 'Retrieved row label does not match');
+		$this->assertEquals($t_object2->getAttributesForDisplay('description'), 'Test description', 'Retrieved value for attribute "description" does not match expected value');
+
+		// try to search for it
+		$o_search = new ObjectSearch();
+		$qr_hits = $o_search->search("Unit test object");
+		$this->assertGreaterThan(0, $qr_hits->numHits(), 'Search for ca_object by label found no results');
+		$vb_found_object = false;
+		while($qr_hits->nextHit()) {
+			if ($qr_hits->get('object_id') == $t_object->getPrimaryKey()) {
+				$vb_found_object = true;
+				break;
 			}
-			$this->assertTrue($vb_found_object, 'ca_object was not in returned search results for ca_object by label');
-			
-			// try delete
-			$t_object->delete(true);
-			$this->assertEquals($t_object->numErrors(), 0, "Errors on delete: ".join('; ', $t_object->getErrors()));
-			
 		}
-		
-		public function testMultipartIDNOGeneration() {
-		
-		}
-		
-		public function testMultipartIDNOVerification() {
-		
-		}
-		
-		// TODO: Test hierarchy functions...
+		$this->assertTrue($vb_found_object, 'ca_object was not in returned search results for ca_object by label');
+
+		// try delete
+		$t_object->delete(true);
+		$this->assertEquals($t_object->numErrors(), 0, "Errors on delete: ".join('; ', $t_object->getErrors()));
+
 	}
+
+	public function testMultipartIDNOGeneration() {
+
+	}
+
+	public function testMultipartIDNOVerification() {
+
+	}
+
+	// TODO: Test hierarchy functions...
+}
 ?>

--- a/tests/lib/ca/Service/BaseJSONServiceTest.php
+++ b/tests/lib/ca/Service/BaseJSONServiceTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once('PHPUnit/Autoload.php');
 require_once(__CA_LIB_DIR__."/ca/Service/BaseJSONService.php");
 require_once(__CA_LIB_DIR__."/core/Controller/Request/RequestHTTP.php");
 require_once(__CA_LIB_DIR__."/core/Controller/Response/ResponseHTTP.php");

--- a/tests/lib/ca/Service/ItemServiceTest.php
+++ b/tests/lib/ca/Service/ItemServiceTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once('PHPUnit/Autoload.php');
 require_once(__CA_LIB_DIR__."/ca/Service/ItemService.php");
 
 class ItemServiceTest extends PHPUnit_Framework_TestCase {

--- a/tests/lib/core/AccessControlTest.php
+++ b/tests/lib/core/AccessControlTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once('PHPUnit/Autoload.php');
 require_once(__CA_LIB_DIR__."/core/Db.php");
 require_once(__CA_LIB_DIR__."/core/Configuration.php");
 require_once(__CA_LIB_DIR__."/core/AccessRestrictions.php");

--- a/tests/lib/core/ConfigurationTest.php
+++ b/tests/lib/core/ConfigurationTest.php
@@ -29,118 +29,118 @@
  * 
  * ----------------------------------------------------------------------
  */
-	define("__CA_DISABLE_CONFIG_CACHING__", true);
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Configuration.php');
-	
-	class ConfigurationTest extends PHPUnit_Framework_TestCase {
-		public function testScalars() {
-			$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
-			
-			$this->assertEquals($o_config->get('a_scalar'), 'Hi there');
-			$this->assertEquals($o_config->get('a_translated_scalar'), 'Hej da!');
-			$this->assertEquals($o_config->get('a_scalar_starting_with_a_bracket'), '[The bracket is part of the string]');
-			$this->assertEquals($o_config->get('a_scalar_using_a_macro'), '/usr/local/fish');
-			$this->assertEquals($o_config->get('a_scalar_using_an_embedded_macro'), 'This scalar is embedded: "/usr/local/fish"');
-			$this->assertEquals($o_config->get('a_scalar_with_utf_8_chars'), 'Expreß zug: חי תהער');
-		}
-		
-		public function testLists() {
-			$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
-			
-			$va_array = $o_config->getList('a_list');
-			$this->assertEquals(sizeof($va_array), 4);
-			$this->assertEquals($va_array[0], 'clouds');
-			$this->assertEquals($va_array[1], 'rain');
-			$this->assertEquals($va_array[2], 'sun');
-			$this->assertEquals($va_array[3], 'gewitter');
-			
-			$va_array = $o_config->getList('a_list_with_quoted_scalars');
-			$this->assertEquals(sizeof($va_array), 2);
-			$this->assertEquals($va_array[0], 'cloudy days');
-			$this->assertEquals($va_array[1], 'rainy days, happy nights');
-			
-			$va_array = $o_config->getList('a_list_with_translated_scalars');
-			$this->assertEquals(sizeof($va_array), 3);
-			$this->assertEquals($va_array[0], 'red');
-			$this->assertEquals($va_array[1], 'blue');
-			$this->assertEquals($va_array[2], 'green');
-			
-			$va_array = $o_config->getList('a_list_with_a_macro');
-			$this->assertEquals(sizeof($va_array), 2);
-			$this->assertEquals($va_array[0], '/usr/local/fish');
-			$this->assertEquals($va_array[1], 'and so it goes');
-			
-			
-			$va_array = $o_config->getList('macro_list');
-			$this->assertEquals(sizeof($va_array), 3, 'Size of list defined in global.conf is not 3');
-			$this->assertEquals($va_array[0], 'flounder');
-			$this->assertEquals($va_array[1], 'lobster');
-			$this->assertEquals($va_array[2], 'haddock');
-			
-			$va_array = $o_config->getList('a_list_with_embedded_brackets');
-			$this->assertEquals($va_array[0], 'Hello [there]');
-		}
-		
-		public function testAssocLists() {
-			$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
-			
-			$va_assoc = $o_config->getAssoc('an_associative_list');
-			$this->assertEquals(sizeof(array_keys($va_assoc)), 1);
-			$this->assertEquals(sizeof(array_keys($va_assoc['key 1'])), 5);
-			$this->assertEquals($va_assoc['key 1']['subkey1'], 1);
-			$this->assertEquals($va_assoc['key 1']['subkey2'], 2);
-			$this->assertTrue(is_array($va_assoc['key 1']['subkey3']));
-			$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey1'], 'at the bottom of the hole');
-			$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey2'], 'this is a quoted string');
-			$this->assertTrue(is_array($va_assoc['key 1']['subkey4']));
-			$this->assertEquals($va_assoc['key 1']['subkey4'][0], 'Providence');
-			$this->assertEquals($va_assoc['key 1']['subkey4'][1], 'Pawtucket');
-			$this->assertEquals($va_assoc['key 1']['subkey4'][2], 'Woonsocket');
-			$this->assertEquals($va_assoc['key 1']['subkey4'][3], 'Narragansett');
-			$this->assertEquals($va_assoc['key 1']['subkey5'], '/usr/local/fish');
-			
-			$va_assoc = $o_config->getAssoc('macro_assoc');
-			$this->assertEquals(sizeof(array_keys($va_assoc)), 3);
-			$this->assertEquals(sizeof(array_keys($va_assoc['fish'])), 3);
-			$this->assertEquals(sizeof(array_keys($va_assoc['shellfish'])), 3);
-			$this->assertEquals(sizeof(array_keys($va_assoc['other'])), 3);
-			$this->assertEquals($va_assoc['fish'][0], 'flounder');
-			$this->assertEquals($va_assoc['shellfish'][0], 'scallop');
-			$this->assertEquals($va_assoc['other'][0], 'chicken');
-			
-			$va_assoc = $o_config->getAssoc('an_assoc_list_with_embedded_brackets');
-			$this->assertEquals($va_assoc['test'], 'Hello {there}');
-		}
-		
-		public function testBoolean() {
-			$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
-			
-			$vb_scalar = $o_config->getBoolean('boolean_yes');
-			$this->assertTrue($vb_scalar);
-			$vb_scalar = $o_config->getBoolean('boolean_ja');
-			$this->assertTrue($vb_scalar);
-			$vb_scalar = $o_config->getBoolean('boolean_wahr');
-			$this->assertTrue($vb_scalar);
-			$vb_scalar = $o_config->getBoolean('boolean_no');
-			$this->assertFalse($vb_scalar);
-			$vb_scalar = $o_config->getBoolean('boolean_nein');
-			$this->assertFalse($vb_scalar);
-		}
-		
-		public function testMisc() {
-			$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
-			
-			$va_keys = $o_config->getScalarKeys();
-			$this->assertTrue(is_array($va_keys));
-			$this->assertEquals(sizeof($va_keys), 13);		// 12 in config file + 1 "LOCALE" value that's automatically inserted
-			$va_keys = $o_config->getListKeys();
-			$this->assertTrue(is_array($va_keys));
-			$this->assertEquals(sizeof($va_keys), 6);
-			$va_keys = $o_config->getAssocKeys();
-			$this->assertTrue(is_array($va_keys));
-			$this->assertEquals(sizeof($va_keys), 3);
-			
-		}
+define("__CA_DISABLE_CONFIG_CACHING__", true);
+
+require_once(__CA_LIB_DIR__.'/core/Configuration.php');
+
+class ConfigurationTest extends PHPUnit_Framework_TestCase {
+	public function testScalars() {
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
+
+		$this->assertEquals($o_config->get('a_scalar'), 'Hi there');
+		$this->assertEquals($o_config->get('a_translated_scalar'), 'Hej da!');
+		$this->assertEquals($o_config->get('a_scalar_starting_with_a_bracket'), '[The bracket is part of the string]');
+		$this->assertEquals($o_config->get('a_scalar_using_a_macro'), '/usr/local/fish');
+		$this->assertEquals($o_config->get('a_scalar_using_an_embedded_macro'), 'This scalar is embedded: "/usr/local/fish"');
+		$this->assertEquals($o_config->get('a_scalar_with_utf_8_chars'), 'Expreß zug: חי תהער');
 	}
+
+	public function testLists() {
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
+
+		$va_array = $o_config->getList('a_list');
+		$this->assertEquals(sizeof($va_array), 4);
+		$this->assertEquals($va_array[0], 'clouds');
+		$this->assertEquals($va_array[1], 'rain');
+		$this->assertEquals($va_array[2], 'sun');
+		$this->assertEquals($va_array[3], 'gewitter');
+
+		$va_array = $o_config->getList('a_list_with_quoted_scalars');
+		$this->assertEquals(sizeof($va_array), 2);
+		$this->assertEquals($va_array[0], 'cloudy days');
+		$this->assertEquals($va_array[1], 'rainy days, happy nights');
+
+		$va_array = $o_config->getList('a_list_with_translated_scalars');
+		$this->assertEquals(sizeof($va_array), 3);
+		$this->assertEquals($va_array[0], 'red');
+		$this->assertEquals($va_array[1], 'blue');
+		$this->assertEquals($va_array[2], 'green');
+
+		$va_array = $o_config->getList('a_list_with_a_macro');
+		$this->assertEquals(sizeof($va_array), 2);
+		$this->assertEquals($va_array[0], '/usr/local/fish');
+		$this->assertEquals($va_array[1], 'and so it goes');
+
+
+		$va_array = $o_config->getList('macro_list');
+		$this->assertEquals(sizeof($va_array), 3, 'Size of list defined in global.conf is not 3');
+		$this->assertEquals($va_array[0], 'flounder');
+		$this->assertEquals($va_array[1], 'lobster');
+		$this->assertEquals($va_array[2], 'haddock');
+
+		$va_array = $o_config->getList('a_list_with_embedded_brackets');
+		$this->assertEquals($va_array[0], 'Hello [there]');
+	}
+
+	public function testAssocLists() {
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
+
+		$va_assoc = $o_config->getAssoc('an_associative_list');
+		$this->assertEquals(sizeof(array_keys($va_assoc)), 1);
+		$this->assertEquals(sizeof(array_keys($va_assoc['key 1'])), 5);
+		$this->assertEquals($va_assoc['key 1']['subkey1'], 1);
+		$this->assertEquals($va_assoc['key 1']['subkey2'], 2);
+		$this->assertTrue(is_array($va_assoc['key 1']['subkey3']));
+		$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey1'], 'at the bottom of the hole');
+		$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey2'], 'this is a quoted string');
+		$this->assertTrue(is_array($va_assoc['key 1']['subkey4']));
+		$this->assertEquals($va_assoc['key 1']['subkey4'][0], 'Providence');
+		$this->assertEquals($va_assoc['key 1']['subkey4'][1], 'Pawtucket');
+		$this->assertEquals($va_assoc['key 1']['subkey4'][2], 'Woonsocket');
+		$this->assertEquals($va_assoc['key 1']['subkey4'][3], 'Narragansett');
+		$this->assertEquals($va_assoc['key 1']['subkey5'], '/usr/local/fish');
+
+		$va_assoc = $o_config->getAssoc('macro_assoc');
+		$this->assertEquals(sizeof(array_keys($va_assoc)), 3);
+		$this->assertEquals(sizeof(array_keys($va_assoc['fish'])), 3);
+		$this->assertEquals(sizeof(array_keys($va_assoc['shellfish'])), 3);
+		$this->assertEquals(sizeof(array_keys($va_assoc['other'])), 3);
+		$this->assertEquals($va_assoc['fish'][0], 'flounder');
+		$this->assertEquals($va_assoc['shellfish'][0], 'scallop');
+		$this->assertEquals($va_assoc['other'][0], 'chicken');
+
+		$va_assoc = $o_config->getAssoc('an_assoc_list_with_embedded_brackets');
+		$this->assertEquals($va_assoc['test'], 'Hello {there}');
+	}
+
+	public function testBoolean() {
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
+
+		$vb_scalar = $o_config->getBoolean('boolean_yes');
+		$this->assertTrue($vb_scalar);
+		$vb_scalar = $o_config->getBoolean('boolean_ja');
+		$this->assertTrue($vb_scalar);
+		$vb_scalar = $o_config->getBoolean('boolean_wahr');
+		$this->assertTrue($vb_scalar);
+		$vb_scalar = $o_config->getBoolean('boolean_no');
+		$this->assertFalse($vb_scalar);
+		$vb_scalar = $o_config->getBoolean('boolean_nein');
+		$this->assertFalse($vb_scalar);
+	}
+
+	public function testMisc() {
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/core/data/test.conf');
+
+		$va_keys = $o_config->getScalarKeys();
+		$this->assertTrue(is_array($va_keys));
+		$this->assertEquals(sizeof($va_keys), 13);		// 12 in config file + 1 "LOCALE" value that's automatically inserted
+		$va_keys = $o_config->getListKeys();
+		$this->assertTrue(is_array($va_keys));
+		$this->assertEquals(sizeof($va_keys), 6);
+		$va_keys = $o_config->getAssocKeys();
+		$this->assertTrue(is_array($va_keys));
+		$this->assertEquals(sizeof($va_keys), 3);
+
+	}
+}
 ?>

--- a/tests/lib/core/Controller/ControllerTest.php
+++ b/tests/lib/core/Controller/ControllerTest.php
@@ -29,15 +29,14 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Controller/AppController.php');
-	
-	class ControllerTest extends PHPUnit_Framework_TestCase {
-	
-		
-		public function testRequestDispatch() {
-		
-		}
-		
+require_once(__CA_LIB_DIR__.'/core/Controller/AppController.php');
+
+class ControllerTest extends PHPUnit_Framework_TestCase {
+
+
+	public function testRequestDispatch() {
+
 	}
+
+}
 ?>

--- a/tests/lib/core/Models/DatamodelTest.php
+++ b/tests/lib/core/Models/DatamodelTest.php
@@ -29,18 +29,17 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
-	
-	class DatamodelTest extends PHPUnit_Framework_TestCase {
-		public function testInstantiateAllModels() {
-			$o_dm = Datamodel::load();
-			
-			$va_tables = $o_dm->getTableNames();
-			
-			foreach($va_tables as $vs_table) {
-				$this->assertInstanceOf($vs_table, $o_dm->getInstanceByTableName($vs_table));
-			}
+require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
+
+class DatamodelTest extends PHPUnit_Framework_TestCase {
+	public function testInstantiateAllModels() {
+		$o_dm = Datamodel::load();
+
+		$va_tables = $o_dm->getTableNames();
+
+		foreach($va_tables as $vs_table) {
+			$this->assertInstanceOf($vs_table, $o_dm->getInstanceByTableName($vs_table));
 		}
 	}
+}
 ?>

--- a/tests/lib/core/Models/ModelTest.php
+++ b/tests/lib/core/Models/ModelTest.php
@@ -29,877 +29,876 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
-	require_once(__CA_MODELS_DIR__.'/ca_objects.php');
-	
-	//
-	// NOTE: REQUIRES CONEY ISLAND HISTORY PROJECT TEST DATA
-	//
-	// You can get this data from the GitHub repository at http://github.com/CollectiveAccess/providence/support/test/test_data_mysql.dump
-	//
-	
-	class ModelTest extends PHPUnit_Framework_TestCase {
-		# -------------------------------------------------------------------------------
-		/**
-		 * @var ca_objects.idno value of record to use for testing
-		 */
-		private $ops_object_idno = 'CIHP.TEST';
-		# -------------------------------------------------------------------------------
-		/**
-		 * Set up request global required by get() returnAsLink option
-		 */
-		public function __construct() {
-			define("__CA_APP_TYPE__", "PAWTUCKET");
-			global $g_request;
-			$g_request = new RequestHTTP(new ResponseHTTP(), array('no_headers' => true, 'no_authentication' => true));
-			
+require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
+require_once(__CA_MODELS_DIR__.'/ca_objects.php');
+
+//
+// NOTE: REQUIRES CONEY ISLAND HISTORY PROJECT TEST DATA
+//
+// You can get this data from the GitHub repository at http://github.com/CollectiveAccess/providence/support/test/test_data_mysql.dump
+//
+
+class ModelTest extends PHPUnit_Framework_TestCase {
+	# -------------------------------------------------------------------------------
+	/**
+	 * @var ca_objects.idno value of record to use for testing
+	 */
+	private $ops_object_idno = 'CIHP.TEST';
+	# -------------------------------------------------------------------------------
+	/**
+	 * Set up request global required by get() returnAsLink option
+	 */
+	public function __construct() {
+		define("__CA_APP_TYPE__", "PAWTUCKET");
+		global $g_request;
+		$g_request = new RequestHTTP(new ResponseHTTP(), array('no_headers' => true, 'no_authentication' => true));
+
+	}
+	# -------------------------------------------------------------------------------
+	public function testIntrinsicGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		//
+		// Get as scalar without locales
+		//
+		$vs_val = $t_object->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
+
+		$vs_val = $t_object->get('idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
+
+		//
+		// Get as array without locales
+		//
+		$va_val = $t_object->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
+
+		//
+		// Get as array with locales
+		//
+		$va_val = $t_object->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($this->ops_object_idno, $va_val, "Value in third level should be ".$this->ops_object_idno);
+
+		//
+		// Get as scalar with locales (should force returnAsArray to true)
+		//
+		$vs_val = $t_object->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $vs_val, "Return value should be array");
+		$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
+	}
+	# -------------------------------------------------------------------------------
+	public function testSimpleRelatedGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		//
+		// Get related entities as string
+		//
+		$vs_val = $t_object->get('ca_entities', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals('Seth Kaufman; Charles Denson', $vs_val, "Return value is incorrect");
+
+		//
+		// Get related entities as link
+		//
+		$vs_val = $t_object->get('ca_entities', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertContains('<a href', $vs_val, "Return value is incorrect");
+		$this->assertContains('Seth Kaufman', $vs_val, "Return value is incorrect");
+
+		foreach(array('with returnAsLink' => true, 'without returnAsLink' => false) as $vs_message => $vb_return_as_link) {
+			//
+			// Get related items for table as array
+			//
+			$va_val = $t_object->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => false, 'returnAsLink' => $vb_return_as_link));
+			$this->assertInternalType("array", $va_val, "Return value should be array {$vs_message}");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("string", $va_val['entity_id'], "Value for key 'entity_id' should be string {$vs_message}");
+			$this->assertGreaterThan(0, (int)$va_val['entity_id'], "Value for key 'entity_id' should be greater than zero when cast to integer {$vs_message}");
+
+			//
+			// Get related items for table as all-locales array
+			//
+			$va_val = $t_object->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => true, 'returnAsLink' => $vb_return_as_link));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array {$vs_message}");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array {$vs_message}");
+
+			$this->assertContains("Seth Kaufman", $va_val, "Value in third level should be Seth Kaufman {$vs_message}");
+
+			//
+			// Get related entities with template
+			//
+			$vs_val = $t_object->get('ca_entities', array('template' => '^preferred_labels.surname, ^preferred_labels.forename (^idno)', 'returnAsLink' => $vb_return_as_link, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+			$this->assertInternalType("string", $vs_val);
+
+			if ($vb_return_as_link) {
+				$this->assertContains('<a href', $vs_val, "Return value is incorrect {$vs_message}");
+				$this->assertContains('Kaufman, Seth (4)', $vs_val, "Return value is incorrect {$vs_message}");
+			} else {
+				$this->assertEquals('Kaufman, Seth (4); Denson, Charles (5)', $vs_val, "Return value is incorrect {$vs_message}");
+			}
 		}
-		# -------------------------------------------------------------------------------
-		public function testIntrinsicGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
+	}
+	# -------------------------------------------------------------------------------
+	public function testAttributeGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		$vs_description = 'This is a test description';
+
+		//
+		// Test <tablename>.<element_code> attributes
+		//
+
 			//
 			// Get as scalar without locales
 			//
-			$vs_val = $t_object->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$vs_val = $t_object->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => false));
 			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
-			
-			$vs_val = $t_object->get('idno', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
-			
+			$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");
+
 			//
 			// Get as array without locales
 			//
-			$va_val = $t_object->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$va_val = $t_object->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
 			$this->assertInternalType("array", $va_val, "Return value should be array");
 			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
-			
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$this->assertArrayHasKey("description", $va_val, "Second level of returned value should be array with key 'description'");
+
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
 			//
 			// Get as array with locales
 			//
-			$va_val = $t_object->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$va_val = $t_object->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => true));
 			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($this->ops_object_idno, $va_val, "Value in third level should be ".$this->ops_object_idno);
-			
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_description, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("description", $va_val, "Fourth level of returned value should be array with key 'description'");
+
 			//
-			// Get as scalar with locales (should force returnAsArray to true)
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
 			//
-			$vs_val = $t_object->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $vs_val, "Return value should be array");
-			$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
-		}
-		# -------------------------------------------------------------------------------
-		public function testSimpleRelatedGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
+			$vs_val = $t_object->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
+			// Get scalar with template
 			//
-			// Get related entities as string
+			$vs_val = $t_object->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $t_object->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
+
+
 			//
-			$vs_val = $t_object->get('ca_entities', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
+			// Get scalar with template as array
+			//
+			$va_val = $t_object->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be string");
+			$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
+
+			$va_val = $t_object->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be string");
+			$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
+
+
+		//
+		// Test <tablename>.<element_code>.<sub_element_code> attributes
+		//
+			//
+			// Get as scalar without locales
+			//
+			$vs_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => false));
 			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals('Seth Kaufman; Charles Denson', $vs_val, "Return value is incorrect");
-			
-			//
-			// Get related entities as link
-			//
-			$vs_val = $t_object->get('ca_entities', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
-			$this->assertInternalType("string", $vs_val);
-			$this->assertContains('<a href', $vs_val, "Return value is incorrect");
-			$this->assertContains('Seth Kaufman', $vs_val, "Return value is incorrect");
-			
-			foreach(array('with returnAsLink' => true, 'without returnAsLink' => false) as $vs_message => $vb_return_as_link) {
-				//
-				// Get related items for table as array
-				//
-				$va_val = $t_object->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => false, 'returnAsLink' => $vb_return_as_link));
-				$this->assertInternalType("array", $va_val, "Return value should be array {$vs_message}");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("string", $va_val['entity_id'], "Value for key 'entity_id' should be string {$vs_message}");
-				$this->assertGreaterThan(0, (int)$va_val['entity_id'], "Value for key 'entity_id' should be greater than zero when cast to integer {$vs_message}");
-			
-				//
-				// Get related items for table as all-locales array
-				//
-				$va_val = $t_object->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => true, 'returnAsLink' => $vb_return_as_link));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array {$vs_message}");
-			
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array {$vs_message}");
-			
-				$this->assertContains("Seth Kaufman", $va_val, "Value in third level should be Seth Kaufman {$vs_message}");
-								
-				//
-				// Get related entities with template
-				//
-				$vs_val = $t_object->get('ca_entities', array('template' => '^preferred_labels.surname, ^preferred_labels.forename (^idno)', 'returnAsLink' => $vb_return_as_link, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
-				$this->assertInternalType("string", $vs_val);
-				
-				if ($vb_return_as_link) {
-					$this->assertContains('<a href', $vs_val, "Return value is incorrect {$vs_message}");
-					$this->assertContains('Kaufman, Seth (4)', $vs_val, "Return value is incorrect {$vs_message}");				
-				} else {
-					$this->assertEquals('Kaufman, Seth (4); Denson, Charles (5)', $vs_val, "Return value is incorrect {$vs_message}");
-				}
-			}
-		}
-		# -------------------------------------------------------------------------------
-		public function testAttributeGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
-			$vs_description = 'This is a test description';
+			$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");
 
 			//
-			// Test <tablename>.<element_code> attributes 
+			// Get as array without locales
 			//
-			
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => false));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$this->assertArrayHasKey("description", $va_val, "Second level of returned value should be array with key 'description'");
-				
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_description, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("description", $va_val, "Fourth level of returned value should be array with key 'description'");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-
-				// Get scalar with template
-				//
-				$vs_val = $t_object->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $t_object->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
-		
-				
-				//
-				// Get scalar with template as array
-				//
-				$va_val = $t_object->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
-			
-				$this->assertInternalType("array", $va_val, "Return value should be string");
-				$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
-				
-				$va_val = $t_object->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
-	
-				$this->assertInternalType("array", $va_val, "Return value should be string");
-				$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
-
-
-			//
-			// Test <tablename>.<element_code>.<sub_element_code> attributes 
-			//
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => false));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_description, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				
-				//
-				// Attribute with template
-				//
-				$va_val = $t_object->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => false, 'returnAllLocales' => false));
-				
-				$this->assertInternalType("string", $va_val, "Return value should be string");
-				$this->assertEquals("W=12.0 in", $va_val, "Returned value is incorrect");
-				
-				$va_val = $t_object->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => true, 'returnAllLocales' => false));
-		
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertContains("W=12.0 in", $va_val, "Returned value is incorrect");
-				
-		}
-		# -------------------------------------------------------------------------------
-		public function testPreferredLabelGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
-			$vs_title = "Canonical test record";
-			
-			//
-			// Get preferred label values (all fields - not specific values)
-			// (eg. <table_name>.preferred_labels
-			//
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$this->assertArrayHasKey("name", $va_val, "Second level of returned value should be array with key 'name'");
-				
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-			//
-			// Get preferred label values (specific values)
-			// (eg. <table_name>.preferred_labels.<field_name>
-			//
-			//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-			
-				
-				//
-				// Get URL attribute as link
-				//
-				$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-			
-				$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$va_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$vs_val = array_pop($va_val);
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsLinkAttributes' => array('class' => 'extLink', 'alt' => 'External link'), 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("href=", $vs_val, "Returned value is not a link");
-				$this->assertContains("<a", $vs_val, "Returned value is not a link");
-				$this->assertContains("class='extLink'", $vs_val, "Returned value is missing class");
-				$this->assertContains("alt='External link'", $vs_val, "Returned value is alt attribute");
-				$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-		}
-		# -------------------------------------------------------------------------------
-		public function testNonPreferredLabelGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
-			$vs_title = "This is an alternate title";
-			
-			//
-			// Get nonpreferred label values (all fields - not specific values)
-			// (eg. <table_name>.nonpreferred_labels
-			//
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertArrayHasKey("name", $va_val, "Third level of returned value should be array with key 'name'");
-				
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-			//
-			// Get preferred label values (specific values)
-			// (eg. <table_name>.nonpreferred_labels.<field_name>
-			//
-			//
-				// Get as scalar without locales
-				//
-				$vs_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-			
-		}
-		# -------------------------------------------------------------------------------
-		public function testRelatedItemsGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-		
-			//
-			// Get related preferred labels array (all fields)
-			//
-			$vs_value = 'Seth Kaufman; Charles Denson';
-			$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get related preferred labels array (all fields) as link
-			//
-			$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains("Seth Kaufman", $va_val, "Returned value is incorrect");
-			
-			//
-			// Get related preferred labels array (all fields) as link with template
-			//
-			$va_val = $t_object->get('ca_entities.preferred_labels', array('template' => '^preferred_labels.surname, ^preferred_labels.forename', 'returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains("Kaufman, Seth", $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertTrue(is_string($va_val[0]['entity_id']), "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$vs_value = 'Seth Kaufman';
-			$this->assertContains($vs_value, $va_val, "Value in fourth level is incorrect");
-			
-			//
-			// Get specific field in preferred labels
-			//
-			$vs_value = 'Kaufman; Denson';
-			$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get specific field in preferred labels as link
-			//
-			$vs_value = 'Kaufman; Denson';
-			$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains('Kaufman', $va_val, "Returned value is incorrect");
-			
-			
-			$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = 'Kaufman';
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => true));
-		
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
-			
-			
-			//
-			// Get entity field
-			//
-			$vs_value = '4; 5';
-			$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity field as link
-			//
-			$va_val = $t_object->get('ca_entities.idno', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains('4', $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = '4';
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-		
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
-			
-			
-			//
-			// Get entity attribute
-			//
-			$vs_value = 'These are test notes';
-			$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute as link
-			//
-			$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not a link");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute as link with template
-			//
-			$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not a link");
-			$this->assertContains("Notes: {$vs_value}", $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute with template
-			//
-			$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => false, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals("Notes: {$vs_value}; Notes: ", $va_val, "Returned value is incorrect");
-			
-			
-			//
-			// Get entity attribute as array and links with template
-			//
-			$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains("Notes: {$vs_value}", array_shift($va_val), "Returned value is incorrect");
-			
-			
-			$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = 'These are test notes';
-			$va_val = array_pop($va_val);
-			
+			$va_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => false));
 			$this->assertInternalType("array", $va_val, "Return value should be array");
 			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertContains($vs_description, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $t_object->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
+
+			//
+			// Attribute with template
+			//
+			$va_val = $t_object->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => false, 'returnAllLocales' => false));
+
+			$this->assertInternalType("string", $va_val, "Return value should be string");
+			$this->assertEquals("W=12.0 in", $va_val, "Returned value is incorrect");
+
+			$va_val = $t_object->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => true, 'returnAllLocales' => false));
 
 			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
-			$this->assertContains($vs_value, $va_val['internal_notes'], "Value in third level is incorrect");
-			
-		}
-		# -------------------------------------------------------------------------------
-		public function testParentGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => 'CIHP.TEST.1')), "Could not load test record");
-			
-			//
-			// Get intrinsic field from parent
-			//
-			$vs_value = $this->ops_object_idno;
-			$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
-			
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get preferred labels from parent
-			//
-			$vs_value = 'Canonical test record';
-			$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get attributes from parent
-			//
-			$vs_value = 'This is a test description';
-			$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertContains("W=12.0 in", $va_val, "Returned value is incorrect");
 
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
-			$this->assertContains($vs_value, $va_tmp, "Value in array is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
-			$this->assertContains($vs_value, $va_val['description'], "Value in fourth level is incorrect");
-		}
-		# -------------------------------------------------------------------------------
-		public function testChildrenGet() {
-			$t_object = new ca_objects();
-			$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
-			
-			//
-			// Get intrinsic field from children
-			//
-			$vs_value = 'CIHP.TEST.1; CIHP.TEST.2';
-			$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$vs_value = 'CIHP.TEST.1';
-			$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get preferred labels from children
-			//
-			$vs_value = 'Canonical test sub-record No. 1; Canonical test sub-record No. 2';
-			$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
-			$vs_value = 'Canonical test sub-record No. 1';
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get attributes from children
-			//
-			$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			
-			$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should greater than 0");
-			$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
-			
-			$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
-		}
-		# -------------------------------------------------------------------------------
 	}
+	# -------------------------------------------------------------------------------
+	public function testPreferredLabelGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		$vs_title = "Canonical test record";
+
+		//
+		// Get preferred label values (all fields - not specific values)
+		// (eg. <table_name>.preferred_labels
+		//
+			//
+			// Get as scalar without locales
+			//
+			$vs_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
+			//
+			// Get as array without locales
+			//
+			$va_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$this->assertArrayHasKey("name", $va_val, "Second level of returned value should be array with key 'name'");
+
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $t_object->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+		//
+		// Get preferred label values (specific values)
+		// (eg. <table_name>.preferred_labels.<field_name>
+		//
+		//
+			// Get as scalar without locales
+			//
+			$vs_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
+			//
+			// Get as array without locales
+			//
+			$va_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $t_object->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+
+			//
+			// Get URL attribute as link
+			//
+			$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$va_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$vs_val = array_pop($va_val);
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $t_object->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsLinkAttributes' => array('class' => 'extLink', 'alt' => 'External link'), 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("href=", $vs_val, "Returned value is not a link");
+			$this->assertContains("<a", $vs_val, "Returned value is not a link");
+			$this->assertContains("class='extLink'", $vs_val, "Returned value is missing class");
+			$this->assertContains("alt='External link'", $vs_val, "Returned value is alt attribute");
+			$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+	}
+	# -------------------------------------------------------------------------------
+	public function testNonPreferredLabelGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		$vs_title = "This is an alternate title";
+
+		//
+		// Get nonpreferred label values (all fields - not specific values)
+		// (eg. <table_name>.nonpreferred_labels
+		//
+			//
+			// Get as scalar without locales
+			//
+			$vs_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
+			//
+			// Get as array without locales
+			//
+			$va_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertArrayHasKey("name", $va_val, "Third level of returned value should be array with key 'name'");
+
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $t_object->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+		//
+		// Get preferred label values (specific values)
+		// (eg. <table_name>.nonpreferred_labels.<field_name>
+		//
+		//
+			// Get as scalar without locales
+			//
+			$vs_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
+			//
+			// Get as array without locales
+			//
+			$va_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $t_object->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+	}
+	# -------------------------------------------------------------------------------
+	public function testRelatedItemsGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		//
+		// Get related preferred labels array (all fields)
+		//
+		$vs_value = 'Seth Kaufman; Charles Denson';
+		$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get related preferred labels array (all fields) as link
+		//
+		$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains("Seth Kaufman", $va_val, "Returned value is incorrect");
+
+		//
+		// Get related preferred labels array (all fields) as link with template
+		//
+		$va_val = $t_object->get('ca_entities.preferred_labels', array('template' => '^preferred_labels.surname, ^preferred_labels.forename', 'returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains("Kaufman, Seth", $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertTrue(is_string($va_val[0]['entity_id']), "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$vs_value = 'Seth Kaufman';
+		$this->assertContains($vs_value, $va_val, "Value in fourth level is incorrect");
+
+		//
+		// Get specific field in preferred labels
+		//
+		$vs_value = 'Kaufman; Denson';
+		$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get specific field in preferred labels as link
+		//
+		$vs_value = 'Kaufman; Denson';
+		$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains('Kaufman', $va_val, "Returned value is incorrect");
+
+
+		$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = 'Kaufman';
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
+
+
+		//
+		// Get entity field
+		//
+		$vs_value = '4; 5';
+		$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity field as link
+		//
+		$va_val = $t_object->get('ca_entities.idno', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains('4', $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = '4';
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
+
+
+		//
+		// Get entity attribute
+		//
+		$vs_value = 'These are test notes';
+		$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute as link
+		//
+		$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not a link");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute as link with template
+		//
+		$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not a link");
+		$this->assertContains("Notes: {$vs_value}", $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute with template
+		//
+		$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => false, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals("Notes: {$vs_value}; Notes: ", $va_val, "Returned value is incorrect");
+
+
+		//
+		// Get entity attribute as array and links with template
+		//
+		$va_val = $t_object->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains("Notes: {$vs_value}", array_shift($va_val), "Returned value is incorrect");
+
+
+		$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = 'These are test notes';
+		$va_val = array_pop($va_val);
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
+		$this->assertContains($vs_value, $va_val['internal_notes'], "Value in third level is incorrect");
+
+	}
+	# -------------------------------------------------------------------------------
+	public function testParentGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => 'CIHP.TEST.1')), "Could not load test record");
+
+		//
+		// Get intrinsic field from parent
+		//
+		$vs_value = $this->ops_object_idno;
+		$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get preferred labels from parent
+		//
+		$vs_value = 'Canonical test record';
+		$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get attributes from parent
+		//
+		$vs_value = 'This is a test description';
+		$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
+		$this->assertContains($vs_value, $va_tmp, "Value in array is incorrect");
+
+		$va_val = $t_object->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
+		$this->assertContains($vs_value, $va_val['description'], "Value in fourth level is incorrect");
+	}
+	# -------------------------------------------------------------------------------
+	public function testChildrenGet() {
+		$t_object = new ca_objects();
+		$this->assertTrue($t_object->load(array('idno' => $this->ops_object_idno)), "Could not load test record");
+
+		//
+		// Get intrinsic field from children
+		//
+		$vs_value = 'CIHP.TEST.1; CIHP.TEST.2';
+		$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$vs_value = 'CIHP.TEST.1';
+		$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $t_object->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get preferred labels from children
+		//
+		$vs_value = 'Canonical test sub-record No. 1; Canonical test sub-record No. 2';
+		$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$vs_value = 'Canonical test sub-record No. 1';
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $t_object->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get attributes from children
+		//
+		$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+
+		$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should greater than 0");
+		$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
+
+		$va_val = $t_object->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
+	}
+	# -------------------------------------------------------------------------------
+}
 ?>

--- a/tests/lib/core/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/core/Parsers/TimeExpressionParserTest.php
@@ -29,666 +29,665 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Parsers/TimeExpressionParser.php');
-	
-	class TimeExpressionParserTest extends PHPUnit_Framework_TestCase {
+require_once(__CA_LIB_DIR__.'/core/Parsers/TimeExpressionParser.php');
 
-		public function setUp() {
-			// most of the comparisons below rely on Eastern time zone
-			date_default_timezone_set('America/New_York');
-		}
-	
-		public function testQuarterCentryDates() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('20 Q2');	// 2nd quarter of 20th century
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], "1925.0101000000");
-			$this->assertEquals($va_parse['end'], "1950.1231235959");
-			$this->assertEquals($va_parse[0], "1925.0101000000");
-			$this->assertEquals($va_parse[1], "1950.1231235959");
-			
-			$vb_res = $o_tep->parse('1 Q4');		// 4th quarter of 1st century
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], "75.0101000000");
-			$this->assertEquals($va_parse['end'], "100.1231235959");
-			$this->assertEquals($va_parse[0], "75.0101000000");
-			$this->assertEquals($va_parse[1], "100.1231235959");
-			
-		}
-		
-		public function testYearlessDates() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('10/24/??');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], "0.1024000000");
-			$this->assertEquals($va_parse['end'], "0.1024235959");
-			$this->assertEquals($va_parse[0], "0.1024000000");
-			$this->assertEquals($va_parse[1], "0.1024235959");
-			$this->assertEquals($o_tep->getText(), "10/24/????");	
-		}
-		
-		public function testRangeSpanningEras() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('88 BCE to 55 CE');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], -88.0101000000);
-			$this->assertEquals($va_parse['end'], 55.1231235959);
-			$this->assertEquals($va_parse[0], -88.0101000000);
-			$this->assertEquals($va_parse[1], 55.1231235959);
-			
-			
-			$vb_res = $o_tep->parse('50 BCE to 10 CE');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], -50.0101000000);
-			$this->assertEquals($va_parse['end'], 10.1231235959);
-			$this->assertEquals($va_parse[0], -50.0101000000);
-			$this->assertEquals($va_parse[1], 10.1231235959);
-		}
-		
-		public function testRangeInFirstCentury() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('50 CE to 80 CE');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], 50.0101000000);
-			$this->assertEquals($va_parse['end'], 80.1231235959);
-			$this->assertEquals($va_parse[0], 50.0101000000);
-			$this->assertEquals($va_parse[1], 80.1231235959);
-		}
-		
-		public function testSeasonDates() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('Winter 2010');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], "2010.1221000000");
-			$this->assertEquals($va_parse['end'], "2011.0320235959");
-			$this->assertEquals($va_parse[0], "2010.1221000000");
-			$this->assertEquals($va_parse[1], "2011.0320235959");
-		}
-		
-		public function testParseSimpleDelimitedDateForEnglishLocale() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('10/23/2004');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			$this->assertEquals($va_parse['start'], 1098504000);
-			$this->assertEquals($va_parse['end'], 1098590399);
-			$this->assertEquals($va_parse[0], 1098504000);
-			$this->assertEquals($va_parse[1], 1098590399);
-		}
-		
-		public function testParseSimpleDelimitedDateForEuropeanLocale() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('fr_FR');
-			$vb_res = $o_tep->parse('23/10/2004');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			
-			$this->assertEquals($va_parse['start'], 1098504000);
-			$this->assertEquals($va_parse['end'], 1098590399);
-			$this->assertEquals($va_parse[0], 1098504000);
-			$this->assertEquals($va_parse[1], 1098590399);
-		}
-		
-		public function testParseTextDate() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('May 10, 1990');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			
-			$this->assertEquals($va_parse['start'], 642312000);
-			$this->assertEquals($va_parse['end'], 642398399);
-			$this->assertEquals($va_parse[0], 642312000);
-			$this->assertEquals($va_parse[1], 642398399);
-			
-			$vb_res = $o_tep->parse('10 May 1990');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			
-			$this->assertEquals($va_parse['start'], 642312000);
-			$this->assertEquals($va_parse['end'], 642398399);
-			$this->assertEquals($va_parse[0], 642312000);
-			$this->assertEquals($va_parse[1], 642398399);
-		}
-		
-		public function testParseISO8601Date() {
-			$o_tep = new TimeExpressionParser();
-			$vb_res = $o_tep->parse('2009-09-18 21:03');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			
-			$this->assertEquals($va_parse['start'], 1253322180);
-			$this->assertEquals($va_parse['end'], 1253322180);
-			$this->assertEquals($va_parse[0], 1253322180);
-			$this->assertEquals($va_parse[1], 1253322180);
-		}
-		
-		public function testParseNowDate() {
-			$o_tep = new TimeExpressionParser();
-			$vb_res = $o_tep->parse('now');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getUnixTimestamps();
-			
-			$this->assertEquals($va_parse['start'], $t= time());
-			$this->assertEquals($va_parse['end'], $t);
-			$this->assertEquals($va_parse[0], $t);
-			$this->assertEquals($va_parse[1], $t);
-		}
-		
-		public function testHistoricDayDateForEnglishLocale() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('March 8, 1945');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "1945.030800000000");
-			$this->assertEquals($va_parse['end'], "1945.030823595900");
-			$this->assertEquals($va_parse[0], "1945.030800000000");
-			$this->assertEquals($va_parse[1], "1945.030823595900");
-		}
-		
-		public function testHistoricDayDateForGermanLocale() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('de_DE');
-			$vb_res = $o_tep->parse('8. Mai 1945');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1945.050800000000");
-			$this->assertEquals($va_parse['end'], "1945.050823595900");
-			$this->assertEquals($va_parse[0], "1945.050800000000");
-			$this->assertEquals($va_parse[1], "1945.050823595900");
-		}
+class TimeExpressionParserTest extends PHPUnit_Framework_TestCase {
 
-		public function testCenturyDatesForGermanLocale() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('de_DE');
-			$vb_res = $o_tep->parse('20. Jahrhundert');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			$this->assertEquals($va_parse['start'], "1900.010100000000");
-			$this->assertEquals($va_parse['end'], "1999.123123595900");
-			$this->assertEquals($va_parse[0], "1900.010100000000");
-			$this->assertEquals($va_parse[1], "1999.123123595900");
-		}
-		
-		public function testHistoricYearRanges() {
-			$o_tep = new TimeExpressionParser();
-			$vb_res = $o_tep->parse('1930 - 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1930.010100000000");
-			$this->assertEquals($va_parse['end'], "1946.123123595900");
-			$this->assertEquals($va_parse[0], "1930.010100000000");
-			$this->assertEquals($va_parse[1], "1946.123123595900");
-			
-			
-			$vb_res = $o_tep->parse('1930-1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1930.010100000000");
-			$this->assertEquals($va_parse['end'], "1946.123123595900");
-			$this->assertEquals($va_parse[0], "1930.010100000000");
-			$this->assertEquals($va_parse[1], "1946.123123595900");
-			
-			$vb_res = $o_tep->parse('1951 to 1955');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1951.010100000000");
-			$this->assertEquals($va_parse['end'], "1955.123123595900");
-			$this->assertEquals($va_parse[0], "1951.010100000000");
-			$this->assertEquals($va_parse[1], "1955.123123595900");
-			
-			$vb_res = $o_tep->parse('Between 1951 and 1955');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1951.010100000000");
-			$this->assertEquals($va_parse['end'], "1955.123123595900");
-			$this->assertEquals($va_parse[0], "1951.010100000000");
-			$this->assertEquals($va_parse[1], "1955.123123595900");
-			
-			$vb_res = $o_tep->parse('From 1951 to 1955');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1951.010100000000");
-			$this->assertEquals($va_parse['end'], "1955.123123595900");
-			$this->assertEquals($va_parse[0], "1951.010100000000");
-			$this->assertEquals($va_parse[1], "1955.123123595900");
-		}
-		
-		public function testCircaDateRanges() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('circa 1950 to 1955');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps(); 
-			$this->assertEquals($va_parse['start'], "1950.010100000010");
-			$this->assertEquals($va_parse['end'], "1955.123123595910");
-			$this->assertEquals($va_parse[0], "1950.010100000010");
-			$this->assertEquals($va_parse[1], "1955.123123595910");
-			
-			
-			$vb_res = $o_tep->parse('circa 6/1950 to 1955');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps(); 
-			$this->assertEquals($va_parse['start'], "1950.060100000010");
-			$this->assertEquals($va_parse['end'], "1955.123123595910");
-			$this->assertEquals($va_parse[0], "1950.060100000010");
-			$this->assertEquals($va_parse[1], "1955.123123595910");
-		}
-		
-		public function testDecadeRanges() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('1950s to 1970s');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps(); 
-			$this->assertEquals($va_parse['start'], "1950.010100000000");
-			$this->assertEquals($va_parse['end'], "1979.123123595900");
-			$this->assertEquals($va_parse[0], "1950.010100000000");
-			$this->assertEquals($va_parse[1], "1979.123123595900");
-		}
-		
-		
-		public function testCircaDecadeRanges() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$vb_res = $o_tep->parse('circa 1950s to 1970s');
-			$this->assertEquals($vb_res, true);
-			
-			$va_parse = $o_tep->getHistoricTimestamps(); 
-			$this->assertEquals($va_parse['start'], "1950.010100000010");
-			$this->assertEquals($va_parse['end'], "1979.123123595910");
-			$this->assertEquals($va_parse[0], "1950.010100000010");
-			$this->assertEquals($va_parse[1], "1979.123123595910");
-		}
-		
-		public function testHistoricCircaYearDate() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('c 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-			
-			$vb_res = $o_tep->parse('c. 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-			
-			$vb_res = $o_tep->parse('circa 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-			
-			
-			$vb_res = $o_tep->parse('ca 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-			
-			
-			$vb_res = $o_tep->parse('ca. 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-			
-			
-			$vb_res = $o_tep->parse('1946?');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.010100000010");
-			$this->assertEquals($va_parse['end'], "1946.123123595910");
-			$this->assertEquals($va_parse[0], "1946.010100000010");
-			$this->assertEquals($va_parse[1], "1946.123123595910");
-		}
-		
-		public function testHistoricCircaMonthAndYearDate() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('c June 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-			
-			$vb_res = $o_tep->parse('c. 6/1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-			
-			$vb_res = $o_tep->parse('circa June 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-			
-			
-			$vb_res = $o_tep->parse('ca 6/1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-			
-			
-			$vb_res = $o_tep->parse('ca. June 1946');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-			
-			
-			$vb_res = $o_tep->parse('6/1946?');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1946.060100000010");
-			$this->assertEquals($va_parse['end'], "1946.063023595910");
-			$this->assertEquals($va_parse[0], "1946.060100000010");
-			$this->assertEquals($va_parse[1], "1946.063023595910");
-		}
-		
-		public function testDecadeDate() {
-			$o_tep = new TimeExpressionParser();
-			$vb_res = $o_tep->parse('1950s');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1950.010100000000");
-			$this->assertEquals($va_parse['end'], "1959.123123595900");
-			$this->assertEquals($va_parse[0], "1950.010100000000");
-			$this->assertEquals($va_parse[1], "1959.123123595900");
-			
-			$vb_res = $o_tep->parse('1950\'s');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1950.010100000000");
-			$this->assertEquals($va_parse['end'], "1959.123123595900");
-			$this->assertEquals($va_parse[0], "1950.010100000000");
-			$this->assertEquals($va_parse[1], "1959.123123595900");
-			
-			$vb_res = $o_tep->parse('195-');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1950.010100000000");
-			$this->assertEquals($va_parse['end'], "1959.123123595900");
-			$this->assertEquals($va_parse[0], "1950.010100000000");
-			$this->assertEquals($va_parse[1], "1959.123123595900");
-		}
-		
-		public function testCenturyDates() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('20th century');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1900.010100000000");
-			$this->assertEquals($va_parse['end'], "1999.123123595900");
-			$this->assertEquals($va_parse[0], "1900.010100000000");
-			$this->assertEquals($va_parse[1], "1999.123123595900");
-			
-			$vb_res = $o_tep->parse('19--');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "1900.010100000000");
-			$this->assertEquals($va_parse['end'], "1999.123123595900");
-			$this->assertEquals($va_parse[0], "1900.010100000000");
-			$this->assertEquals($va_parse[1], "1999.123123595900");
-		}
-		
-		
-		public function testADBCDates() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('2000bc');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], -"2000.010100000000");
-			$this->assertEquals($va_parse['end'], -"2000.123123595900");
-			$this->assertEquals($va_parse[0], -"2000.010100000000");
-			$this->assertEquals($va_parse[1], -"2000.123123595900");
-			
-			
-			$vb_res = $o_tep->parse('2000ad');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], "2000.010100000000");
-			$this->assertEquals($va_parse['end'], "2000.123123595900");
-			$this->assertEquals($va_parse[0], "2000.010100000000");
-			$this->assertEquals($va_parse[1], "2000.123123595900");
-		}
-		
-		public function testTimes() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parseTime('10:55pm');
-			$va_parse = $o_tep->getTimes();
-			
-			$this->assertEquals($va_parse['start'], 82500);
-			$this->assertEquals($va_parse['end'], 82500);
-			$this->assertEquals($va_parse[0], 82500);
-			$this->assertEquals($va_parse[1], 82500);
-			
-			
-			$vb_res = $o_tep->parseTime('22:55');
-			$va_parse = $o_tep->getTimes();
-			
-			$this->assertEquals($va_parse['start'], 82500);
-			$this->assertEquals($va_parse['end'], 82500);
-			$this->assertEquals($va_parse[0], 82500);
-			$this->assertEquals($va_parse[1], 82500);
-			
-			
-			$vb_res = $o_tep->parseTime('22:55:15');
-			$va_parse = $o_tep->getTimes();
-			
-			$this->assertEquals($va_parse['start'], 82515);
-			$this->assertEquals($va_parse['end'], 82515);
-			$this->assertEquals($va_parse[0], 82515);
-			$this->assertEquals($va_parse[1], 82515);
-		}
-		
-		public function testDatesWithTimes() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('June 6 2009 at 10:55pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2009.060622550000");
-			$this->assertEquals($va_parse['end'], "2009.060622550000");
-			$this->assertEquals($va_parse[0], "2009.060622550000");
-			$this->assertEquals($va_parse[1], "2009.060622550000");
-			
-			$vb_res = $o_tep->parse('June 6 2009 @ 22:55');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2009.060622550000");
-			$this->assertEquals($va_parse['end'], "2009.060622550000");
-			$this->assertEquals($va_parse[0], "2009.060622550000");
-			$this->assertEquals($va_parse[1], "2009.060622550000");
-			
-			$vb_res = $o_tep->parse('June 6 2009 @ 10:55:10pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2009.060622551000");
-			$this->assertEquals($va_parse['end'], "2009.060622551000");
-			$this->assertEquals($va_parse[0], "2009.060622551000");
-			$this->assertEquals($va_parse[1], "2009.060622551000");
-			
-			
-			$vb_res = $o_tep->parse('6 june 2009 @ 10:55:10pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2009.060622551000");
-			$this->assertEquals($va_parse['end'], "2009.060622551000");
-			$this->assertEquals($va_parse[0], "2009.060622551000");
-			$this->assertEquals($va_parse[1], "2009.060622551000");
-			
-			$vb_res = $o_tep->parse('6/6/2009 @ 10:55:10pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2009.060622551000");
-			$this->assertEquals($va_parse['end'], "2009.060622551000");
-			$this->assertEquals($va_parse[0], "2009.060622551000");
-			$this->assertEquals($va_parse[1], "2009.060622551000");
-		}
-		
-		public function testDateRangesWithTimes() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('6/5/2007 @ 9am .. 6/5/2007 @ 5pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], "2007.060509000000");
-			$this->assertEquals($va_parse['end'],   "2007.060517000000");
-			$this->assertEquals($va_parse[0], "2007.060509000000");
-			$this->assertEquals($va_parse[1], "2007.060517000000");
-		}
-		
-		public function testDatesWithImplicitYear() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$va_date = getDate();
-			$vb_res = $o_tep->parse('6/5 at 9am - 5pm');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-		
-			$this->assertEquals($va_parse['start'], $va_date['year'].'.060509000000');
-			$this->assertEquals($va_parse['end'], $va_date['year'].'.060517000000');
-			$this->assertEquals($va_parse[0], $va_date['year'].'.060509000000');
-			$this->assertEquals($va_parse[1], $va_date['year'].'.060517000000');
-		}
-		
-		public function testDateTextOutput() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('6/6/2009 @ 10:55:10pm');
-			$this->assertEquals($vb_res, true);
-			
-			$this->assertEquals($o_tep->getText(), 'June 6 2009 at 22:55:10');
-			
-			$o_tep->setLanguage('de_DE');
-			
-			$this->assertEquals($o_tep->getText(), '6. Juni 2009 um 22:55:10');
-		}
-		
-		public function testMYADate() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			
-			$vb_res = $o_tep->parse('40 MYA');
-			$this->assertEquals($vb_res, true);
-			
-			$this->assertEquals($o_tep->getText(), '40000000 BCE');
-		}
-		
-		public function testIncompleteRanges() {
-			$o_tep = new TimeExpressionParser();
-			$o_tep->setLanguage('en_US');
-			$va_date = getDate();
-			
-			$vb_res = $o_tep->parse('August 20 - 27 2011');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], '2011.082000000000');
-			$this->assertEquals($va_parse['end'], '2011.082723595900');
-			
-			
-			$vb_res = $o_tep->parse('August 20 - 27');
-			$this->assertEquals($vb_res, true);
-			$va_parse = $o_tep->getHistoricTimestamps();
-			
-			$this->assertEquals($va_parse['start'], $va_date['year'].'.082000000000');
-			$this->assertEquals($va_parse['end'], $va_date['year'].'.082723595900');
-		}
+	public function setUp() {
+		// most of the comparisons below rely on Eastern time zone
+		date_default_timezone_set('America/New_York');
 	}
+
+	public function testQuarterCentryDates() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('20 Q2');	// 2nd quarter of 20th century
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1925.0101000000");
+		$this->assertEquals($va_parse['end'], "1950.1231235959");
+		$this->assertEquals($va_parse[0], "1925.0101000000");
+		$this->assertEquals($va_parse[1], "1950.1231235959");
+
+		$vb_res = $o_tep->parse('1 Q4');		// 4th quarter of 1st century
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "75.0101000000");
+		$this->assertEquals($va_parse['end'], "100.1231235959");
+		$this->assertEquals($va_parse[0], "75.0101000000");
+		$this->assertEquals($va_parse[1], "100.1231235959");
+
+	}
+
+	public function testYearlessDates() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('10/24/??');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "0.1024000000");
+		$this->assertEquals($va_parse['end'], "0.1024235959");
+		$this->assertEquals($va_parse[0], "0.1024000000");
+		$this->assertEquals($va_parse[1], "0.1024235959");
+		$this->assertEquals($o_tep->getText(), "10/24/????");
+	}
+
+	public function testRangeSpanningEras() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('88 BCE to 55 CE');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], -88.0101000000);
+		$this->assertEquals($va_parse['end'], 55.1231235959);
+		$this->assertEquals($va_parse[0], -88.0101000000);
+		$this->assertEquals($va_parse[1], 55.1231235959);
+
+
+		$vb_res = $o_tep->parse('50 BCE to 10 CE');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], -50.0101000000);
+		$this->assertEquals($va_parse['end'], 10.1231235959);
+		$this->assertEquals($va_parse[0], -50.0101000000);
+		$this->assertEquals($va_parse[1], 10.1231235959);
+	}
+
+	public function testRangeInFirstCentury() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('50 CE to 80 CE');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], 50.0101000000);
+		$this->assertEquals($va_parse['end'], 80.1231235959);
+		$this->assertEquals($va_parse[0], 50.0101000000);
+		$this->assertEquals($va_parse[1], 80.1231235959);
+	}
+
+	public function testSeasonDates() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('Winter 2010');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "2010.1221000000");
+		$this->assertEquals($va_parse['end'], "2011.0320235959");
+		$this->assertEquals($va_parse[0], "2010.1221000000");
+		$this->assertEquals($va_parse[1], "2011.0320235959");
+	}
+
+	public function testParseSimpleDelimitedDateForEnglishLocale() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('10/23/2004');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+		$this->assertEquals($va_parse['start'], 1098504000);
+		$this->assertEquals($va_parse['end'], 1098590399);
+		$this->assertEquals($va_parse[0], 1098504000);
+		$this->assertEquals($va_parse[1], 1098590399);
+	}
+
+	public function testParseSimpleDelimitedDateForEuropeanLocale() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('fr_FR');
+		$vb_res = $o_tep->parse('23/10/2004');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 1098504000);
+		$this->assertEquals($va_parse['end'], 1098590399);
+		$this->assertEquals($va_parse[0], 1098504000);
+		$this->assertEquals($va_parse[1], 1098590399);
+	}
+
+	public function testParseTextDate() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('May 10, 1990');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 642312000);
+		$this->assertEquals($va_parse['end'], 642398399);
+		$this->assertEquals($va_parse[0], 642312000);
+		$this->assertEquals($va_parse[1], 642398399);
+
+		$vb_res = $o_tep->parse('10 May 1990');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 642312000);
+		$this->assertEquals($va_parse['end'], 642398399);
+		$this->assertEquals($va_parse[0], 642312000);
+		$this->assertEquals($va_parse[1], 642398399);
+	}
+
+	public function testParseISO8601Date() {
+		$o_tep = new TimeExpressionParser();
+		$vb_res = $o_tep->parse('2009-09-18 21:03');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 1253322180);
+		$this->assertEquals($va_parse['end'], 1253322180);
+		$this->assertEquals($va_parse[0], 1253322180);
+		$this->assertEquals($va_parse[1], 1253322180);
+	}
+
+	public function testParseNowDate() {
+		$o_tep = new TimeExpressionParser();
+		$vb_res = $o_tep->parse('now');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], $t= time());
+		$this->assertEquals($va_parse['end'], $t);
+		$this->assertEquals($va_parse[0], $t);
+		$this->assertEquals($va_parse[1], $t);
+	}
+
+	public function testHistoricDayDateForEnglishLocale() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('March 8, 1945');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1945.030800000000");
+		$this->assertEquals($va_parse['end'], "1945.030823595900");
+		$this->assertEquals($va_parse[0], "1945.030800000000");
+		$this->assertEquals($va_parse[1], "1945.030823595900");
+	}
+
+	public function testHistoricDayDateForGermanLocale() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('de_DE');
+		$vb_res = $o_tep->parse('8. Mai 1945');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1945.050800000000");
+		$this->assertEquals($va_parse['end'], "1945.050823595900");
+		$this->assertEquals($va_parse[0], "1945.050800000000");
+		$this->assertEquals($va_parse[1], "1945.050823595900");
+	}
+
+	public function testCenturyDatesForGermanLocale() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('de_DE');
+		$vb_res = $o_tep->parse('20. Jahrhundert');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1900.010100000000");
+		$this->assertEquals($va_parse['end'], "1999.123123595900");
+		$this->assertEquals($va_parse[0], "1900.010100000000");
+		$this->assertEquals($va_parse[1], "1999.123123595900");
+	}
+
+	public function testHistoricYearRanges() {
+		$o_tep = new TimeExpressionParser();
+		$vb_res = $o_tep->parse('1930 - 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1930.010100000000");
+		$this->assertEquals($va_parse['end'], "1946.123123595900");
+		$this->assertEquals($va_parse[0], "1930.010100000000");
+		$this->assertEquals($va_parse[1], "1946.123123595900");
+
+
+		$vb_res = $o_tep->parse('1930-1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1930.010100000000");
+		$this->assertEquals($va_parse['end'], "1946.123123595900");
+		$this->assertEquals($va_parse[0], "1930.010100000000");
+		$this->assertEquals($va_parse[1], "1946.123123595900");
+
+		$vb_res = $o_tep->parse('1951 to 1955');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1951.010100000000");
+		$this->assertEquals($va_parse['end'], "1955.123123595900");
+		$this->assertEquals($va_parse[0], "1951.010100000000");
+		$this->assertEquals($va_parse[1], "1955.123123595900");
+
+		$vb_res = $o_tep->parse('Between 1951 and 1955');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1951.010100000000");
+		$this->assertEquals($va_parse['end'], "1955.123123595900");
+		$this->assertEquals($va_parse[0], "1951.010100000000");
+		$this->assertEquals($va_parse[1], "1955.123123595900");
+
+		$vb_res = $o_tep->parse('From 1951 to 1955');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1951.010100000000");
+		$this->assertEquals($va_parse['end'], "1955.123123595900");
+		$this->assertEquals($va_parse[0], "1951.010100000000");
+		$this->assertEquals($va_parse[1], "1955.123123595900");
+	}
+
+	public function testCircaDateRanges() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('circa 1950 to 1955');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1950.010100000010");
+		$this->assertEquals($va_parse['end'], "1955.123123595910");
+		$this->assertEquals($va_parse[0], "1950.010100000010");
+		$this->assertEquals($va_parse[1], "1955.123123595910");
+
+
+		$vb_res = $o_tep->parse('circa 6/1950 to 1955');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1950.060100000010");
+		$this->assertEquals($va_parse['end'], "1955.123123595910");
+		$this->assertEquals($va_parse[0], "1950.060100000010");
+		$this->assertEquals($va_parse[1], "1955.123123595910");
+	}
+
+	public function testDecadeRanges() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('1950s to 1970s');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1950.010100000000");
+		$this->assertEquals($va_parse['end'], "1979.123123595900");
+		$this->assertEquals($va_parse[0], "1950.010100000000");
+		$this->assertEquals($va_parse[1], "1979.123123595900");
+	}
+
+
+	public function testCircaDecadeRanges() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$vb_res = $o_tep->parse('circa 1950s to 1970s');
+		$this->assertEquals($vb_res, true);
+
+		$va_parse = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_parse['start'], "1950.010100000010");
+		$this->assertEquals($va_parse['end'], "1979.123123595910");
+		$this->assertEquals($va_parse[0], "1950.010100000010");
+		$this->assertEquals($va_parse[1], "1979.123123595910");
+	}
+
+	public function testHistoricCircaYearDate() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('c 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+
+		$vb_res = $o_tep->parse('c. 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+
+		$vb_res = $o_tep->parse('circa 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+
+
+		$vb_res = $o_tep->parse('ca 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+
+
+		$vb_res = $o_tep->parse('ca. 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+
+
+		$vb_res = $o_tep->parse('1946?');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.010100000010");
+		$this->assertEquals($va_parse['end'], "1946.123123595910");
+		$this->assertEquals($va_parse[0], "1946.010100000010");
+		$this->assertEquals($va_parse[1], "1946.123123595910");
+	}
+
+	public function testHistoricCircaMonthAndYearDate() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('c June 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+
+		$vb_res = $o_tep->parse('c. 6/1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+
+		$vb_res = $o_tep->parse('circa June 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+
+
+		$vb_res = $o_tep->parse('ca 6/1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+
+
+		$vb_res = $o_tep->parse('ca. June 1946');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+
+
+		$vb_res = $o_tep->parse('6/1946?');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1946.060100000010");
+		$this->assertEquals($va_parse['end'], "1946.063023595910");
+		$this->assertEquals($va_parse[0], "1946.060100000010");
+		$this->assertEquals($va_parse[1], "1946.063023595910");
+	}
+
+	public function testDecadeDate() {
+		$o_tep = new TimeExpressionParser();
+		$vb_res = $o_tep->parse('1950s');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1950.010100000000");
+		$this->assertEquals($va_parse['end'], "1959.123123595900");
+		$this->assertEquals($va_parse[0], "1950.010100000000");
+		$this->assertEquals($va_parse[1], "1959.123123595900");
+
+		$vb_res = $o_tep->parse('1950\'s');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1950.010100000000");
+		$this->assertEquals($va_parse['end'], "1959.123123595900");
+		$this->assertEquals($va_parse[0], "1950.010100000000");
+		$this->assertEquals($va_parse[1], "1959.123123595900");
+
+		$vb_res = $o_tep->parse('195-');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1950.010100000000");
+		$this->assertEquals($va_parse['end'], "1959.123123595900");
+		$this->assertEquals($va_parse[0], "1950.010100000000");
+		$this->assertEquals($va_parse[1], "1959.123123595900");
+	}
+
+	public function testCenturyDates() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('20th century');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1900.010100000000");
+		$this->assertEquals($va_parse['end'], "1999.123123595900");
+		$this->assertEquals($va_parse[0], "1900.010100000000");
+		$this->assertEquals($va_parse[1], "1999.123123595900");
+
+		$vb_res = $o_tep->parse('19--');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "1900.010100000000");
+		$this->assertEquals($va_parse['end'], "1999.123123595900");
+		$this->assertEquals($va_parse[0], "1900.010100000000");
+		$this->assertEquals($va_parse[1], "1999.123123595900");
+	}
+
+
+	public function testADBCDates() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('2000bc');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], -"2000.010100000000");
+		$this->assertEquals($va_parse['end'], -"2000.123123595900");
+		$this->assertEquals($va_parse[0], -"2000.010100000000");
+		$this->assertEquals($va_parse[1], -"2000.123123595900");
+
+
+		$vb_res = $o_tep->parse('2000ad');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2000.010100000000");
+		$this->assertEquals($va_parse['end'], "2000.123123595900");
+		$this->assertEquals($va_parse[0], "2000.010100000000");
+		$this->assertEquals($va_parse[1], "2000.123123595900");
+	}
+
+	public function testTimes() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parseTime('10:55pm');
+		$va_parse = $o_tep->getTimes();
+
+		$this->assertEquals($va_parse['start'], 82500);
+		$this->assertEquals($va_parse['end'], 82500);
+		$this->assertEquals($va_parse[0], 82500);
+		$this->assertEquals($va_parse[1], 82500);
+
+
+		$vb_res = $o_tep->parseTime('22:55');
+		$va_parse = $o_tep->getTimes();
+
+		$this->assertEquals($va_parse['start'], 82500);
+		$this->assertEquals($va_parse['end'], 82500);
+		$this->assertEquals($va_parse[0], 82500);
+		$this->assertEquals($va_parse[1], 82500);
+
+
+		$vb_res = $o_tep->parseTime('22:55:15');
+		$va_parse = $o_tep->getTimes();
+
+		$this->assertEquals($va_parse['start'], 82515);
+		$this->assertEquals($va_parse['end'], 82515);
+		$this->assertEquals($va_parse[0], 82515);
+		$this->assertEquals($va_parse[1], 82515);
+	}
+
+	public function testDatesWithTimes() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('June 6 2009 at 10:55pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2009.060622550000");
+		$this->assertEquals($va_parse['end'], "2009.060622550000");
+		$this->assertEquals($va_parse[0], "2009.060622550000");
+		$this->assertEquals($va_parse[1], "2009.060622550000");
+
+		$vb_res = $o_tep->parse('June 6 2009 @ 22:55');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2009.060622550000");
+		$this->assertEquals($va_parse['end'], "2009.060622550000");
+		$this->assertEquals($va_parse[0], "2009.060622550000");
+		$this->assertEquals($va_parse[1], "2009.060622550000");
+
+		$vb_res = $o_tep->parse('June 6 2009 @ 10:55:10pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2009.060622551000");
+		$this->assertEquals($va_parse['end'], "2009.060622551000");
+		$this->assertEquals($va_parse[0], "2009.060622551000");
+		$this->assertEquals($va_parse[1], "2009.060622551000");
+
+
+		$vb_res = $o_tep->parse('6 june 2009 @ 10:55:10pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2009.060622551000");
+		$this->assertEquals($va_parse['end'], "2009.060622551000");
+		$this->assertEquals($va_parse[0], "2009.060622551000");
+		$this->assertEquals($va_parse[1], "2009.060622551000");
+
+		$vb_res = $o_tep->parse('6/6/2009 @ 10:55:10pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2009.060622551000");
+		$this->assertEquals($va_parse['end'], "2009.060622551000");
+		$this->assertEquals($va_parse[0], "2009.060622551000");
+		$this->assertEquals($va_parse[1], "2009.060622551000");
+	}
+
+	public function testDateRangesWithTimes() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('6/5/2007 @ 9am .. 6/5/2007 @ 5pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], "2007.060509000000");
+		$this->assertEquals($va_parse['end'],   "2007.060517000000");
+		$this->assertEquals($va_parse[0], "2007.060509000000");
+		$this->assertEquals($va_parse[1], "2007.060517000000");
+	}
+
+	public function testDatesWithImplicitYear() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$va_date = getDate();
+		$vb_res = $o_tep->parse('6/5 at 9am - 5pm');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], $va_date['year'].'.060509000000');
+		$this->assertEquals($va_parse['end'], $va_date['year'].'.060517000000');
+		$this->assertEquals($va_parse[0], $va_date['year'].'.060509000000');
+		$this->assertEquals($va_parse[1], $va_date['year'].'.060517000000');
+	}
+
+	public function testDateTextOutput() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('6/6/2009 @ 10:55:10pm');
+		$this->assertEquals($vb_res, true);
+
+		$this->assertEquals($o_tep->getText(), 'June 6 2009 at 22:55:10');
+
+		$o_tep->setLanguage('de_DE');
+
+		$this->assertEquals($o_tep->getText(), '6. Juni 2009 um 22:55:10');
+	}
+
+	public function testMYADate() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('40 MYA');
+		$this->assertEquals($vb_res, true);
+
+		$this->assertEquals($o_tep->getText(), '40000000 BCE');
+	}
+
+	public function testIncompleteRanges() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		$va_date = getDate();
+
+		$vb_res = $o_tep->parse('August 20 - 27 2011');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], '2011.082000000000');
+		$this->assertEquals($va_parse['end'], '2011.082723595900');
+
+
+		$vb_res = $o_tep->parse('August 20 - 27');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], $va_date['year'].'.082000000000');
+		$this->assertEquals($va_parse['end'], $va_date['year'].'.082723595900');
+	}
+}
 ?>

--- a/tests/lib/core/SearchResult/SearchResultTest.php
+++ b/tests/lib/core/SearchResult/SearchResultTest.php
@@ -29,896 +29,895 @@
  * 
  * ----------------------------------------------------------------------
  */
-	require_once('PHPUnit/Autoload.php');
-	require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
-	require_once(__CA_LIB_DIR__.'/ca/Search/ObjectSearch.php');
-	require_once(__CA_LIB_DIR__.'/ca/Search/EntitySearch.php');
-	
-	//
-	// NOTE: REQUIRES CONEY ISLAND HISTORY PROJECT TEST DATA
-	//
-	// You can get this data from the GitHub repository at http://github.com/CollectiveAccess/providence/support/test/test_data_mysql.dump
-	//
-	
-	class SearchResultTest extends PHPUnit_Framework_TestCase {
-		# -------------------------------------------------------------------------------
-		/**
-		 * @var ca_objects.idno value of record to use for testing
-		 */
-		private $ops_object_idno = 'CIHP.TEST';
-		# -------------------------------------------------------------------------------
-		/**
-		 * Set up request global required by get() returnAsLink option
-		 */
-		public function __construct() {
-			define("__CA_APP_TYPE__", "PAWTUCKET");
-			global $g_request;
-			$g_request = new RequestHTTP(new ResponseHTTP(), array('no_headers' => true, 'no_authentication' => true));
-			
+require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
+require_once(__CA_LIB_DIR__.'/ca/Search/ObjectSearch.php');
+require_once(__CA_LIB_DIR__.'/ca/Search/EntitySearch.php');
+
+//
+// NOTE: REQUIRES CONEY ISLAND HISTORY PROJECT TEST DATA
+//
+// You can get this data from the GitHub repository at http://github.com/CollectiveAccess/providence/support/test/test_data_mysql.dump
+//
+
+class SearchResultTest extends PHPUnit_Framework_TestCase {
+	# -------------------------------------------------------------------------------
+	/**
+	 * @var ca_objects.idno value of record to use for testing
+	 */
+	private $ops_object_idno = 'CIHP.TEST';
+	# -------------------------------------------------------------------------------
+	/**
+	 * Set up request global required by get() returnAsLink option
+	 */
+	public function __construct() {
+		define("__CA_APP_TYPE__", "PAWTUCKET");
+		global $g_request;
+		$g_request = new RequestHTTP(new ResponseHTTP(), array('no_headers' => true, 'no_authentication' => true));
+
+	}
+	# -------------------------------------------------------------------------------
+	public function testIntrinsicGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		//
+		// Get as scalar without locales
+		//
+		$vs_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
+
+		$vs_val = $qr_res->get('idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
+
+		//
+		// Get as array without locales
+		//
+		$va_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
+
+		//
+		// Get as array with locales
+		//
+		$va_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($this->ops_object_idno, $va_val, "Value in third level should be ".$this->ops_object_idno);
+
+		//
+		// Get as scalar with locales (should force returnAsArray to true)
+		//
+		$vs_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $vs_val, "Return value should be array");
+		$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
+	}
+	# -------------------------------------------------------------------------------
+	public function testSimpleRelatedGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		//
+		// Get related entities as string
+		//
+		$vs_val = $qr_res->get('ca_entities', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertEquals('Seth Kaufman; Charles Denson', $vs_val, "Return value is incorrect");
+
+		//
+		// Get related entities as link
+		//
+		$vs_val = $qr_res->get('ca_entities', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $vs_val);
+		$this->assertContains('<a href', $vs_val, "Return value is incorrect");
+		$this->assertContains('Seth Kaufman', $vs_val, "Return value is incorrect");
+
+		foreach(array('with returnAsLink' => true, 'without returnAsLink' => false) as $vs_message => $vb_return_as_link) {
+			//
+			// Get related items for table as array
+			//
+			$va_val = $qr_res->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => false, 'returnAsLink' => $vb_return_as_link));
+			$this->assertInternalType("array", $va_val, "Return value should be array {$vs_message}");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("string", $va_val['entity_id'], "Value for key 'entity_id' should be string {$vs_message}");
+			$this->assertGreaterThan(0, (int)$va_val['entity_id'], "Value for key 'entity_id' should be greater than zero when cast to integer {$vs_message}");
+
+			//
+			// Get related items for table as all-locales array
+			//
+			$va_val = $qr_res->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => true, 'returnAsLink' => $vb_return_as_link));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array {$vs_message}");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array {$vs_message}");
+
+			$this->assertContains("Seth Kaufman", $va_val, "Value in third level should be Seth Kaufman {$vs_message}");
+
+			//
+			// Get related entities with template
+			//
+			$vs_val = $qr_res->get('ca_entities', array('template' => '^preferred_labels.surname, ^preferred_labels.forename (^idno)', 'returnAsLink' => $vb_return_as_link, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+			$this->assertInternalType("string", $vs_val);
+
+			if ($vb_return_as_link) {
+				$this->assertContains('<a href', $vs_val, "Return value is incorrect {$vs_message}");
+				$this->assertContains('Kaufman, Seth (4)', $vs_val, "Return value is incorrect {$vs_message}");
+			} else {
+				$this->assertEquals('Kaufman, Seth (4); Denson, Charles (5)', $vs_val, "Return value is incorrect {$vs_message}");
+			}
 		}
-		# -------------------------------------------------------------------------------
-		public function testIntrinsicGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
+	}
+	# -------------------------------------------------------------------------------
+	public function testAttributeGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		$vs_description = 'This is a test description';
+
+		//
+		// Test <tablename>.<element_code> attributes
+		//
+if (false) {
 			//
 			// Get as scalar without locales
 			//
-			$vs_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$vs_val = $qr_res->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => false));
 			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
-			
-			$vs_val = $qr_res->get('idno', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals($vs_val, $this->ops_object_idno, "Return value should be string");
-			
+			$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");
+
 			//
 			// Get as array without locales
 			//
-			$va_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
 			$this->assertInternalType("array", $va_val, "Return value should be array");
 			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
-			
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$this->assertArrayHasKey("description", $va_val, "Second level of returned value should be array with key 'description'");
+
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
 			//
 			// Get as array with locales
 			//
-			$va_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => true));
 			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($this->ops_object_idno, $va_val, "Value in third level should be ".$this->ops_object_idno);
-			
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_description, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("description", $va_val, "Fourth level of returned value should be array with key 'description'");
+
 			//
-			// Get as scalar with locales (should force returnAsArray to true)
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
 			//
-			$vs_val = $qr_res->get('ca_objects.idno', array('returnAsArray' => false, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $vs_val, "Return value should be array");
-			$this->assertContains($this->ops_object_idno, $va_val, "Returned value should be ".$this->ops_object_idno);
-		}
-		# -------------------------------------------------------------------------------
-		public function testSimpleRelatedGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
+			$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
 			//
-			// Get related entities as string
+			// Get scalar with template
 			//
-			$vs_val = $qr_res->get('ca_entities', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
+			$vs_val = $qr_res->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $qr_res->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
+
+
+			//
+			// Get scalar with template as array
+			//
+			$va_val = $qr_res->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be string");
+			$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
+
+			$va_val = $qr_res->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be string");
+			$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
+
+		//
+		// Test <tablename>.<element_code>.<sub_element_code> attributes
+		//
+			//
+			// Get as scalar without locales
+			//
+}
+			$vs_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => false));
 			$this->assertInternalType("string", $vs_val);
-			$this->assertEquals('Seth Kaufman; Charles Denson', $vs_val, "Return value is incorrect");
-			
+			$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");
+
 			//
-			// Get related entities as link
+			// Get as array without locales
 			//
-			$vs_val = $qr_res->get('ca_entities', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
+			$va_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertContains($vs_description, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
+
+			//
+			// Attribute with template
+			//
+			$va_val = $qr_res->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => false, 'returnAllLocales' => false));
+
+			$this->assertInternalType("string", $va_val, "Return value should be string");
+			$this->assertEquals("W=12.0 in", $va_val, "Returned value is incorrect");
+
+			$va_val = $qr_res->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertContains("W=12.0 in", $va_val, "Returned value is incorrect");
+
+			//
+			// Get URL attribute as link
+			//
+			$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertEquals("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$va_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$vs_val = array_pop($va_val);
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("<a href", $vs_val, "Returned value is not a link");
+			$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+
+			$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsLinkAttributes' => array('class' => 'extLink', 'alt' => 'External link'), 'returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val, "Return value should be string");
+			$this->assertContains("href=", $vs_val, "Returned value is not a link");
+			$this->assertContains("<a", $vs_val, "Returned value is not a link");
+			$this->assertContains("class='extLink'", $vs_val, "Returned value is missing class");
+			$this->assertContains("alt='External link'", $vs_val, "Returned value is alt attribute");
+			$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
+			$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
+	}
+	# -------------------------------------------------------------------------------
+	public function testPreferredLabelGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		$vs_title = "Canonical test record";
+
+		//
+		// Get preferred label values (all fields - not specific values)
+		// (eg. <table_name>.preferred_labels
+		//
+			//
+			// Get as scalar without locales
+			//
+			$vs_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
 			$this->assertInternalType("string", $vs_val);
-			$this->assertContains('<a href', $vs_val, "Return value is incorrect");
-			$this->assertContains('Seth Kaufman', $vs_val, "Return value is incorrect");
-			
-			foreach(array('with returnAsLink' => true, 'without returnAsLink' => false) as $vs_message => $vb_return_as_link) {
-				//
-				// Get related items for table as array
-				//
-				$va_val = $qr_res->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => false, 'returnAsLink' => $vb_return_as_link));
-				$this->assertInternalType("array", $va_val, "Return value should be array {$vs_message}");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("string", $va_val['entity_id'], "Value for key 'entity_id' should be string {$vs_message}");
-				$this->assertGreaterThan(0, (int)$va_val['entity_id'], "Value for key 'entity_id' should be greater than zero when cast to integer {$vs_message}");
-			
-				//
-				// Get related items for table as all-locales array
-				//
-				$va_val = $qr_res->get('ca_entities', array('returnAsArray' => true, 'returnAllLocales' => true, 'returnAsLink' => $vb_return_as_link));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array {$vs_message}");
-			
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array {$vs_message}");
-			
-				$this->assertContains("Seth Kaufman", $va_val, "Value in third level should be Seth Kaufman {$vs_message}");
-								
-				//
-				// Get related entities with template
-				//
-				$vs_val = $qr_res->get('ca_entities', array('template' => '^preferred_labels.surname, ^preferred_labels.forename (^idno)', 'returnAsLink' => $vb_return_as_link, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));	
-				$this->assertInternalType("string", $vs_val);
-				
-				if ($vb_return_as_link) {
-					$this->assertContains('<a href', $vs_val, "Return value is incorrect {$vs_message}");
-					$this->assertContains('Kaufman, Seth (4)', $vs_val, "Return value is incorrect {$vs_message}");				
-				} else {
-					$this->assertEquals('Kaufman, Seth (4); Denson, Charles (5)', $vs_val, "Return value is incorrect {$vs_message}");
-				}
-			}
-		}
-		# -------------------------------------------------------------------------------
-		public function testAttributeGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
-			$vs_description = 'This is a test description';
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
 
 			//
-			// Test <tablename>.<element_code> attributes 
+			// Get as array without locales
 			//
-	if (false) {		
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $qr_res->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => false));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$this->assertArrayHasKey("description", $va_val, "Second level of returned value should be array with key 'description'");
-				
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_description, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("description", $va_val, "Fourth level of returned value should be array with key 'description'");
+			$va_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
 
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$va_val = $qr_res->get('ca_objects.description', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get scalar with template
-				//
-				$vs_val = $qr_res->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $qr_res->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("Description is: This is a test description", $vs_val, "Returned value is incorrect");
-		
-				
-				//
-				// Get scalar with template as array
-				//
-				$va_val = $qr_res->get('ca_objects.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
-			
-				$this->assertInternalType("array", $va_val, "Return value should be string");
-				$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
-				
-				$va_val = $qr_res->get('ca_objects.description.description', array('template' => 'Description is: ^ca_objects.description', 'returnAsArray' => true, 'returnAllLocales' => false));
-			
-				$this->assertInternalType("array", $va_val, "Return value should be string");
-				$this->assertContains("Description is: {$vs_description}", $va_val, "Returned value is incorrect");
-				
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$this->assertArrayHasKey("name", $va_val, "Second level of returned value should be array with key 'name'");
+
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
 			//
-			// Test <tablename>.<element_code>.<sub_element_code> attributes 
+			// Get as array with locales
 			//
-				//
-				// Get as scalar without locales
-				//
+			$va_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+		//
+		// Get preferred label values (specific values)
+		// (eg. <table_name>.preferred_labels.<field_name>
+		//
+		//
+			// Get as scalar without locales
+			//
+			$vs_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
+			//
+			// Get as array without locales
+			//
+			$va_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+			$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
 	}
-				$vs_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_description, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => false));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_description, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $qr_res->get('ca_objects.description.description', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_description, $va_val, "Returned value is incorrect");
-				
-				//
-				// Attribute with template
-				//
-				$va_val = $qr_res->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => false, 'returnAllLocales' => false));
-				
-				$this->assertInternalType("string", $va_val, "Return value should be string");
-				$this->assertEquals("W=12.0 in", $va_val, "Returned value is incorrect");
-				
-				$va_val = $qr_res->get('ca_objects.dimensions_numeric', array('template' => 'W=^dimensions_width', 'returnAsArray' => true, 'returnAllLocales' => false));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertContains("W=12.0 in", $va_val, "Returned value is incorrect");
-				
-				//
-				// Get URL attribute as link
-				//
-				$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertEquals("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-			
-				$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$va_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$vs_val = array_pop($va_val);
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("<a href", $vs_val, "Returned value is not a link");
-				$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-				
-				$vs_val = $qr_res->get('ca_objects.external_link.url_entry', array('returnAsLink' => true, 'returnAsLinkText' => 'LINK_GOES_HERE', 'returnAsLinkAttributes' => array('class' => 'extLink', 'alt' => 'External link'), 'returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val, "Return value should be string");
-				$this->assertContains("href=", $vs_val, "Returned value is not a link");
-				$this->assertContains("<a", $vs_val, "Returned value is not a link");
-				$this->assertContains("class='extLink'", $vs_val, "Returned value is missing class");
-				$this->assertContains("alt='External link'", $vs_val, "Returned value is alt attribute");
-				$this->assertContains(">LINK_GOES_HERE<", $vs_val, "Returned value is incorrect");
-				$this->assertContains("http://www.coneyislandhistory.org/about", $vs_val, "Returned value is incorrect");
-		}
-		# -------------------------------------------------------------------------------
-		public function testPreferredLabelGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
-			$vs_title = "Canonical test record";
-			
-			//
-			// Get preferred label values (all fields - not specific values)
-			// (eg. <table_name>.preferred_labels
-			//
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+	# -------------------------------------------------------------------------------
+	public function testNonPreferredLabelGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
 
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$this->assertArrayHasKey("name", $va_val, "Second level of returned value should be array with key 'name'");
-				
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $qr_res->get('ca_objects.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-			//
-			// Get preferred label values (specific values)
-			// (eg. <table_name>.preferred_labels.<field_name>
-			//
-			//
-				// Get as scalar without locales
-				//
-				$vs_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$vs_title = "This is an alternate title";
 
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
+		//
+		// Get nonpreferred label values (all fields - not specific values)
+		// (eg. <table_name>.nonpreferred_labels
+		//
+			//
+			// Get as scalar without locales
+			//
+			$vs_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
 
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $qr_res->get('ca_objects.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-			
-		}
-		# -------------------------------------------------------------------------------
-		public function testNonPreferredLabelGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
-			$vs_title = "This is an alternate title";
-			
 			//
-			// Get nonpreferred label values (all fields - not specific values)
-			// (eg. <table_name>.nonpreferred_labels
+			// Get as array without locales
 			//
-				//
-				// Get as scalar without locales
-				//
-				$vs_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$va_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
 
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertArrayHasKey("name", $va_val, "Third level of returned value should be array with key 'name'");
-				
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-				
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
-				$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-			//
-			// Get preferred label values (specific values)
-			// (eg. <table_name>.nonpreferred_labels.<field_name>
-			//
-			//
-				// Get as scalar without locales
-				//
-				$vs_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-				$this->assertInternalType("string", $vs_val);
-				$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");	
-				
-				//
-				// Get as array without locales
-				//
-				$va_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-				
-				$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-				
-				//
-				// Get as array with locales
-				//
-				$va_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $va_val, "Return value should be array");
-
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-				
-				$va_val = array_shift($va_val);
-				$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-				
-				$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
-				
-				//
-				// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
-				//
-				$vs_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
-				$this->assertInternalType("array", $vs_val, "Return value should be string");
-				$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
-			
-		}
-		# -------------------------------------------------------------------------------
-		public function testRelatedItemsGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-		
-			//
-			// Get related preferred labels array (all fields)
-			//
-			$vs_value = 'Seth Kaufman; Charles Denson';
-			$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get related preferred labels array (all fields) as link
-			//
-			$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains("Seth Kaufman", $va_val, "Returned value is incorrect");
-			
-			//
-			// Get related preferred labels array (all fields) as link with template
-			//
-			$va_val = $qr_res->get('ca_entities.preferred_labels', array('template' => '^preferred_labels.surname, ^preferred_labels.forename', 'returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-	
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains("Kaufman, Seth", $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
 			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertTrue(is_string($va_val[0]['entity_id']), "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
+			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
+
+			$this->assertArrayHasKey("name", $va_val, "Third level of returned value should be array with key 'name'");
+
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+			//
+			// Get as array with locales
+			//
+			$va_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+			$this->assertInternalType("array", $va_val, "Return value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+			$va_val = array_shift($va_val);
+			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$vs_value = 'Seth Kaufman';
-			$this->assertContains($vs_value, $va_val, "Value in fourth level is incorrect");
-			
+
+			$this->assertContains($vs_title, $va_val, "Value in fourth level is incorrect");
+			$this->assertArrayHasKey("name", $va_val, "Fourth level of returned value should be array with key 'name'");
+
 			//
-			// Get specific field in preferred labels
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
 			//
-			$vs_value = 'Kaufman; Denson';
-			$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
+			$vs_val = $qr_res->get('ca_objects.nonpreferred_labels', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
+		//
+		// Get preferred label values (specific values)
+		// (eg. <table_name>.nonpreferred_labels.<field_name>
+		//
+		//
+			// Get as scalar without locales
 			//
-			// Get specific field in preferred labels as link
+			$vs_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+			$this->assertInternalType("string", $vs_val);
+			$this->assertEquals($vs_title, $vs_val, "Return value is incorrect");
+
 			//
-			$vs_value = 'Kaufman; Denson';
-			$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains('Kaufman', $va_val, "Returned value is incorrect");
-			
-			
-			$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = 'Kaufman';
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => true));
-		
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
-			
-			
+			// Get as array without locales
 			//
-			// Get entity field
-			//
-			$vs_value = '4; 5';
-			$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity field as link
-			//
-			$va_val = $qr_res->get('ca_entities.idno', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not link");
-			$this->assertContains('4', $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = '4';
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-		
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
-			
-			
-			//
-			// Get entity attribute
-			//
-			$vs_value = 'These are test notes';
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute as link
-			//
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not a link");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute as link with template
-			//
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertContains('<a href', $va_val, "Returned value is not a link");
-			$this->assertContains("Notes: {$vs_value}", $va_val, "Returned value is incorrect");
-			
-			//
-			// Get entity attribute with template
-			//
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => false, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("string", $va_val, "Return value should be string");
-			$this->assertEquals("Notes: {$vs_value}; Notes: ", $va_val, "Returned value is incorrect");
-			
-			
-			//
-			// Get entity attribute as array and links with template
-			//
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false, 'delimiter' => '; '));
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertContains("Notes: {$vs_value}", array_shift($va_val), "Returned value is incorrect");
-			
-			
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => false));
-			
-			$vs_value = 'These are test notes';
-			$va_val = array_pop($va_val);
-			
-			$this->assertInternalType("array", $va_val, "Return value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
-			$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$va_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
 
 			$this->assertInternalType("array", $va_val, "Return value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
-			$this->assertContains($vs_value, $va_val['internal_notes'], "Value in third level is incorrect");
-			
-		}
-		# -------------------------------------------------------------------------------
-		public function testParentGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno.".1");
-			$qr_res->nextHit();
-			
-			//
-			// Get intrinsic field from parent
-			//
-			$vs_value = $this->ops_object_idno;
-			$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
-			
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get preferred labels from parent
-			//
-			$vs_value = 'Canonical test record';
-			$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get attributes from parent
-			//
-			$vs_value = 'This is a test description';
-			$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => false));
 
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
 			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
-			$this->assertContains($vs_value, $va_tmp, "Value in array is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
-			$this->assertContains($vs_value, $va_val['description'], "Value in fourth level is incorrect");
-		}
-		# -------------------------------------------------------------------------------
-		public function testChildrenGet() {
-			$o_search = new ObjectSearch();
-			$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
-			$qr_res->nextHit();
-			
-			//
-			// Get intrinsic field from children
-			//
-			$vs_value = 'CIHP.TEST.1; CIHP.TEST.2';
-			$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$vs_value = 'CIHP.TEST.1';
-			$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
 
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
 			//
-			// Get preferred labels from children
+			// Get as array with locales
 			//
-			$vs_value = 'Canonical test sub-record No. 1; Canonical test sub-record No. 2';
-			$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
-			$vs_value = 'Canonical test sub-record No. 1';
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
-			
-			//
-			// Get attributes from children
-			//
-			$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => false, 'returnAllLocales' => false));
-			$this->assertInternalType("string", $va_val, "Returned value should be string");
-			
-			$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+			$va_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $va_val, "Return value should be array");
 
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should greater than 0");
-			$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
-			
-			$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => true));
-			$this->assertInternalType("array", $va_val, "Returned value should be array");
-			$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
-			
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
-			
+
 			$va_val = array_shift($va_val);
 			$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
-			
-			$va_val = array_shift($va_val);
-			$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
-			
-			$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
-		}
-		# -------------------------------------------------------------------------------
+
+			$this->assertContains($vs_title, $va_val, "Value in third level is incorrect");
+
+			//
+			// Get as scalar with locales (setting of returnAllLocales should force returnAsArray to true)
+			//
+			$vs_val = $qr_res->get('ca_objects.nonpreferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => true));
+			$this->assertInternalType("array", $vs_val, "Return value should be string");
+			$this->assertContains($vs_title, $va_val, "Returned value is incorrect");
+
 	}
+	# -------------------------------------------------------------------------------
+	public function testRelatedItemsGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		//
+		// Get related preferred labels array (all fields)
+		//
+		$vs_value = 'Seth Kaufman; Charles Denson';
+		$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get related preferred labels array (all fields) as link
+		//
+		$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains("Seth Kaufman", $va_val, "Returned value is incorrect");
+
+		//
+		// Get related preferred labels array (all fields) as link with template
+		//
+		$va_val = $qr_res->get('ca_entities.preferred_labels', array('template' => '^preferred_labels.surname, ^preferred_labels.forename', 'returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains("Kaufman, Seth", $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertTrue(is_string($va_val[0]['entity_id']), "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.preferred_labels', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$vs_value = 'Seth Kaufman';
+		$this->assertContains($vs_value, $va_val, "Value in fourth level is incorrect");
+
+		//
+		// Get specific field in preferred labels
+		//
+		$vs_value = 'Kaufman; Denson';
+		$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get specific field in preferred labels as link
+		//
+		$vs_value = 'Kaufman; Denson';
+		$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains('Kaufman', $va_val, "Returned value is incorrect");
+
+
+		$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = 'Kaufman';
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.preferred_labels.surname', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
+
+
+		//
+		// Get entity field
+		//
+		$vs_value = '4; 5';
+		$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity field as link
+		//
+		$va_val = $qr_res->get('ca_entities.idno', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not link");
+		$this->assertContains('4', $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = '4';
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$this->assertContains($vs_value, $va_val, "Value in third level is incorrect");
+
+
+		//
+		// Get entity attribute
+		//
+		$vs_value = 'These are test notes';
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute as link
+		//
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not a link");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute as link with template
+		//
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertContains('<a href', $va_val, "Returned value is not a link");
+		$this->assertContains("Notes: {$vs_value}", $va_val, "Returned value is incorrect");
+
+		//
+		// Get entity attribute with template
+		//
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => false, 'returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("string", $va_val, "Return value should be string");
+		$this->assertEquals("Notes: {$vs_value}; Notes: ", $va_val, "Returned value is incorrect");
+
+
+		//
+		// Get entity attribute as array and links with template
+		//
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('template' => 'Notes: ^internal_notes','returnAsLink' => true, 'returnAsArray' => true, 'returnAllLocales' => false, 'delimiter' => '; '));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertContains("Notes: {$vs_value}", array_shift($va_val), "Returned value is incorrect");
+
+
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$vs_value = 'These are test notes';
+		$va_val = array_pop($va_val);
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
+		$this->assertContains($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_entities.internal_notes', array('returnAsArray' => true, 'returnAllLocales' => true));
+
+		$this->assertInternalType("array", $va_val, "Return value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('internal_notes', $va_val, "Returned array should have key 'internal_notes'");
+		$this->assertContains($vs_value, $va_val['internal_notes'], "Value in third level is incorrect");
+
+	}
+	# -------------------------------------------------------------------------------
+	public function testParentGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno.".1");
+		$qr_res->nextHit();
+
+		//
+		// Get intrinsic field from parent
+		//
+		$vs_value = $this->ops_object_idno;
+		$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => false, 'returnAllLocales' => false));
+
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get preferred labels from parent
+		//
+		$vs_value = 'Canonical test record';
+		$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get attributes from parent
+		//
+		$vs_value = 'This is a test description';
+		$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+		$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
+		$this->assertContains($vs_value, $va_tmp, "Value in array is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.parent.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertEquals(sizeof($va_val), 1, "Size of returned array should be 1");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
+		$this->assertContains($vs_value, $va_val['description'], "Value in fourth level is incorrect");
+	}
+	# -------------------------------------------------------------------------------
+	public function testChildrenGet() {
+		$o_search = new ObjectSearch();
+		$qr_res = $o_search->search('ca_objects.idno:'.$this->ops_object_idno);
+		$qr_res->nextHit();
+
+		//
+		// Get intrinsic field from children
+		//
+		$vs_value = 'CIHP.TEST.1; CIHP.TEST.2';
+		$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$vs_value = 'CIHP.TEST.1';
+		$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.children.idno', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get preferred labels from children
+		//
+		$vs_value = 'Canonical test sub-record No. 1; Canonical test sub-record No. 2';
+		$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => false, 'returnAllLocales' => false, 'delimiter' => '; '));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+		$this->assertEquals($vs_value, $va_val, "Returned value is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => false));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$vs_value = 'Canonical test sub-record No. 1';
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		$va_val = $qr_res->get('ca_objects.children.preferred_labels.name', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+		$this->assertContains($vs_value, $va_val, "Value in array is incorrect");
+
+		//
+		// Get attributes from children
+		//
+		$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => false, 'returnAllLocales' => false));
+		$this->assertInternalType("string", $va_val, "Returned value should be string");
+
+		$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => false));
+
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should greater than 0");
+		$this->assertArrayHasKey('description', $va_tmp = array_shift($va_val), "Returned array should have key 'description'");
+
+		$va_val = $qr_res->get('ca_objects.children.description', array('returnAsArray' => true, 'returnAllLocales' => true));
+		$this->assertInternalType("array", $va_val, "Returned value should be array");
+		$this->assertGreaterThan(0, sizeof($va_val), "Size of returned array should be greater than 0");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Second level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Third level of returned value should be array");
+
+		$va_val = array_shift($va_val);
+		$this->assertInternalType("array", $va_val, "Fourth level of returned value should be array");
+
+		$this->assertArrayHasKey('description', $va_val, "Returned array should have key 'description'");
+	}
+	# -------------------------------------------------------------------------------
+}
 ?>

--- a/tests/models/ModelSchemaTest.php
+++ b/tests/models/ModelSchemaTest.php
@@ -29,7 +29,6 @@
  * 
  * ----------------------------------------------------------------------
  */
-require_once 'PHPUnit/Autoload.php';
 require_once(__CA_LIB_DIR__."/core/Datamodel.php");
 require_once(__CA_LIB_DIR__."/core/Db.php");
 require_once(__CA_LIB_DIR__."/core/Configuration.php");

--- a/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginConfigurationTest.php
+++ b/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginConfigurationTest.php
@@ -30,7 +30,6 @@
  * ----------------------------------------------------------------------
  */
 
-require_once 'PHPUnit/Autoload.php';
 require_once __CA_APP_DIR__ . '/plugins/relationshipGenerator/relationshipGeneratorPlugin.php';
 
 /**

--- a/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
+++ b/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php
@@ -30,7 +30,6 @@
  * ----------------------------------------------------------------------
  */
 
-require_once 'PHPUnit/Autoload.php';
 require_once(__CA_BASE_DIR__ . '/tests/plugins/AbstractPluginIntegrationTest.php');
 require_once(__CA_LIB_DIR__ . '/ca/ApplicationPluginManager.php');
 require_once __CA_APP_DIR__ . '/plugins/relationshipGenerator/relationshipGeneratorPlugin.php';

--- a/tests/setup-tests.php
+++ b/tests/setup-tests.php
@@ -1,8 +1,17 @@
 <?php
 
-if (!defined("__CA_LOCAL_CONFIG_DIRECTORY__")) {
-	define("__CA_LOCAL_CONFIG_DIRECTORY__", __DIR__."/conf");
+// Ensure that the base dir is set correctly; this should normally be the parent of the "tests" dir.
+if (!defined("__CA_BASE_DIR__")) {
+	define("__CA_BASE_DIR__", dirname(__DIR__));
 }
 
-// Define config overrides for unit tests above, the following line will use remaining settings from main config.
-require_once('../setup.php');
+// Ensure that the local configuration directory is set to a location that does not exist; this ensures only defaults
+// are used by the tests and site-specific overrides do not cause unexpected failures.
+if (!defined("__CA_LOCAL_CONFIG_DIRECTORY__")) {
+	define("__CA_LOCAL_CONFIG_DIRECTORY__", __DIR__ . "/conf");
+}
+
+// If you require any overrides in setup.php that are specific to running unit tests, put them here.
+
+// Use remaining settings from main config.
+require_once(__CA_BASE_DIR__ . '/setup.php');


### PR DESCRIPTION
For http://clangers.collectiveaccess.org/jira/browse/PROV-932

You might want to ignore whitespace (?w=1) for this pull request, the unit tests have had "fix indentation" applied in IDE.
- Add `caUtils install` which performs an installation to a blank database instance.
- Add `caUtils --setup [/path/to/setup.php]` to allow caUtils to use a different setup.php than the one in the root.  This is used for integration tests.
- Fix a bug where logical combination was `&&` where it should be `||`, in "guess paths" fallback for caUtils.
- Add .travis.yml script to define the Travis CI build process.
- Add setup.php to be used (as symlink) by Travis CI builds.
- Change submodule to use https instead of ssh, because Travis CI does not have keys so https is just easier.
- Fixes to setup.php-dist to make things work in less fully-fledged environments.
- Remove static inclusion of Autoload.php from unit tests.
- Fix indentation in unit tests.
- Specify `__CA_BASE_DIR__` in setup-tests.php.
- Add some comments to setup-tests.php.
