### PR TITLE
PROV-913: Fixes for PHP 5.3

### DIFF
--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -80,10 +80,11 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 
 	public function checkStatus() {
 		$va_errors = array();
+		$vo_config = $this->opo_config;
 		$this->_testConfigurationSection(
 			_t('top level'),
 			self::_getTopLevelConfigurationRequirements(),
-			function ($key) { return $this->opo_config->get($key); },
+			function ($key) use ($vo_config) { return $vo_config->get($key); },
 			$va_errors
 		);
 		$va_rules = $this->opo_config->get('rules');
@@ -282,7 +283,8 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 						array( 'idno' => $pm_related_record ) :
 						array( 'id' => $pm_related_record ))
 		));
-		return sizeof($va_items) > 0 ? array_shift(array_keys($va_items)) : null;
+		$va_keys = array_keys($va_items);
+		return sizeof($va_keys) > 0 ? $va_keys[0] : null;
 	}
 
 	/**

--- a/tests/plugins/AbstractPluginIntegrationTest.php
+++ b/tests/plugins/AbstractPluginIntegrationTest.php
@@ -164,10 +164,11 @@ abstract class AbstractPluginIntegrationTest extends PHPUnit_Framework_TestCase 
 
 			// Replace placeholders with generated (unique) values
 			while (strpos($vs_line, '%%') !== false) {
+				$vs_className = get_called_class();
 				$vs_line = preg_replace_callback(
 					'/%%(.*?)%%/',
-					function ($pa_match) {
-						return sizeof($pa_match) > 1 ? self::_getIdno($pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
+					function ($pa_match) use ($vs_className) {
+						return sizeof($pa_match) > 1 ? call_user_func(array( $vs_className, '_getIdno' ), $pa_match[1]) : '::: ERROR PARSING CONFIGURATION TEMPLATE :::';
 					},
 					$vs_line
 				);


### PR DESCRIPTION
- Incorrect variable and class contexts.
- Retrieving element of array returned from function directly, without local variable.
