### PR TITLE
PROV-936 Move refinery tests to correct location

### DIFF
--- a/tests/refineries/dateAccuracyJoiner/DateAccuracyJoinerRefineryTest.php
+++ b/tests/refineries/dateAccuracyJoiner/DateAccuracyJoinerRefineryTest.php
@@ -1,6 +1,6 @@
 <?php
 /** ---------------------------------------------------------------------
- * support/tests/refineries/DateAccuracyJoinerRefineryTest.php
+ * tests/refineries/DateAccuracyJoinerRefineryTest.php
  * ----------------------------------------------------------------------
  * CollectiveAccess
  * Open-source collections management software
@@ -30,9 +30,7 @@
  * ----------------------------------------------------------------------
  */
 
-require_once 'PHPUnit/Autoload.php';
 require_once __CA_APP_DIR__ . '/refineries/dateAccuracyJoiner/dateAccuracyJoinerRefinery.php';
-
 
 class DateAccuracyJoinerRefineryTest extends PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
These tests were written before we moved tests to the top level. This
moves the test to where it will actually be run
