### PR TITLE
NOJIRA Fix incorrect attributes in Change Location panel.

### DIFF
--- a/themes/default/views/bundles/ca_objects_history.php
+++ b/themes/default/views/bundles/ca_objects_history.php
@@ -239,6 +239,8 @@
 				isSortable: false,
 				listSortItems: 'div.roundedRel',			
 				autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
+				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/storage_locations', 'StorageLocationQuickAdd', 'Form', array('location_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 1,
 				addMode: 'prepend'


### PR DESCRIPTION
Fix incorrect attributes in Change Location panel.

The ID attribute was mismatched between the HTML source and the JavaScript
used to hook up the autocomplete.  This fixes the mismatch.

---

Add missing attributes for Quick Add.

The Quick Add form was previously not working for Storage Locations,
in the Object Use History bundle.  This fixes it.
