### PR TITLE
reset support for additional controls

### DIFF
--- a/app/widgets/advancedSearchForm/views/search_advanced_form_html.php
+++ b/app/widgets/advancedSearchForm/views/search_advanced_form_html.php
@@ -80,9 +80,11 @@
 ?>
 		<script type="text/javascript">
 			function caAdvancedSearchFormReset() {
+				jQuery('#AdvancedSearchForm textarea').val('');
 				jQuery('#AdvancedSearchForm input[type=text]').val('');
+				jQuery('#AdvancedSearchForm input[type=hidden]').val('');
+				jQuery('#AdvancedSearchForm select').prop('selectedIndex', -1);
 				jQuery('#AdvancedSearchForm input[type=checkbox]').attr('checked', 0);
-				jQuery('#AdvancedSearchForm select').attr('selectedIndex', 0);
 			}
 		</script>
 	</form>

--- a/themes/default/views/find/Search/search_advanced_form_html.php
+++ b/themes/default/views/find/Search/search_advanced_form_html.php
@@ -112,8 +112,10 @@
 	}
 	
 	function caAdvancedSearchFormReset() {
+		jQuery('#AdvancedSearchForm textarea').val('');
 		jQuery('#AdvancedSearchForm input[type=text]').val('');
+		jQuery('#AdvancedSearchForm input[type=hidden]').val('');
+		jQuery('#AdvancedSearchForm select').prop('selectedIndex', -1);
 		jQuery('#AdvancedSearchForm input[type=checkbox]').attr('checked', 0);
-		jQuery('#AdvancedSearchForm select').attr('selectedIndex', 0);
 	}
 </script>


### PR DESCRIPTION
Resetting on advance search was missing for some controls (e.g. textarea and hidden). This fix solves the issue.
