### PR TITLE
enable/disable identifier based on settings in conf

### DIFF
--- a/app/lib/ca/IDNumbering/MultipartIDNumber.php
+++ b/app/lib/ca/IDNumbering/MultipartIDNumber.php
@@ -1085,5 +1085,21 @@
 			$this->opo_db = $po_db;
 		}
 		# -------------------------------------------------------
+        # Returns true if editable is set to 1 for the identifier, otherwise returns false
+        # Also, if the identifier consists of multiple elements, false will be returned
+        public function isFormatEditable($ps_format_name) {
+            $va_elements = $this->getElements();
+            if(sizeof($va_elements) == 1 ){
+                $vs_edit_info = $this->opa_formats[$ps_format_name][$this->getType()]['elements'][key($va_elements)];
+                switch($vs_edit_info['editable']){
+                    case 1:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+            return false;
+        }
+        # -------------------------------------------------------
 	}
 ?>

--- a/app/models/ca_bundle_displays.php
+++ b/app/models/ca_bundle_displays.php
@@ -499,7 +499,20 @@ class ca_bundle_displays extends BundlableLabelableBaseModelWithAttributes {
 							$va_placements[$vn_placement_id]['allowInlineEditing'] = false;
 							$va_placements[$vn_placement_id]['inlineEditingType'] = null;
 						} else {
-							$va_placements[$vn_placement_id]['allowInlineEditing'] = true;
+						
+                            if(isset($va_bundle_name[1])){
+                                // check if identifier is editable
+                                $id_editable = $t_subject->opo_idno_plugin_instance->isFormatEditable($vs_subject_table);
+
+                                // Do not allow in-line editing if the intrinsic element is identifier and
+                                // a). is not editable (editable = 0 in multipart_id_numbering.conf)
+                                // b). consists of multiple elements
+                                if($va_bundle_name[1] == $t_subject->getProperty('ID_NUMBERING_ID_FIELD') && $id_editable == false)
+                                    $va_placements[$vn_placement_id]['allowInlineEditing'] = false;
+                                else
+                                    $va_placements[$vn_placement_id]['allowInlineEditing'] = true;
+                            }						
+						
 							switch($t_subject->getFieldInfo($va_bundle_name[1], 'DISPLAY_TYPE')) {
 								case 'DT_SELECT':
 									if (($vs_list_code = $t_subject->getFieldInfo($va_bundle_name[1], 'LIST')) || ($vs_list_code = $t_subject->getFieldInfo($va_bundle_name[1], 'LIST_CODE'))) {


### PR DESCRIPTION
There is an issue in displaying identifiers in 'editable' search display. Identifiers are always editable regardless of how they are set in the configuration file (multipart_id_numbering). In this fix we solve this issue. Now, the identifier column will be disabled if 'editable' is set to 0 in the configuration file.  
We also disable identifier column if identifier is a composite element, because it is not clear how the update operation will be performed for its composing elements.
