### PR TITLE
PROV-1025 Don't throw an error if there is no setting for current_location_criteria

### DIFF
--- a/app/models/ca_objects.php
+++ b/app/models/ca_objects.php
@@ -1732,7 +1732,9 @@ class ca_objects extends RepresentableBaseModel implements IBundleProvider {
  		$va_bundle_settings = array();
  		$t_rel_type = new ca_relationship_types();
  		$va_map = $this->getAppConfig()->getAssoc('current_location_criteria');
- 		
+ 		if(!is_array($va_map)){
+		    $va_map = array();
+	    }
  		foreach($va_map as $vs_table => $va_types) {
  			$va_bundle_settings["{$vs_table}_showTypes"] = array();
  			foreach($va_types as $vs_type => $va_config) {


### PR DESCRIPTION
Fixes:

```
 Invalid argument supplied for foreach()

providence/app/models/ca_objects.php:1736
providence/app/models/ca_objects.php:1675
providence/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php:196
providence/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php:133
providence/app/lib/ca/ApplicationPluginManager.php:70
providence/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php:245
providence/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php:245
providence/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php:280
providence/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php:238
```
