### PR TITLE
Make _getIdNo available in PHP 5.3

### DIFF
--- a/tests/plugins/AbstractPluginIntegrationTest.php
+++ b/tests/plugins/AbstractPluginIntegrationTest.php
@@ -140,7 +140,7 @@ abstract class AbstractPluginIntegrationTest extends PHPUnit_Framework_TestCase 
 	 * @param $ps_idno_base string
 	 * @return string
 	 */
-	protected static function _getIdno($ps_idno_base) {
+	public static function _getIdno($ps_idno_base) {
 		return sprintf('%s_%s_%s', self::$s_timestamp, self::$s_random_number, $ps_idno_base);
 	}
 


### PR DESCRIPTION
The tests under PHP 5.3 suddenly complained about this.
https://travis-ci.org/kehh/providence/builds/33547824
Appears to be ok now:
https://travis-ci.org/kehh/providence/builds/33548865

Warning:  call_user_func() expects parameter 1 to be a valid callback,
cannot access protected method
RelationshipGeneratorPluginIntegrationTest::_getIdno() in
/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php
on line 171
PHP Stack trace:
PHP   1. {main}() /home/travis/.phpenv/versions/5.3.27/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main()
/home/travis/.phpenv/versions/5.3.27/bin/phpunit:586
PHP   3. PHPUnit_TextUI_Command->run()
phar:///home/travis/.phpenv/versions/5.3.27/bin/phpunit/phpunit/TextUI/Command.php:132
PHP   4. PHPUnit_TextUI_TestRunner->doRun()
phar:///home/travis/.phpenv/versions/5.3.27/bin/phpunit/phpunit/TextUI/Command.php:179
PHP   5. PHPUnit_Framework_TestSuite->run()
/home/travis/build/kehh/providence/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:426
PHP   6. PHPUnit_Framework_TestSuite->run()
/home/travis/build/kehh/providence/vendor/phpunit/phpunit/src/Framework/TestSuite.php:675
PHP   7. PHPUnit_Framework_TestSuite->run()
/home/travis/build/kehh/providence/vendor/phpunit/phpunit/src/Framework/TestSuite.php:675
PHP   8. call_user_func()
/home/travis/build/kehh/providence/vendor/phpunit/phpunit/src/Framework/TestSuite.php:642
PHP   9. RelationshipGeneratorPluginIntegrationTest::setUpBeforeClass()
/home/travis/build/kehh/providence/vendor/phpunit/phpunit/src/Framework/TestSuite.php:642
PHP  10. AbstractPluginIntegrationTest::_processConfiguration()
/home/travis/build/kehh/providence/tests/plugins/relationshipGenerator/RelationshipGeneratorPluginIntegrationTest.php:51
PHP  11. preg_replace_callback()
/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php:174
PHP  12.
{closure:/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php:170-172}()
/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php:174
PHP  13. call_user_func()
/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php:171
Warning: call_user_func() expects parameter 1 to be a valid callback,
cannot access protected method
RelationshipGeneratorPluginIntegrationTest::_getIdno() in
/home/travis/build/kehh/providence/tests/plugins/AbstractPluginIntegrationTest.php
on line 171
