### PR TITLE
NOJIRA ExpressionParser: Fix typo $vs_s is not defined

### DIFF
--- a/app/lib/core/Parsers/ExpressionParser.php
+++ b/app/lib/core/Parsers/ExpressionParser.php
@@ -142,7 +142,7 @@ class ExpressionParser {
 						$vs_buf = '';
 						break;
 					} else {
-						if ($vs_s !== '/') { 
+						if ($vs_c !== '/') {
 							$vs_buf .= $vs_c;
 							break;
 						}


### PR DESCRIPTION
Assuming it's $vs_c
