### PR TITLE
NOJIRA Adding unit test for incorrect UTM Zone parsing

### DIFF
--- a/tests/helpers/GisHelpersTest.php
+++ b/tests/helpers/GisHelpersTest.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012 Whirl-i-Gig
+ * Copyright 2014 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *


### PR DESCRIPTION
Note this does not fix the problem that coordinates in the southern hemisphere are parsed incorrectly (sorry) (the tests will fail until this is fixed).
