### PR TITLE
Ignore files generated by DOMPDF library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ setup.php
 *.swp
 /import/*
 app/lib/core/Parsers/htmlpurifier/standalone/HTMLPurifier/DefinitionCache/Serializer/*
+app/lib/core/Parsers/dompdf/lib/fonts/*fm.php
 app/log/log*.txt
+


### PR DESCRIPTION
This is just something we found useful to ignore, as the files are generated so we don't want them in the VCS.
