### PR TITLE
Serve *.map files, for minified JavaScript.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,6 +10,6 @@ Allow from all
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|ttf|swf)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|ttf|swf|map)$">
         Allow from all
 </FilesMatch>


### PR DESCRIPTION
Allows original (unminified) source to be used in firebug and
other browser developer tools.
