### PR TITLE
Add --skip-roles to speed up travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # Create setup.php
   - ln -s .travis.setup.php setup.php
   # Install the WAM CMIS profile
-  - support/bin/caUtils install --hostname=localhost --setup="$(pwd)/tests/setup-tests.php" --profile-name=$PROFILE --admin-email=dev@gaiaresources.com.au >install.log
+  - support/bin/caUtils install --hostname=localhost --setup="$(pwd)/tests/setup-tests.php" --skip-roles --profile-name=$PROFILE --admin-email=dev@gaiaresources.com.au >install.log
 
 before_script:
   # Go into the tests directory to run the tests


### PR DESCRIPTION
Roles are not necessary for any of the tests, and some profiles
might have many roles which accounts for a large portion of the
time for a Travis build.

Strictly this does not affect the profiles being tested, but in
our fork we have our own profile added to the list, and this has
decreased the time for a Travis run significantly, so the same
might be true for other forks wishing to put their own profile
through the Travis CI.
