### PR TITLE
Use redirects during login process.

### DIFF
--- a/app/controllers/system/AuthController.php
+++ b/app/controllers/system/AuthController.php
@@ -37,11 +37,15 @@
 			if (isset($_COOKIE['CA_'.__CA_APP_NAME__.'_ui_locale'])) {
 				if(!initializeLocale($_COOKIE['CA_'.__CA_APP_NAME__.'_ui_locale'])) die("Error loading locale ".$g_ui_locale);
 			}
+			// Redirect to the default action
+			$vs_redirect = $this->request->getParameter('redirect', pString);
+			$this->getView()->setVar('redirect', $vs_redirect);
  			$this->render('login_html.php');
  		}
  		# -------------------------------------------------------
  		public function DoLogin() {
  			global $g_ui_locale;
+			$vs_redirect_url = $this->request->getParameter('redirect', pString) ?: caNavUrl($this->request, null, null, null);
 			if (!$this->request->doAuthentication(array('dont_redirect' => true, 'noPublicUsers' => true, 'user_name' => $this->request->getParameter('username', pString), 'password' => $this->request->getParameter('password', pString)))) {
 				$this->notification->addNotification(_t("Login was invalid"), __NOTIFICATION_TYPE_ERROR__);
  				
@@ -49,7 +53,7 @@
 				if (isset($_COOKIE['CA_'.__CA_APP_NAME__.'_ui_locale'])) {
 					if(!initializeLocale($_COOKIE['CA_'.__CA_APP_NAME__.'_ui_locale'])) die("Error loading locale ".$g_ui_locale);
 				}
- 				$this->render('login_html.php');
+				$this->redirect(sprintf('%s?redirect=%s', caNavUrl($this->request, 'system', 'auth', 'login'), urlencode($vs_redirect_url)));
 			} else {
 				//
 				// Reset locale globals
@@ -66,9 +70,7 @@
 				
 				// Notify the user of the good news
  				$this->notification->addNotification(_t("You are now logged in"), __NOTIFICATION_TYPE_INFO__);
- 				
-							
-				$this->render('welcome_html.php');
+ 				$this->redirect($vs_redirect_url);
  			}
  		}
  		# -------------------------------------------------------
@@ -171,3 +173,4 @@
 		}
 		# -------------------------------------------------------
  	}
+

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -586,7 +586,7 @@ class RequestHTTP extends Request {
 		
 		foreach(array(
 			'no_headers', 'dont_redirect_to_login', 'dont_create_new_session', 'dont_redirect_to_welcome',
-			'user_name', 'password', 'options', 'noPublicUsers', 'dont_redirect', 'no_headers'
+			'user_name', 'password', 'options', 'noPublicUsers', 'dont_redirect', 'no_headers', 'redirect'
 		) as $vs_key) {
 			if (!isset($pa_options[$vs_key])) { $pa_options[$vs_key] = null; }
 		}
@@ -646,7 +646,14 @@ class RequestHTTP extends Request {
 				if (!$vb_login_successful) {																	// throw user to login screen
 					if (!$pa_options["dont_redirect_to_login"]) {
 						$o_event_log->log(array("CODE" => "LOGF", "SOURCE" => "Auth", "MESSAGE" => "Failed login with redirect for user id '".$vn_user_id."' (".$_SERVER['REQUEST_URI']."); IP=".$_SERVER["REMOTE_ADDR"]."; user agent='".$_SERVER["HTTP_USER_AGENT"]."'"));
-						$this->opo_response->addHeader("Location", $this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_path"));
+						$vs_redirect = $this->getRequestUrl(true);
+
+						if (strpos($vs_redirect, $this->config->get("auth_login_path") !== -1)) {
+							$vs_redirect = '';
+						} else {
+							$vs_redirect = '?redirect=' . urlencode($vs_redirect);
+						}
+						$this->opo_response->addHeader("Location", $this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_path") . $vs_redirect);
 					}
 					return false;
 				}
@@ -701,7 +708,9 @@ class RequestHTTP extends Request {
 			
 			//$this->user->close(); ** will be called externally **
 			$AUTH_CURRENT_USER_ID = $vn_user_id;
-			if (!$pa_options["dont_redirect_to_welcome"]) {
+			if ($pa_options['redirect']) {
+				$this->opo_response->addHeader("Location", $pa_options['redirect']);
+			} elseif (!$pa_options["dont_redirect_to_welcome"]) {
 				//header("Location: ".$this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_welcome_path"));				// redirect to "welcome" page
 				$this->opo_response->addHeader("Location", $this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_welcome_path"));
 				//exit;

--- a/themes/default/views/system/login_html.php
+++ b/themes/default/views/system/login_html.php
@@ -69,6 +69,7 @@
 						<div class="loginFormElement"><?php print _t("Password"); ?>:<br/>
 							<input type="password" name="password" size="25"/>
 						</div>
+						<input name="redirect" type="hidden" value="<?php echo $this->getVar('redirect'); ?>" />
 						<div class="loginSubmitButton"><?php print caFormSubmitButton($this->request, __CA_NAV_BUTTON_LOGIN__, _t("Login"),"login", array('icon_position' => __CA_NAV_BUTTON_ICON_POS_RIGHT__)); ?></div>
 						<script type="text/javascript">
 							jQuery(document).ready(function() {


### PR DESCRIPTION
When loading a page while not authenticated, the user is now
redirected to the login page (`system/auth/login`), with a
`redirect` URL parameter set to the (encoded) URL of the original
page.  This `redirect` parameter is passed through any number of
unsuccessful login attempts, each of which loads the URL
`system/auth/login` with the `redirect` parameter.  Following a
successful login, the user is taken back to the URL given by the
`redirect` parameter (i.e. the original URL), or to the dashboard
if no `redirect` parameter is given.

Previously, the login form was rendered "at" the original URL, and
this did not play nicely after a failed authentication attempt -
the user would always be taken back to the dashboard.

This is also better from a pure URL management perspective -- each
URL has a single purpose and that purpose is never subverted by the
login mechanism (only diverted).
