### PR TITLE
Add check for existence of object before deref.

### DIFF
--- a/app/lib/core/BaseModelWithAttributes.php
+++ b/app/lib/core/BaseModelWithAttributes.php
@@ -2261,7 +2261,7 @@
 					$vs_pk = $t_instance->primaryKey();
 					$qr_del = $o_db->query("SELECT {$vs_pk} FROM ".$t_instance->tableName()." WHERE {$vs_pk} IN (?) AND deleted = 1", array($va_row_ids));
 					
-					while($qr_del->nextRow()) {
+					while($qr_del && $qr_del->nextRow()) {
 						unset($va_references[$vn_table_num][$qr_del->get($vs_pk)]);
 					}
 				}


### PR DESCRIPTION
This was relevant at some stage, sorry I can't remember what the
actual issue was, but in any case it is always safe to check an
object for non-falsy value before dereferencing it.
