### PR TITLE
Add `<meta>` element to force IE to use "edge".

### DIFF
--- a/themes/default/views/pageFormat/pageHeader.php
+++ b/themes/default/views/pageFormat/pageHeader.php
@@ -37,6 +37,7 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
+		<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 	    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 		<meta http-equiv="Content-Style-Type" content="text/css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>


### PR DESCRIPTION
This ensures that IE will use its latest version and not
"compatibility view" where it emulates an older version (which may
be enabled due to corporate policy, etc).
