### PR TITLE
Prevent double path separators in redirect URL.

### DIFF
--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -387,22 +387,22 @@ class RequestHTTP extends Request {
 	public function getRequestUrl($pb_absolute=false) {
 		$va_url = array();
 		if ($vs_tmp = $this->getBaseUrlPath()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		if ($vs_tmp = $this->getScriptName()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		if ($vs_tmp = $this->getModulePath()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		if ($vs_tmp = $this->getController()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		if ($vs_tmp = $this->getAction()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		if ($vs_tmp = $this->getActionExtra()) {
-			$va_url[] = $vs_tmp;
+			$va_url[] = trim($vs_tmp, '/');
 		}
 		
 		//foreach($this->opa_params['PATH'] as $vs_param => $vs_value) {


### PR DESCRIPTION
- The base URL path was set to '/providence', which was then part
  of an array joined using '/' separator, which resulted in a '//'
  in the URL, which was causing a problem with redirects on logging
  in, and preventing login under some circumstances.  This ensures
  that all components are trimmed of leading and trailing '/'
  characters before joining.
