### PR TITLE
NOJIRA Migrate from ZipFile to PharData

### DIFF
--- a/app/controllers/editor/object_lots/ObjectLotEditorController.php
+++ b/app/controllers/editor/object_lots/ObjectLotEditorController.php
@@ -27,7 +27,6 @@
  */
  
  	require_once(__CA_MODELS_DIR__."/ca_object_lots.php");
-	require_once(__CA_LIB_DIR__."/core/Parsers/ZipFile.php");
  	require_once(__CA_LIB_DIR__."/ca/BaseEditorController.php");
  
  	class ObjectLotEditorController extends BaseEditorController {
@@ -109,7 +108,8 @@
 					}
 					
 					if (sizeof($va_paths) > 0){
-						$o_zip = new ZipFile();
+						$vs_tmp_name = caGetTempFileName('DownloadLotMedia', 'zip');
+						$o_phar = new PharData($vs_tmp_name, null, null, Phar::ZIP);
 						
 						foreach($va_paths as $vn_object_id => $va_path_info) {
 							$vn_c = 1;
@@ -121,7 +121,7 @@
 								if ($vs_ext = pathinfo($vs_path, PATHINFO_EXTENSION)) {
 									$vs_filename .= ".{$vs_ext}";
 								}
-								$o_zip->addFile($vs_path, $vs_filename, 0, array('compression' => 0));
+								$o_phar->addFile($vs_path, $vs_filename);
 								
 								$vn_c++;
 							}
@@ -132,7 +132,7 @@
 						// send download
 						$vs_idno = $t_lot->get('idno_stub');			
 						
-						$o_view->setVar('zip', $o_zip);
+						$o_view->setVar('tmp_file', $vs_tmp_name);
 						$o_view->setVar('download_name', 'media_for_'.mb_substr(preg_replace('![^A-Za-z0-9]+!u', '_', $vs_idno ? $vs_idno : $t_lot->getPrimaryKey()), 0, 20).'.zip');
 						
 						$this->response->addContent($o_view->render('ca_object_lots_download_media.php'));

--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -1807,16 +1807,17 @@
 			if (sizeof($va_file_paths) > 1) {
 				if (!($vn_limit = ini_get('max_execution_time'))) { $vn_limit = 30; }
 				set_time_limit($vn_limit * 2);
-				$o_zip = new ZipFile();
+				$vs_tmp_name = caGetTempFileName('DownloadMedia', 'zip');
+				$o_phar = new PharData($vs_tmp_name, null, null, Phar::ZIP);
 				foreach($va_file_paths as $vs_path => $vs_name) {
-					$o_zip->addFile($vs_path, $vs_name, null, array('compression' => 0));	// don't try to compress
+					$o_phar->addFile($vs_path, $vs_name);
 				}
-				$o_view->setVar('archive_path', $vs_path = $o_zip->output(ZIPFILE_FILEPATH));
+				$o_view->setVar('archive_path', $vs_tmp_name);
 				$o_view->setVar('archive_name', preg_replace('![^A-Za-z0-9\.\-]+!', '_', $t_subject->get('idno')).'.zip');
 				
  				$this->response->addContent($o_view->render('download_media_binary.php'));
 				
- 				if ($vs_path) { unlink($vs_path); }
+ 				if ($vs_tmp_name) { @unlink($vs_tmp_name); }
 			} else {
 				foreach($va_file_paths as $vs_path => $vs_name) {
 					$o_view->setVar('archive_path', $vs_path);

--- a/app/lib/ca/BaseFindController.php
+++ b/app/lib/ca/BaseFindController.php
@@ -38,7 +38,6 @@
  	require_once(__CA_LIB_DIR__.'/ca/ResultContext.php');
  	require_once(__CA_MODELS_DIR__.'/ca_bundle_displays.php');
  	require_once(__CA_MODELS_DIR__."/ca_sets.php");
-	require_once(__CA_LIB_DIR__."/core/Parsers/ZipFile.php");
 	require_once(__CA_LIB_DIR__."/core/AccessRestrictions.php");
  	require_once(__CA_LIB_DIR__.'/ca/Visualizer.php');
  	require_once(__CA_LIB_DIR__.'/core/Parsers/dompdf/dompdf_config.inc.php');
@@ -1000,7 +999,9 @@
  				if (is_array($pa_ids) && sizeof($pa_ids)) {
  					$ps_version = $this->request->getParameter('version', pString);
 					if ($qr_res = $t_subject->makeSearchResult($t_subject->tableName(), $pa_ids, array('filterNonPrimaryRepresentations' => false))) {
-						$o_zip = new ZipFile();
+						$vs_tmp_name = caGetTempFileName('DownloadRepresentations', 'zip');
+						$o_phar = new PharData($vs_tmp_name, null, null, Phar::ZIP);
+
 						if (!($vn_limit = ini_get('max_execution_time'))) { $vn_limit = 30; }
 						set_time_limit($vn_limit * 2);
 						
@@ -1052,11 +1053,12 @@
 								if ($vs_path_with_embedding = caEmbedMetadataIntoRepresentation(new ca_objects($qr_res->get('ca_objects.object_id')), new ca_object_representations($vn_representation_id), $vs_version)) {
 									$vs_path = $vs_path_with_embedding;
 								}
-								$o_zip->addFile($vs_path, $vs_filename, 0, array('compression' => 0));
+								$o_phar->addFile($vs_path, $vs_filename);
 								$vn_file_count++;
 							}
 						}
-						$this->view->setVar('zip', $o_zip);
+
+						$this->view->setVar('tmp_file', $vs_tmp_name);
 						$this->view->setVar('download_name', 'media_for_'.mb_substr(preg_replace('![^A-Za-z0-9]+!u', '_', $this->getCriteriaForDisplay()), 0, 20).'.zip');
 						
  						set_time_limit($vn_limit);

--- a/app/lib/ca/ConfigurationCheck.php
+++ b/app/lib/ca/ConfigurationCheck.php
@@ -375,6 +375,9 @@ final class ConfigurationCheck {
 		if (!in_array('sha256', hash_algos())){
 			self::addError(_t("Your PHP installation doesn't seem to have support for the sha256 hashing algorithm. Please install a newer version of either PHP or the hash module."));
 		}
+		if (!class_exists('PharData')) {
+			self::addError(_t("The PHP phar module is required for CollectiveAccess to run. Please install it."));
+		}
 		
 		if (@preg_match('/\p{L}/u', 'a') != 1) {
 			self::addError(_t("Your version of the PHP PCRE module lacks unicode features. Please install a module version with UTF-8 support."));

--- a/themes/default/views/bundles/ca_object_lots_download_media.php
+++ b/themes/default/views/bundles/ca_object_lots_download_media.php
@@ -25,21 +25,23 @@
  *
  * ----------------------------------------------------------------------
  */
- 	$o_zip = $this->getVar('zip');
- 
+	$vs_file_path = $this->getVar('tmp_file');
+
 	header("Content-type: application/zip");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 	header("Cache-Control: no-store, no-cache, must-revalidate");
 	header("Cache-Control: post-check=0, pre-check=0", false);
 	header("Pragma: no-cache");
 	header("Cache-control: private");
-	
+	header('Content-Length: ' . filesize($vs_file_path));
 	header("Content-Disposition: attachment; filename=".$this->getVar('download_name'));
+
 	set_time_limit(0);
-	$o_fp = @fopen($o_zip->output(ZIPFILE_FILEPATH),"rb");
+	$o_fp = @fopen($vs_file_path,"rb");
 	while(is_resource($o_fp) && !feof($o_fp)) {
 		print(@fread($o_fp, 1024*8));
 		ob_flush();
 		flush();
 	}
-?>
+	@unlink($vs_file_path);
+	exit();

--- a/themes/default/views/bundles/download_media_binary.php
+++ b/themes/default/views/bundles/download_media_binary.php
@@ -43,4 +43,3 @@
 		ob_flush();
 		flush();
 	}
-?>

--- a/themes/default/views/find/Results/object_representation_download_binary.php
+++ b/themes/default/views/find/Results/object_representation_download_binary.php
@@ -25,8 +25,7 @@
  *
  * ----------------------------------------------------------------------
  */
- 	$o_zip = $this->getVar('zip');
- 	$vs_file_path = $o_zip->output(ZIPFILE_FILEPATH);
+ 	$vs_file_path = $this->getVar('tmp_file');
  
 	header("Content-type: application/zip");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");


### PR DESCRIPTION
ZipFile produces corrupt files on CentOS with PHP5.4 and I'm not in the mood to reinvent the wheel so I thought we might as well migrate to something that works out of the box.

The phar extension is not really a new requirement, we've been using it in the zip extraction code of BaseModell::_processMedia for ages. Now it's a formal requirement with config check and everything.

I'm not sure but I think the extension is part of the core distribution since PHP5.3. It's available in the default php 5.4 packages in Debian and CentOS. No extra setup required.

I replaced all occurrences I could find but kept ZipFile around for now because it's probably still in use in Pawtucket.
