### PR TITLE
allow reindexing after inserting items in the database

### DIFF
--- a/app/lib/core/BaseModelWithAttributes.php
+++ b/app/lib/core/BaseModelWithAttributes.php
@@ -524,7 +524,7 @@
 				// set the field values array for this instance
 				$this->setFieldValuesArray($va_field_values_with_updated_attributes);
 				
-				$this->doSearchIndexing($va_fields_changed_array);
+				$this->doSearchIndexing($va_fields_changed_array, true);
 				
 				if ($vb_web_set_change_log_unit_id) { BaseModel::unsetChangeLogUnitID(); }
 				if ($this->numErrors() > 0) {


### PR DESCRIPTION
We are facing a problem with indexing while adding or removing set items (objects) from a set, this fix solves a part of that problem. 
When we add or delete a set item from a set, item is removed from the database but its index information is not updated. Adding to set from object editor is a problem, whereas it works fine when an object is added to a set from set editor. Problem with adding items to a set occures only when added from object editor, whereas it works fine when added from set editor. 
This particular fix solves the problem related to 'adding an item'.  Currently, in add (insert) operation new set item is added to the database and indexed properly, however index of the object is not updated, this is being caused by the false value of the reindex mode. Setting reindex mode to true solves the problem.

We are working on 'delete item' part of the problem and will make another pull request as soon as we have a solution.

More information about the problem can be found on our question on Collective Access forum:
http://www.collectiveaccess.org/support/forum/index.php?p=/discussion/294068/set-item-removal-problem