### PR TITLE
Grey background for disabled input elements

### DIFF
--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -3199,6 +3199,7 @@ input[type="text"], input[type="textarea"], textarea,  input[type="password"] {
 }
 
 input[type="text"]:disabled, input[type="textarea"]:disabled, textarea:disabled {
+    background-color-color:#F0F0F0;
     color: #808080;
     -webkit-text-fill-color:#808080;
 }


### PR DESCRIPTION
Just a minor usability improvement to help users recognize read-only fields. #F0F0F0 is default for FF and IE, slightly different from Chromes default bg color for disabled input elements (#EBEBE4).

![disabled_background](https://cloud.githubusercontent.com/assets/3026896/6723735/7127e70c-cdec-11e4-98ec-7c09d2521f15.png)