### PR TITLE
Fix search/browse criteria CSS

### DIFF
--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -3936,6 +3936,7 @@ div.quickSearchNoResults {
     text-transform:uppercase;
     font-size:11px;
     line-height: 27px;
+    white-space: nowrap;
 }
 #browseCriteria a.startOver:hover{
     color:#1ab3c8;

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -3908,7 +3908,7 @@ div.quickSearchNoResults {
 #browseCriteria .criteriaHeading, #searchRefineParameters .criteriaHeading{
     font-weight:bold;
     color:#333;
-    font-size:12px
+    font-size:12px;
     line-height: 27px;
 }
 /*#browseCriteria a.close{

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -3908,7 +3908,8 @@ div.quickSearchNoResults {
 #browseCriteria .criteriaHeading, #searchRefineParameters .criteriaHeading{
     font-weight:bold;
     color:#333;
-    font-size:12px;
+    font-size:12px
+    line-height: 27px;
 }
 /*#browseCriteria a.close{
     text-transform:uppercase;
@@ -3936,6 +3937,7 @@ div.quickSearchNoResults {
     text-transform:uppercase;
     font-size:11px;
     margin-left:10px;
+    line-height: 27px;
 }
 #browseCriteria a.startOver:hover{
     color:#1ab3c8;
@@ -3952,6 +3954,7 @@ div.quickSearchNoResults {
 	display:inline;
 	font-size:11px;
 	margin-right: 5px;
+	line-height: 27px;
 }
 .criteriaLink a{
 	background-color:#eee;

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -3928,15 +3928,13 @@ div.quickSearchNoResults {
 #browseCriteria a.startOver, #searchRefineParameters a.startOver{
     color: #aaa;
     text-decoration:none;
-    font-size:12px;
     border-radius:4px;
     -moz-border-radius:4px;
     -webkit-border-radius:4px;
     border: 1px solid #ccc;
-    padding:5px 5px 4px 5px;
+    padding:4px 5px 4px 5px;
     text-transform:uppercase;
     font-size:11px;
-    margin-left:10px;
     line-height: 27px;
 }
 #browseCriteria a.startOver:hover{
@@ -3968,6 +3966,9 @@ div.quickSearchNoResults {
 	padding:5px 7px 5px 7px;
 	margin-left:5px;
 	text-decoration:none;
+}
+.criteriaLink:last-of-type{
+    margin-right:15px;
 }
 /* browse pop up panel */
 #splashBrowsePanel {


### PR DESCRIPTION
Just a little fix for search/browse criteria that span multiple lines.
![criteria_css](https://cloud.githubusercontent.com/assets/3026896/6724435/3236746c-cdf8-11e4-80ff-51837827d009.png)
