### PR TITLE
PROV-1268 Add token-based authentication to web service API

### DIFF
--- a/app/conf/access_restrictions.conf
+++ b/app/conf/access_restrictions.conf
@@ -656,7 +656,7 @@ access_restrictions = {
 			actions = { can_delete_ca_storage_locations }
 		}
 	},
-	
+
 	editor/loans/LoanEditorController = {
 		default = {
 			operator = OR,
@@ -713,7 +713,7 @@ access_restrictions = {
 			actions = { can_delete_ca_loans }
 		}
 	},
-	
+
 	editor/movements/MovementEditorController = {
 		default = {
 			operator = OR,
@@ -770,7 +770,7 @@ access_restrictions = {
 			actions = { can_delete_ca_movements }
 		}
 	},
-	
+
 	editor/tours/TourEditorController = {
 		default = {
 			operator = OR,
@@ -827,7 +827,7 @@ access_restrictions = {
 			actions = { can_delete_ca_tours }
 		}
 	},
-	
+
 	editor/tour_stops/TourStopEditorController = {
 		default = {
 			operator = OR,
@@ -892,10 +892,10 @@ access_restrictions = {
 	find = {
 		default = {
 			operator = OR,
-			actions = { 
-				can_browse_ca_collections, can_browse_ca_collections, can_browse_ca_entities, can_browse_ca_object_lots, can_browse_ca_objects, can_browse_ca_occurrences, can_browse_ca_places, can_browse_ca_loans, can_browse_ca_movements,  
+			actions = {
+				can_browse_ca_collections, can_browse_ca_collections, can_browse_ca_entities, can_browse_ca_object_lots, can_browse_ca_objects, can_browse_ca_occurrences, can_browse_ca_places, can_browse_ca_loans, can_browse_ca_movements,
 				can_search_ca_collections, can_search_ca_collections, can_search_ca_entities, can_search_ca_object_lots, can_search_ca_objects, can_search_ca_occurrences, can_search_ca_places, can_search_ca_loans, can_search_ca_movements,
-				can_quicksearch 
+				can_quicksearch
 			}
 		}
 	},
@@ -948,7 +948,7 @@ access_restrictions = {
 			actions = { can_browse_ca_loans}
 		}
 	},
-	
+
 	find/BrowseMovements = {
 		default = {
 			operator = OR,
@@ -1046,7 +1046,7 @@ access_restrictions = {
 			actions = { can_search_ca_storage_locations }
 		}
 	},
-	
+
 	find/SearchLoansAdvancedController = {
 		default = {
 			operator = OR,
@@ -1059,7 +1059,7 @@ access_restrictions = {
 			actions = { can_search_ca_loans }
 		}
 	},
-	
+
 	find/SearchMovementsAdvancedController = {
 		default = {
 			operator = OR,
@@ -1394,7 +1394,11 @@ access_restrictions = {
 			actions = { can_use_json_browse_service }
 		}
 	},
-
+    /AuthController = {
+    	default = {
+    		actions = { can_use_json_browse_service }
+    	}
+    },
 	aboutDrawingServices/controllers/ADFindController = {
     	default = {
     		actions = { can_use_about_drawing_search_service }

--- a/app/service/controllers/AuthController.php
+++ b/app/service/controllers/AuthController.php
@@ -1,0 +1,63 @@
+<?php
+/* ----------------------------------------------------------------------
+ * app/service/controllers/AuthController.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2015 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * ----------------------------------------------------------------------
+ */
+	require_once(__CA_LIB_DIR__.'/ca/Service/BaseServiceController.php');
+	require_once(__CA_LIB_DIR__.'/ca/Service/ModelService.php');
+
+	class AuthController extends BaseServiceController {
+		# -------------------------------------------------------
+		public function __construct(&$po_request, &$po_response, $pa_view_paths) {
+ 			parent::__construct($po_request, $po_response, $pa_view_paths);
+ 		}
+		# -------------------------------------------------------
+		public function login() {
+			$o_session = $this->getRequest()->getSession();
+			if(!$o_session->getSessionID()) {
+				$this->view->setVar("errors", array("Invalid session"));
+				$this->render("json_error.php");
+				return;
+			}
+
+			$this->view->setVar("content",array('authToken' => $o_session->getServiceAuthToken()));
+			$this->render('json.php');
+		}
+		# -------------------------------------------------------
+		public function logout() {
+			$o_session = $this->getRequest()->getSession();
+			if(!$o_session->getSessionID()) {
+				$this->view->setVar("errors", array("Invalid session"));
+				$this->render("json_error.php");
+				return;
+			}
+
+			$o_session->deleteSession();
+
+			$this->view->setVar("content",array('authToken' => $o_session->getServiceAuthToken()));
+			$this->render('json.php');
+		}
+		# -------------------------------------------------------
+	}


### PR DESCRIPTION
This finally allows us to re-use sessions for the API. While this is technically not REST it's common practice and allows us to not basic auth for every request.

The idea is that you call the /service.php/auth/login endpoint via GET (w/ basic auth) and it'll give you an authToken. Append this authToken as GET parameter to any subsequent service API calls and you'll be authenticated and find yourself in the same session.

Auth tokens don't last very long (which is kind of the point) so you'e going to have to re-authenticate every once in a while, when you get a 401.

The old "basic auth on every request" way still works for compatibility.

A good next step would be to allow users to generate API keys that can be used for service authentication instead of their account passwords.

I updated the PHP API wrapper at https://github.com/skeidel/ca-service-wrapper to support this and will update the readme soon.