### PR TITLE
correct query terms for default data type

### DIFF
--- a/app/lib/core/Plugins/SearchEngine/Solr.php
+++ b/app/lib/core/Plugins/SearchEngine/Solr.php
@@ -300,7 +300,7 @@ class WLPlugSearchEngineSolr extends BaseSearchPlugin implements IWLPlugSearchEn
 														$o_lucene_query_element = new Zend_Search_Lucene_Search_Query_Term(new Zend_Search_Lucene_Index_Term((float)$vs_term, $vs_table.'.'.$vs_fld_num));
 														break;
 													default:	// everything else
-														$o_lucene_query_element->getTerm()->field = $vs_table.'.'.$vs_fld_num;
+														$o_lucene_query_element = new Zend_Search_Lucene_Search_Query_Term(new Zend_Search_Lucene_Index_Term($vs_term, $vs_table.'.'.$vs_fld_num));
 														break;
 												}
 											} else {


### PR DESCRIPTION
Query parsing for default element data type in solr search implementation seems to be incorrect. Current implementation, which is supposed to prepare correct solr query by converting field names into corresponding field codes(e.g. ca_objects.A123). The implementation handles it with "$o_lucene_query_element->getTerm()->field = $vs_table.'.'.$vs_fld_num;". There are two problems with this implementation. 

First, there is no such function available in two of the three Lucene serch query types handled here, that are:  'Zend_Search_Lucene_Search_Query_MultiTerm' and 'Zend_Search_Lucene_Search_Query_Phrase'.
These classes rather have getTerms() function. The terms returned by this function do not have element 'field', therefore setting its throws an error.

Second, current implementation does not set the changed value (field name to field code) to the right variable ($o_lucene_query_element), which is being used later- on to construct solr query.

Fix in this pull request solves this problem (for Solr) by assigning changed value to the right variable. 

While we have this problem with Solr it seems Elastic Search and Mysql may have avoided this problem by simply not processing default element data types. In their implementation they handle "2,4,6,8,9,10,11 and 12" element data types. Whereas Solr implementation handles an extra data type, i.e.  'default'. This is where we have encountered problem.
