### PR TITLE
Move after-save search indexing into a separate process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ branches:
     - develop
     - master
     - master-fix
+    - dev/outOfProcessSearchIndexing

--- a/app/conf/datamodel.conf
+++ b/app/conf/datamodel.conf
@@ -203,7 +203,8 @@ tables = {
 	"ca_metadata_dictionary_rules" = 215,
 	"ca_attribute_value_multifiles" = 216,
 	"ca_metadata_dictionary_rule_violations" = 217,
-	"ca_object_checkouts" = 218
+	"ca_object_checkouts" = 218,
+	"ca_search_indexing_queue" = 219,
 }
 
 relationships = [

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -3268,7 +3268,7 @@ if (!$vb_batch) {
 										continue;
 									}
 									$vn_label_type_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_Pref'.'type_id_'.$va_label['label_id'], pInteger);
-									$this->editLabel($va_label['label_id'], $va_label_values, $vn_label_locale_id, $vn_label_type_id, true);
+									$this->editLabel($va_label['label_id'], $va_label_values, $vn_label_locale_id, $vn_label_type_id, true, array('queueIndexing' => true));
 									if ($this->numErrors()) {
 										foreach($this->errors() as $o_e) {
 											switch($o_e->getErrorNumber()) {
@@ -3352,7 +3352,7 @@ if (!$vb_batch) {
 								continue;
 							}
 							$vn_label_type_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_Pref'.'type_id_new_'.$vn_c, pInteger);
-							$this->addLabel($va_label_values, $vn_new_label_locale_id, $vn_label_type_id, true);	
+							$this->addLabel($va_label_values, $vn_new_label_locale_id, $vn_label_type_id, true, array('queueIndexing' => true));
 							if ($this->numErrors()) {
 								$po_request->addActionErrors($this->errors(), $vs_f);
 								$vb_error_inserting_pref_label = true;
@@ -3395,7 +3395,7 @@ if (!$vb_batch) {
 							if ($vn_label_locale_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_NPref'.'locale_id_'.$va_label['label_id'], pString)) {
 								if (is_array($va_label_values = $this->getLabelUIValuesFromRequest($po_request, $vs_placement_code.$vs_form_prefix, $va_label['label_id'], false))) {
 									$vn_label_type_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_NPref'.'type_id_'.$va_label['label_id'], pInteger);
-									$this->editLabel($va_label['label_id'], $va_label_values, $vn_label_locale_id, $vn_label_type_id, false);
+									$this->editLabel($va_label['label_id'], $va_label_values, $vn_label_locale_id, $vn_label_type_id, false, array('queueIndexing' => true));
 									if ($this->numErrors()) {
 										foreach($this->errors() as $o_e) {
 											switch($o_e->getErrorNumber()) {

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -3189,9 +3189,9 @@ if (!$vb_batch) {		// hierarchy moves are not supported in batch mode
 		$vb_is_insert = false;
 		
 		if ($this->getPrimaryKey()) {
-			$this->update();
+			$this->update(array('queueIndexing' => true));
 		} else {
-			$this->insert();
+			$this->insert(array('queueIndexing' => true));
 			$vb_is_insert = true;
 		}
 		if ($this->numErrors() > 0) {

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -3286,7 +3286,7 @@ if (!$vb_batch) {
 							} else {
 								if ($po_request->getParameter($vs_placement_code.$vs_form_prefix.'_PrefLabel_'.$va_label['label_id'].'_delete', pString)) {
 									// delete
-									$this->removeLabel($va_label['label_id']);
+									$this->removeLabel($va_label['label_id'], array('queueIndexing' => true));
 								}
 							}
 						}
@@ -3328,7 +3328,7 @@ if (!$vb_batch) {
 						 				foreach($va_labels_by_locale as $vn_locale_id => $va_labels) {
 						 					foreach($va_labels as $vn_i => $va_label) {
 						 						if(isset($va_label[$this->getLabelDisplayField()]) && ($va_label[$this->getLabelDisplayField()] == '['._t('BLANK').']')) {
-						 							$this->removeLabel($va_label['label_id']);
+						 							$this->removeLabel($va_label['label_id'], array('queueIndexing' => true));
 						 						}
 						 					}
 						 				}
@@ -3413,7 +3413,7 @@ if (!$vb_batch) {
 							} else {
 								if ($po_request->getParameter($vs_placement_code.$vs_form_prefix.'_NPrefLabel_'.$va_label['label_id'].'_delete', pString)) {
 									// delete
-									$this->removeLabel($va_label['label_id']);
+									$this->removeLabel($va_label['label_id'], array('queueIndexing' => true));
 								}
 							}
 						}
@@ -3543,7 +3543,7 @@ if (!$vb_batch) {
 										global $g_ui_locale_id;
 										if ($t_rep->load($va_rep['representation_id'])) {
 											$t_rep->setMode(ACCESS_WRITE);
-											$t_rep->replaceLabel(array('name' => $vs_rep_label), $g_ui_locale_id, null, true);
+											$t_rep->replaceLabel(array('name' => $vs_rep_label), $g_ui_locale_id, null, true, array('queueIndexing' => true));
 											if ($t_rep->numErrors()) {
 												$po_request->addActionErrors($t_rep->errors(), $vs_f, $va_rep['representation_id']);
 											}

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -3449,7 +3449,7 @@ if (!$vb_batch) {
 					if ($vn_new_label_locale_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_NPref'.'locale_id_new_'.$vn_c, pString)) {
 						if (is_array($va_label_values = $this->getLabelUIValuesFromRequest($po_request, $vs_placement_code.$vs_form_prefix, 'new_'.$vn_c, false))) {
 							$vn_new_label_type_id = $po_request->getParameter($vs_placement_code.$vs_form_prefix.'_NPref'.'type_id_new_'.$vn_c, pInteger);
-							$this->addLabel($va_label_values, $vn_new_label_locale_id, $vn_new_label_type_id, false);	
+							$this->addLabel($va_label_values, $vn_new_label_locale_id, $vn_new_label_type_id, false, array('queueIndexing' => true));
 						
 							if ($this->numErrors()) {
 								$po_request->addActionErrors($this->errors(), $vs_f);

--- a/app/lib/ca/LabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/LabelableBaseModelWithAttributes.php
@@ -86,12 +86,14 @@
 		 * @param bool $pb_is_preferred
 		 * @param array $pa_options Options include:
 		 *		truncateLongLabels = truncate label values that exceed the maximum storable length. [Default=false]
+		 * 		queueIndexing =
 		 * @return int id for newly created label, false on error or null if no row is loaded
 		 */ 
 		public function addLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=false, $pa_options=null) {
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
 			
 			$vb_truncate_long_labels = caGetOption('truncateLongLabels', $pa_options, false);
+			$pb_queue_indexing = caGetOption('queueIndexing', $pa_options, false);
 			
 			$vs_table_name = $this->tableName();
 			
@@ -131,7 +133,7 @@
 			
 			$this->opo_app_plugin_manager->hookBeforeLabelInsert(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
-			$vn_label_id = $t_label->insert();
+			$vn_label_id = $t_label->insert(array('queueIndexing' => $pb_queue_indexing));
 			
 			$this->opo_app_plugin_manager->hookAfterLabelInsert(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
@@ -152,12 +154,14 @@
 		 * @param bool $pb_is_preferred
 		 * @param array $pa_options Options include:
 		 *		truncateLongLabels = truncate label values that exceed the maximum storable length. [Default=false]
+		 * 		queueIndexing =
 		 * @return int id for the edited label, false on error or null if no row is loaded
 		 */
 		public function editLabel($pn_label_id, $pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=false, $pa_options=null) {
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
 			
 			$vb_truncate_long_labels = caGetOption('truncateLongLabels', $pa_options, false);
+			$pb_queue_indexing = caGetOption('queueIndexing', $pa_options, false);
 			
 			$vs_table_name = $this->tableName();
 			
@@ -211,7 +215,7 @@
 			
 			$this->opo_app_plugin_manager->hookBeforeLabelUpdate(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
-			$t_label->update();
+			$t_label->update(array('queueIndexing' => $pb_queue_indexing));
 			
 			$this->opo_app_plugin_manager->hookAfterLabelUpdate(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		

--- a/app/lib/ca/LabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/LabelableBaseModelWithAttributes.php
@@ -229,8 +229,9 @@
 		/**
 		 * Remove specified label
 		 */
- 		public function removeLabel($pn_label_id) {
+ 		public function removeLabel($pn_label_id, $pa_options = null) {
  			if (!$this->getPrimaryKey()) { return null; }
+			$pb_queue_indexing = caGetOption('queueIndexing', $pa_options, false);
  			
  			if (!($t_label = $this->_DATAMODEL->getInstanceByTableName($this->getLabelTableName()))) { return null; }
  			if ($this->inTransaction()) {
@@ -244,8 +245,8 @@
  			$t_label->setMode(ACCESS_WRITE);
  			
  			$this->opo_app_plugin_manager->hookBeforeLabelDelete(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
-		
- 			$t_label->delete();
+
+ 			$t_label->delete(false, array('queueIndexing' => $pb_queue_indexing));
  			
  			$this->opo_app_plugin_manager->hookAfterLabelDelete(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
@@ -264,7 +265,7 @@
 		 *
 		 * @return bool True on success, false on error
 		 */
- 		public function removeAllLabels($pn_mode=__CA_LABEL_TYPE_ANY__) {
+ 		public function removeAllLabels($pn_mode=__CA_LABEL_TYPE_ANY__, $pa_options = null) {
  			if (!$this->getPrimaryKey()) { return null; }
  			
  			if (!($t_label = $this->_DATAMODEL->getInstanceByTableName($this->getLabelTableName()))) { return null; }
@@ -288,7 +289,7 @@
 									break;
 							}
 						}
- 						$vb_ret &= $this->removeLabel($va_label['label_id']);
+ 						$vb_ret &= $this->removeLabel($va_label['label_id'], $pa_options);
  					}
  				}
  			}
@@ -298,7 +299,7 @@
 		/**
 		 * 
 		 */
- 		public function replaceLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=true) {
+ 		public function replaceLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=true, $pa_options = null) {
  			if (!($vn_id = $this->getPrimaryKey())) { return null; }
  			
  			$va_labels = $this->getLabels(array($pn_locale_id), $pb_is_preferred ? __CA_LABEL_TYPE_PREFERRED__ : __CA_LABEL_TYPE_NONPREFERRED__);
@@ -307,11 +308,11 @@
  				$va_labels = caExtractValuesByUserLocale($va_labels);
  				$va_label = array_shift($va_labels);
  				return $this->editLabel(
- 					$va_label[0]['label_id'], $pa_label_values, $pn_locale_id, $pn_type_id, $pb_is_preferred
+ 					$va_label[0]['label_id'], $pa_label_values, $pn_locale_id, $pn_type_id, $pb_is_preferred, $pa_options
  				);
  			} else {
  				return $this->addLabel(
- 					$pa_label_values, $pn_locale_id, $pn_type_id, $pb_is_preferred
+ 					$pa_label_values, $pn_locale_id, $pn_type_id, $pb_is_preferred, $pa_options
  				);
  			}
  		}

--- a/app/lib/ca/Utils/CLIUtils.php
+++ b/app/lib/ca/Utils/CLIUtils.php
@@ -146,9 +146,6 @@
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Setting up hierarchies")); }
 			$vo_installer->processMiscHierarchicalSetup();
 
-			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing search indexing queue")); }
-			$vo_installer->processSearchIndexingQueue();
-
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Installation complete")); }
 
 			$vs_time = _t("Installation took %1 seconds", $t_total->getTime(0));

--- a/app/lib/ca/Utils/CLIUtils.php
+++ b/app/lib/ca/Utils/CLIUtils.php
@@ -146,6 +146,9 @@
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Setting up hierarchies")); }
 			$vo_installer->processMiscHierarchicalSetup();
 
+			if (!$vb_quiet) { CLIUtils::addMessage(_t("Processing search indexing queue")); }
+			$vo_installer->processSearchIndexingQueue();
+
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Installation complete")); }
 
 			$vs_time = _t("Installation took %1 seconds", $t_total->getTime(0));
@@ -2836,7 +2839,6 @@
 		 */
 		public static function process_indexing_queue($po_opts=null) {
 			require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
-			define('__CA_IS_INDEXING_SERVICE__', true);
 
 			ca_search_indexing_queue::process();
 		}

--- a/app/lib/ca/Utils/CLIUtils.php
+++ b/app/lib/ca/Utils/CLIUtils.php
@@ -2834,6 +2834,47 @@
 		/**
 		 *
 		 */
+		public static function process_indexing_queue($po_opts=null) {
+			require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
+			define('__CA_IS_INDEXING_SERVICE__', true);
+
+			ca_search_indexing_queue::process();
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function process_indexing_queueParamList() {
+			return array(
+
+			);
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function process_indexing_queueUtilityClass() {
+			return _t('Search');
+		}
+
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function process_indexing_queueShortHelp() {
+			return _t('Process search indexing queue.');
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function process_indexing_queueHelp() {
+			return _t('Process search indexing queue.');
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
 		public static function reload_object_current_locations($po_opts=null) {
 			require_once(__CA_LIB_DIR__."/core/Db.php");
 			require_once(__CA_MODELS_DIR__."/ca_objects.php");

--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -2444,7 +2444,12 @@ class BaseModel extends BaseObject {
 					$vn_id = $this->getPrimaryKey();
 					
 					if ((!isset($pa_options['dont_do_search_indexing']) || (!$pa_options['dont_do_search_indexing'])) && !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
-						$this->doSearchIndexing($this->getFieldValuesArray(true), false, array('isNewRow' => true));
+						$va_index_options = array('isNewRow' => true);
+						if(caGetOption('queueIndexing', $pa_options, false)) {
+							$va_index_options['queueIndexing'] = true;
+						}
+
+						$this->doSearchIndexing($this->getFieldValuesArray(true), false, $va_index_options);
 					}
 
 					$this->logChange("I");
@@ -3000,7 +3005,12 @@ class BaseModel extends BaseObject {
 					}
 					if ((!isset($pa_options['dont_do_search_indexing']) || (!$pa_options['dont_do_search_indexing'])) &&  !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
 						# update search index
-						$this->doSearchIndexing(null, false);
+						$va_index_options = array();
+						if(caGetOption('queueIndexing', $pa_options, false)) {
+							$va_index_options['queueIndexing'] = true;
+						}
+
+						$this->doSearchIndexing(null, false, $va_index_options);
 					}
 														
 					if (is_array($va_rebuild_hierarchical_index)) {
@@ -3058,6 +3068,9 @@ class BaseModel extends BaseObject {
 	 * @return bool true on success, false on failure of indexing
 	 */
 	public function doSearchIndexing($pa_changed_field_values_array=null, $pb_reindex_mode=false, $pa_options=null) {
+		caDebug($pa_options);
+		caDebug(caPrintStacktrace());
+
 		if (defined("__CA_DONT_DO_SEARCH_INDEXING__")) { return; }
 		if (is_null($pa_changed_field_values_array)) { 
 			$pa_changed_field_values_array = $this->getChangedFieldValuesArray();

--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -3068,9 +3068,6 @@ class BaseModel extends BaseObject {
 	 * @return bool true on success, false on failure of indexing
 	 */
 	public function doSearchIndexing($pa_changed_field_values_array=null, $pb_reindex_mode=false, $pa_options=null) {
-		caDebug($pa_options);
-		caDebug(caPrintStacktrace());
-
 		if (defined("__CA_DONT_DO_SEARCH_INDEXING__")) { return; }
 		if (is_null($pa_changed_field_values_array)) { 
 			$pa_changed_field_values_array = $this->getChangedFieldValuesArray();
@@ -3082,7 +3079,7 @@ class BaseModel extends BaseObject {
 			$this->getFieldValuesArray(true), // data to index
 			$pb_reindex_mode,
 			null, // esclusion list, always null in the beginning
-			$pa_changed_field_values_array, // changed valyes
+			$pa_changed_field_values_array, // changed values
 			$pa_options
 		);
 	}

--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -3064,7 +3064,14 @@ class BaseModel extends BaseObject {
 		}
 		
 		$o_indexer = $this->getSearchIndexer(caGetOption('engine', $pa_options, null));
-		return $o_indexer->indexRow($this->tableNum(), $this->getPrimaryKey(), $this->getFieldValuesArray(true), $pb_reindex_mode, null, $pa_changed_field_values_array, $this->_FIELD_VALUES_OLD, $pa_options);
+		return $o_indexer->indexRow(
+			$this->tableNum(), $this->getPrimaryKey(), // identify record
+			$this->getFieldValuesArray(true), // data to index
+			$pb_reindex_mode,
+			null, // esclusion list, always null in the beginning
+			$pa_changed_field_values_array, // changed valyes
+			$pa_options
+		);
 	}
 	
 	/**

--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -3109,6 +3109,7 @@ class BaseModel extends BaseObject {
 	 * @param bool $pb_delete_related delete stuff related to the record? pass non-zero value if you want to.
 	 * @param array $pa_options Options for delete process. Options are:
 	 *		hard = if true records which can support "soft" delete are really deleted rather than simply being marked as deleted
+	 *		queueIndexing =
 	 * @param array $pa_fields instead of deleting the record represented by this object instance you can
 	 * pass an array of field => value assignments which is used in a SQL-DELETE-WHERE clause.
 	 * @param array $pa_table_list this is your possibility to pass an array of table name => true assignments

--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -3117,6 +3117,7 @@ class BaseModel extends BaseObject {
 	 */
 	public function delete ($pb_delete_related=false, $pa_options=null, $pa_fields=null, $pa_table_list=null) {
 		if(!is_array($pa_options)) { $pa_options = array(); }
+		$pb_queue_indexing = caGetOption('queueIndexing', $pa_options, false);;
 		
 		$vn_id = $this->getPrimaryKey();
 		if ($this->hasField('deleted') && (!isset($pa_options['hard']) || !$pa_options['hard'])) {
@@ -3133,7 +3134,7 @@ class BaseModel extends BaseObject {
 					if(!defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
 						$o_indexer = $this->getSearchIndexer();
 						$o_indexer->startRowUnIndexing($this->tableNum(), $vn_id);
-						$o_indexer->commitRowUnIndexing($this->tableNum(), $vn_id);
+						$o_indexer->commitRowUnIndexing($this->tableNum(), $vn_id, array('queueIndexing' => $pb_queue_indexing));
 					}
 				}
 				$this->logChange("D");
@@ -3286,7 +3287,7 @@ class BaseModel extends BaseObject {
 			# --- complete delete of search index entries
 			#
 			if(!defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
-				$o_indexer->commitRowUnIndexing($this->tableNum(), $vn_id);
+				$o_indexer->commitRowUnIndexing($this->tableNum(), $vn_id, array('queueIndexing' => $pb_queue_indexing));
 			}
 			
 			# cancel and pending queued tasks against this record

--- a/app/lib/core/BaseModelWithAttributes.php
+++ b/app/lib/core/BaseModelWithAttributes.php
@@ -485,9 +485,12 @@
 				
 				// set the field values array for this instance
 				//$this->setFieldValuesArray($va_field_values_with_updated_attributes);
-				
-				$this->doSearchIndexing(array_merge($this->getFieldValuesArray(true), $va_fields_changed_array), false, array('isNewRow' => true));	
-				
+
+				$va_index_options = array('isNewRow' => true);
+				if(caGetOption('queueIndexing', $pa_options, false)) {
+					$va_index_options['queueIndexing'] = true;
+				}
+				$this->doSearchIndexing(array_merge($this->getFieldValuesArray(true), $va_fields_changed_array), false, $va_index_options);
 				
 				if ($vb_web_set_change_log_unit_id) { BaseModel::unsetChangeLogUnitID(); }
 				if ($this->numErrors() > 0) {
@@ -531,8 +534,13 @@
 				
 				// set the field values array for this instance
 				//$this->setFieldValuesArray($va_field_values_with_updated_attributes);
+
+				$va_index_options = array();
+				if(caGetOption('queueIndexing', $pa_options, false)) {
+					$va_index_options['queueIndexing'] = true;
+				}
 				
-				$this->doSearchIndexing($va_fields_changed_array);
+				$this->doSearchIndexing($va_fields_changed_array, false, $va_index_options);
 				
 				if ($vb_web_set_change_log_unit_id) { BaseModel::unsetChangeLogUnitID(); }
 				if ($this->numErrors() > 0) {

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -535,13 +535,13 @@ class RequestHTTP extends Request {
 				$vn_port = 80;
 			}
 
-			$r_socket = fsockopen(__CA_SITE_HOSTNAME__, $vn_port, $errno, $err, 3);
+			$r_socket = pfsockopen(__CA_SITE_HOSTNAME__, $vn_port, $errno, $err, 3);
 			if ($r_socket) {
 				$vs_http  = "GET ".$this->getBaseUrlPath()."/index.php?processIndexingQueue=1 HTTP/1.1\r\n";
 				$vs_http .= "Host: ".__CA_SITE_HOSTNAME__."\r\n";
-				$vs_http .= "Connection: Close\r\n\r\n";
+				$vs_http .= "Connection: keep-alive\r\n\r\n";
 				fwrite($r_socket, $vs_http);
-				fclose($r_socket);
+				//fclose($r_socket);
 			}
 		}
 	}

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -535,13 +535,13 @@ class RequestHTTP extends Request {
 				$vn_port = 80;
 			}
 
-			$r_socket = pfsockopen(__CA_SITE_HOSTNAME__, $vn_port, $errno, $err, 3);
+			$r_socket = fsockopen(__CA_SITE_HOSTNAME__, $vn_port, $errno, $err, 3);
 			if ($r_socket) {
 				$vs_http  = "GET ".$this->getBaseUrlPath()."/index.php?processIndexingQueue=1 HTTP/1.1\r\n";
 				$vs_http .= "Host: ".__CA_SITE_HOSTNAME__."\r\n";
-				$vs_http .= "Connection: keep-alive\r\n\r\n";
+				$vs_http .= "Connection: Close\r\n\r\n";
 				fwrite($r_socket, $vs_http);
-				//fclose($r_socket);
+				fclose($r_socket);
 			}
 		}
 	}

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -514,18 +514,35 @@ class RequestHTTP extends Request {
 		return false;
 	}
 	# -------------------------------------------------------
- 		/**
- * 
- * Saves changes to session and user objects. You should call this at the end of every request to ensure
- * that user and session variables are saved.
- *
- * @access public 
- * @return float Seconds elapsed since request started.
- */	
+ 	/**
+	 *
+	 * Saves changes to session, user objects and sends asynchronous request for search indexing
+	 * You should call this at the end of every request to ensure that user and session variables are saved.
+	 *
+	 * @access public
+	 */
 	function close() {
 		$this->session->close();
 		if (is_object($this->user)) {
 			$this->user->close();
+		}
+
+		if(defined('__CA_SITE_HOSTNAME__') && strlen(__CA_SITE_HOSTNAME__) > 0) {
+
+			if(isset($_SERVER['SERVER_PORT']) &&  $_SERVER['SERVER_PORT']) {
+				$vn_port = $_SERVER['SERVER_PORT'];
+			} else {
+				$vn_port = 80;
+			}
+
+			$r_socket = fsockopen(__CA_SITE_HOSTNAME__, $vn_port, $errno, $err, 3);
+			if ($r_socket) {
+				$vs_http  = "GET ".$this->getBaseUrlPath()."/index.php?processIndexingQueue=1 HTTP/1.1\r\n";
+				$vs_http .= "Host: ".__CA_SITE_HOSTNAME__."\r\n";
+				$vs_http .= "Connection: Close\r\n\r\n";
+				fwrite($r_socket, $vs_http);
+				fclose($r_socket);
+			}
 		}
 	}
 	# ----------------------------------------

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -482,7 +482,9 @@ class SearchIndexer extends SearchBase {
 	 * @param null|array $pa_exclusion_list list of records to exclude from indexing
 	 * 		(to prevent endless recursive reindexing). Should always be null when called externally.
 	 * @param null|array $pa_changed_fields list of fields that have changed (and must be indexed)
-	 * @param null $pa_options
+	 * @param null|array $pa_options
+	 * 		queueIndexing -
+	 * 		isNewRow -
 	 * @throws Exception
 	 * @return bool
 	 */
@@ -497,7 +499,7 @@ class SearchIndexer extends SearchBase {
 		if (is_array($pa_exclusion_list[$pn_subject_tablenum]) && (isset($pa_exclusion_list[$pn_subject_tablenum][$pn_subject_row_id]))) { return; }
 
 		// @todo add a config setting
-		if(!caGetOption('dontQueueIndexing', $pa_options, false)) {
+		if(caGetOption('queueIndexing', $pa_options, false)) {
 			$this->queueIndexRow(array(
 				'table_num' => $pn_subject_tablenum,
 				'row_id' => $pn_subject_row_id,

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -49,6 +49,11 @@ class SearchIndexer extends SearchBase {
 
 	private $opo_metadata_element = null;
 
+	/**
+	 * @var null|ca_search_indexing_queue
+	 */
+	private $opo_search_indexing_queue = null;
+
 	# ------------------------------------------------
 	/**
 	 * Constructor takes Db() instance which it uses for all database access. You should pass an instance in
@@ -62,6 +67,7 @@ class SearchIndexer extends SearchBase {
 		parent::__construct($opo_db, $ps_engine);
 
 		$this->opo_metadata_element = new ca_metadata_elements();
+		$this->opo_search_indexing_queue = new ca_search_indexing_queue();
 	}
 	# -------------------------------------------------------
 	/**
@@ -411,16 +417,32 @@ class SearchIndexer extends SearchBase {
 	}
 	# ------------------------------------------------
 	private function queueIndexRow($pa_row_values) {
-		$t_queue_entry = new ca_search_indexing_queue();
-		$t_queue_entry->setMode(ACCESS_WRITE);
+		foreach($pa_row_values as $vs_fld => &$vm_val) {
+			if(!$this->opo_search_indexing_queue->hasField($vs_fld)) {
+				return false;
+			}
 
-		foreach($pa_row_values as $vs_fld => $vm_val) {
-			if($t_queue_entry->hasField($vs_fld)) {
-				$t_queue_entry->set($vs_fld, $vm_val);
+			if(is_null($vm_val)) {
+				$vm_val = array();
+			}
+
+			if(is_array($vm_val)) {
+				$vm_val = caSerializeForDatabase($vm_val);
 			}
 		}
 
-		$t_queue_entry->insert();
+		$va_insert_values = array(
+			'table_num' => $pa_row_values['table_num'],
+			'row_id' => $pa_row_values['row_id'],
+			'field_data' => $pa_row_values['field_data'],
+			'reindex' => $pa_row_values['reindex'] ? 1 : 0,
+			'changed_fields' => $pa_row_values['changed_fields'],
+			'options' => $pa_row_values['options'],
+		);
+
+		$this->opo_db->query("INSERT INTO ca_search_indexing_queue (table_num, row_id, field_data, reindex, changed_fields, options) VALUES (?, ?, ?, ?, ?, ?)", $va_insert_values);
+
+		return true;
 	}
 	# ------------------------------------------------
 	/**
@@ -463,7 +485,7 @@ class SearchIndexer extends SearchBase {
 
 		// queue this indexing task, unless we are in the indexing microservice
 		// @todo add a config setting to disable this
-		/*if(!defined('__CA_IS_INDEXING_SERVICE__') || !__CA_IS_INDEXING_SERVICE__) {
+		if(!defined('__CA_IS_INDEXING_SERVICE__') || !__CA_IS_INDEXING_SERVICE__) {
 			$this->queueIndexRow(array(
 				'table_num' => $pn_subject_tablenum,
 				'row_id' => $pn_subject_row_id,
@@ -473,7 +495,7 @@ class SearchIndexer extends SearchBase {
 				'options' => $pa_options
 			));
 			//return;
-		}*/
+		}
 
 		$pb_is_new_row = (int)caGetOption('isNewRow', $pa_options, false);
 		$vb_reindex_children = false;

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -213,7 +213,7 @@ class ca_search_indexing_queue extends BaseModel {
 				caUnserializeForDatabase($o_result->get('field_data')),
 				(bool)$o_result->get('reindex'), null,
 				caUnserializeForDatabase($o_result->get('changed_fields')),
-				array_merge(array('queueIndexing' => false), caUnserializeForDatabase($o_result->get('options')))
+				array_merge(caUnserializeForDatabase($o_result->get('options')), array('queueIndexing' => false))
 			);
 
 			$o_db->query('DELETE FROM ca_search_indexing_queue WHERE entry_id=?', $o_result->get('entry_id'));

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -223,30 +223,37 @@ class ca_search_indexing_queue extends BaseModel {
 	}
 	# ------------------------------------------------------
 	static public function process() {
-		$o_db = new Db();
-		$o_result = $o_db->query("SELECT * FROM ca_search_indexing_queue ORDER BY entry_id");
-		if($o_result && $o_result->numRows()) {
-			$o_si = new SearchIndexer($o_db);
+		$r_semaphore = sem_get(ftok(__FILE__,'CASearchIndexingQueue'));
 
-			while ($o_result->nextRow()) {
+		if(sem_acquire($r_semaphore)) {
+			$o_db = new Db();
+			$o_result = $o_db->query("SELECT * FROM ca_search_indexing_queue ORDER BY entry_id");
+			if($o_result && $o_result->numRows()) {
+				$o_si = new SearchIndexer($o_db);
 
-				if(!$o_result->get('is_unindex')) { // normal indexRow() call
-					$o_si->indexRow(
-						$o_result->get('table_num'), $o_result->get('row_id'),
-						caUnserializeForDatabase($o_result->get('field_data')),
-						(bool)$o_result->get('reindex'), null,
-						caUnserializeForDatabase($o_result->get('changed_fields')),
-						array_merge(caUnserializeForDatabase($o_result->get('options')), array('queueIndexing' => false))
-					);
-				} else { // is_unindex = 1, so it's a commitRowUnindexing() call
-					$o_si->commitRowUnIndexing(
-						$o_result->get('table_num'), $o_result->get('row_id'),
-						array('queueIndexing' => false, 'dependencies' => caUnserializeForDatabase($o_result->get('dependencies')))
-					);
+				while ($o_result->nextRow()) {
+
+					if(!$o_result->get('is_unindex')) { // normal indexRow() call
+						$o_si->indexRow(
+							$o_result->get('table_num'), $o_result->get('row_id'),
+							caUnserializeForDatabase($o_result->get('field_data')),
+							(bool)$o_result->get('reindex'), null,
+							caUnserializeForDatabase($o_result->get('changed_fields')),
+							array_merge(caUnserializeForDatabase($o_result->get('options')), array('queueIndexing' => false))
+						);
+					} else { // is_unindex = 1, so it's a commitRowUnindexing() call
+						$o_si->commitRowUnIndexing(
+							$o_result->get('table_num'), $o_result->get('row_id'),
+							array('queueIndexing' => false, 'dependencies' => caUnserializeForDatabase($o_result->get('dependencies')))
+						);
+					}
+
+					$o_db->query('DELETE FROM ca_search_indexing_queue WHERE entry_id=?', $o_result->get('entry_id'));
 				}
 
-				$o_db->query('DELETE FROM ca_search_indexing_queue WHERE entry_id=?', $o_result->get('entry_id'));
 			}
+
+			sem_release($r_semaphore);
 		}
 	}
 	# ------------------------------------------------------

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -213,7 +213,7 @@ class ca_search_indexing_queue extends BaseModel {
 				caUnserializeForDatabase($o_result->get('field_data')),
 				(bool)$o_result->get('reindex'), null,
 				caUnserializeForDatabase($o_result->get('changed_fields')),
-				caUnserializeForDatabase($o_result->get('options'))
+				array_merge(array('dontQueueIndexing' => true), caUnserializeForDatabase($o_result->get('options')))
 			);
 
 			$o_db->query('DELETE FROM ca_search_indexing_queue WHERE entry_id=?', $o_result->get('entry_id'));

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -15,30 +15,30 @@
  * the terms of the provided license as published by Whirl-i-Gig
  *
  * CollectiveAccess is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * This source code is free and modifiable under the terms of 
+ * This source code is free and modifiable under the terms of
  * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
  * the "license.txt" file for details, or visit the CollectiveAccess web site at
  * http://www.CollectiveAccess.org
- * 
+ *
  * @package CollectiveAccess
  * @subpackage models
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
- * 
+ *
  * ----------------------------------------------------------------------
  */
- 
- /**
-   *
-   */
+
+/**
+ *
+ */
 
 
 BaseModel::$s_ca_models_definitions['ca_search_indexing_queue'] = array(
- 	'NAME_SINGULAR' 	=> _t('search indexing queue entry'),
- 	'NAME_PLURAL' 		=> _t('search indexing queue entries'),
- 	'FIELDS' 			=> array(
+	'NAME_SINGULAR' 	=> _t('search indexing queue entry'),
+	'NAME_PLURAL' 		=> _t('search indexing queue entries'),
+	'FIELDS' 			=> array(
 		'entry_id' => array(
 			'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_HIDDEN,
 			'IDENTITY' => true, 'DISPLAY_WIDTH' => 10, 'DISPLAY_HEIGHT' => 1,
@@ -102,7 +102,7 @@ BaseModel::$s_ca_models_definitions['ca_search_indexing_queue'] = array(
 			'DEFAULT' => '',
 			'LABEL' => 'Options', 'DESCRIPTION' => 'Options'
 		),
- 	)
+	)
 );
 
 class ca_search_indexing_queue extends BaseModel {
@@ -118,9 +118,9 @@ class ca_search_indexing_queue extends BaseModel {
 	# ------------------------------------------------------
 	# what table does this class represent?
 	protected $TABLE = 'ca_search_indexing_queue';
-	      
+
 	# what is the primary key of the table?
-	protected $PRIMARY_KEY = 'element';
+	protected $PRIMARY_KEY = 'entry_id';
 
 	# ------------------------------------------------------
 	# --- Properties used by standard editing scripts
@@ -131,7 +131,7 @@ class ca_search_indexing_queue extends BaseModel {
 	# ------------------------------------------------------
 
 	# Array of fields to display in a listing of records from this table
-	protected $LIST_FIELDS = array('idno_stub');
+	protected $LIST_FIELDS = array('field_data');
 
 	# When the list of "list fields" above contains more than one field,
 	# the LIST_DELIMITER text is displayed between fields as a delimiter.
@@ -146,10 +146,10 @@ class ca_search_indexing_queue extends BaseModel {
 
 	# List of fields to sort listing of records by; you can use 
 	# SQL 'ASC' and 'DESC' here if you like.
-	protected $ORDER_BY = array('idno_stub');
+	protected $ORDER_BY = array('field_data');
 
 	# Maximum number of record to display per page in a listing
-	protected $MAX_RECORDS_PER_PAGE = 20; 
+	protected $MAX_RECORDS_PER_PAGE = 20;
 
 	# How do you want to page through records in a listing: by number pages ordered
 	# according to your setting above? Or alphabetically by the letters of the first
@@ -159,8 +159,8 @@ class ca_search_indexing_queue extends BaseModel {
 	# If you want to order records arbitrarily, add a numeric field to the table and place
 	# its name here. The generic list scripts can then use it to order table records.
 	protected $RANK = '';
-	
-	
+
+
 	# ------------------------------------------------------
 	# Hierarchical table properties
 	# ------------------------------------------------------
@@ -171,7 +171,7 @@ class ca_search_indexing_queue extends BaseModel {
 	protected $HIERARCHY_DEFINITION_TABLE	=	null;
 	protected $HIERARCHY_ID_FLD				=	null;
 	protected $HIERARCHY_POLY_TABLE			=	null;
-	
+
 	# ------------------------------------------------------
 	# Change logging
 	# ------------------------------------------------------
@@ -179,10 +179,10 @@ class ca_search_indexing_queue extends BaseModel {
 	protected $LOG_CHANGES_TO_SELF = false;
 	protected $LOG_CHANGES_USING_AS_SUBJECT = array(
 		"FOREIGN_KEYS" => array(
-		
+
 		),
 		"RELATED_TABLES" => array(
-		
+
 		)
 	);
 	# ------------------------------------------------------
@@ -190,7 +190,7 @@ class ca_search_indexing_queue extends BaseModel {
 	# are listed here is the order in which they will be returned using getFields()
 
 	protected $FIELDS;
-	
+
 	# ------------------------------------------------------
 	# --- Constructor
 	#
@@ -207,4 +207,3 @@ class ca_search_indexing_queue extends BaseModel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -1,0 +1,210 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/models/ca_search_indexing_queue.php : table access class for table ca_search_indexing_queue
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2015 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ * 
+ * @package CollectiveAccess
+ * @subpackage models
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ * 
+ * ----------------------------------------------------------------------
+ */
+ 
+ /**
+   *
+   */
+
+
+BaseModel::$s_ca_models_definitions['ca_search_indexing_queue'] = array(
+ 	'NAME_SINGULAR' 	=> _t('search indexing queue entry'),
+ 	'NAME_PLURAL' 		=> _t('search indexing queue entries'),
+ 	'FIELDS' 			=> array(
+		'entry_id' => array(
+			'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_HIDDEN,
+			'IDENTITY' => true, 'DISPLAY_WIDTH' => 10, 'DISPLAY_HEIGHT' => 1,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => _t('CollectiveAccess id'), 'DESCRIPTION' => _t('Unique numeric identifier used by CollectiveAccess internally to identify this queue entry')
+		),
+		'table_num' => array(
+			'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_FIELD,
+			'DISPLAY_WIDTH' => 10, 'DISPLAY_HEIGHT' => 1,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Table', 'DESCRIPTION' => 'Table to index for search',
+			'BOUNDS_VALUE' => array(0,255)
+		),
+		'row_id' => array(
+			'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_FIELD,
+			'DISPLAY_WIDTH' => 10, 'DISPLAY_HEIGHT' => 1,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Row id', 'DESCRIPTION' => 'Identifier of row to index for search'
+		),
+		'field_data' => array(
+			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
+			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Field data', 'DESCRIPTION' => 'Field data'
+		),
+		'reindex' => array(
+			'FIELD_TYPE' => FT_BIT, 'DISPLAY_TYPE' => DT_CHECKBOXES,
+			'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
+			'IS_NULL' => false,
+			'DEFAULT' => 0,
+			'OPTIONS' => array(
+				_t('Yes') => 1,
+				_t('No') => 0
+			),
+			'ALLOW_BUNDLE_ACCESS_CHECK' => true,
+			'DONT_ALLOW_IN_UI' => true,
+			'LABEL' => 'Reindex?', 'DESCRIPTION' => 'Indicates if this is a full reindex for this row'
+		),
+		'changed_fields' => array(
+			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
+			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Changed fields', 'DESCRIPTION' => 'Changed fields'
+		),
+		'old_values' => array(
+			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
+			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Old values', 'DESCRIPTION' => 'Old values'
+		),
+		'options' => array(
+			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
+			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,
+			'IS_NULL' => false,
+			'DEFAULT' => '',
+			'LABEL' => 'Options', 'DESCRIPTION' => 'Options'
+		),
+ 	)
+);
+
+class ca_search_indexing_queue extends BaseModel {
+	# ---------------------------------
+	# --- Object attribute properties
+	# ---------------------------------
+	# Describe structure of content object's properties - eg. database fields and their
+	# associated types, what modes are supported, et al.
+	#
+
+	# ------------------------------------------------------
+	# --- Basic object parameters
+	# ------------------------------------------------------
+	# what table does this class represent?
+	protected $TABLE = 'ca_search_indexing_queue';
+	      
+	# what is the primary key of the table?
+	protected $PRIMARY_KEY = 'element';
+
+	# ------------------------------------------------------
+	# --- Properties used by standard editing scripts
+	# 
+	# These class properties allow generic scripts to properly display
+	# records from the table represented by this class
+	#
+	# ------------------------------------------------------
+
+	# Array of fields to display in a listing of records from this table
+	protected $LIST_FIELDS = array('idno_stub');
+
+	# When the list of "list fields" above contains more than one field,
+	# the LIST_DELIMITER text is displayed between fields as a delimiter.
+	# This is typically a comma or space, but can be any string you like
+	protected $LIST_DELIMITER = ' ';
+
+	# What you'd call a single record from this table (eg. a "person")
+	protected $NAME_SINGULAR;
+
+	# What you'd call more than one record from this table (eg. "people")
+	protected $NAME_PLURAL;
+
+	# List of fields to sort listing of records by; you can use 
+	# SQL 'ASC' and 'DESC' here if you like.
+	protected $ORDER_BY = array('idno_stub');
+
+	# Maximum number of record to display per page in a listing
+	protected $MAX_RECORDS_PER_PAGE = 20; 
+
+	# How do you want to page through records in a listing: by number pages ordered
+	# according to your setting above? Or alphabetically by the letters of the first
+	# LIST_FIELD?
+	protected $PAGE_SCHEME = 'alpha'; # alpha [alphabetical] or num [numbered pages; default]
+
+	# If you want to order records arbitrarily, add a numeric field to the table and place
+	# its name here. The generic list scripts can then use it to order table records.
+	protected $RANK = '';
+	
+	
+	# ------------------------------------------------------
+	# Hierarchical table properties
+	# ------------------------------------------------------
+	protected $HIERARCHY_TYPE				=	null;
+	protected $HIERARCHY_LEFT_INDEX_FLD 	= 	null;
+	protected $HIERARCHY_RIGHT_INDEX_FLD 	= 	null;
+	protected $HIERARCHY_PARENT_ID_FLD		=	null;
+	protected $HIERARCHY_DEFINITION_TABLE	=	null;
+	protected $HIERARCHY_ID_FLD				=	null;
+	protected $HIERARCHY_POLY_TABLE			=	null;
+	
+	# ------------------------------------------------------
+	# Change logging
+	# ------------------------------------------------------
+	protected $UNIT_ID_FIELD = null;
+	protected $LOG_CHANGES_TO_SELF = false;
+	protected $LOG_CHANGES_USING_AS_SUBJECT = array(
+		"FOREIGN_KEYS" => array(
+		
+		),
+		"RELATED_TABLES" => array(
+		
+		)
+	);
+	# ------------------------------------------------------
+	# $FIELDS contains information about each field in the table. The order in which the fields
+	# are listed here is the order in which they will be returned using getFields()
+
+	protected $FIELDS;
+	
+	# ------------------------------------------------------
+	# --- Constructor
+	#
+	# This is a function called when a new instance of this object is created. This
+	# standard constructor supports three calling modes:
+	#
+	# 1. If called without parameters, simply creates a new, empty objects object
+	# 2. If called with a single, valid primary key value, creates a new objects object and loads
+	#    the record identified by the primary key value
+	#
+	# ------------------------------------------------------
+	public function __construct($pn_id=null) {
+		parent::__construct($pn_id);	# call superclass constructor
+	}
+	# ------------------------------------------------------
+}
+?>

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -203,9 +203,9 @@ class ca_search_indexing_queue extends BaseModel {
 	}
 	# ------------------------------------------------------
 	static public function process() {
-		$r_sem = sem_get(ftok(__FILE__, 'SearchIndexingQueue'));
+		$r_lock_file = fopen(__CA_BASE_DIR__.'/app/tmp/search_indexing_queue.lock', 'r+');
 
-		if(sem_acquire($r_sem)) {
+		if (flock($r_lock_file, LOCK_EX)) {  // acquire an exclusive lock
 			$o_db = new Db();
 			$o_result = $o_db->query("SELECT * FROM ca_search_indexing_queue ORDER BY entry_id");
 			if($o_result && $o_result->numRows()) {
@@ -224,7 +224,7 @@ class ca_search_indexing_queue extends BaseModel {
 				}
 			}
 
-			sem_release($r_sem);
+			flock($r_lock_file, LOCK_UN);    // release the lock
 		}
 	}
 	# ------------------------------------------------------

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -88,13 +88,6 @@ BaseModel::$s_ca_models_definitions['ca_search_indexing_queue'] = array(
 			'DEFAULT' => '',
 			'LABEL' => 'Changed fields', 'DESCRIPTION' => 'Changed fields'
 		),
-		'old_values' => array(
-			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
-			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,
-			'IS_NULL' => false,
-			'DEFAULT' => '',
-			'LABEL' => 'Old values', 'DESCRIPTION' => 'Old values'
-		),
 		'options' => array(
 			'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT,
 			'DISPLAY_WIDTH' => 88, 'DISPLAY_HEIGHT' => 15,

--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -213,7 +213,7 @@ class ca_search_indexing_queue extends BaseModel {
 				caUnserializeForDatabase($o_result->get('field_data')),
 				(bool)$o_result->get('reindex'), null,
 				caUnserializeForDatabase($o_result->get('changed_fields')),
-				array_merge(array('dontQueueIndexing' => true), caUnserializeForDatabase($o_result->get('options')))
+				array_merge(array('queueIndexing' => false), caUnserializeForDatabase($o_result->get('options')))
 			);
 
 			$o_db->query('DELETE FROM ca_search_indexing_queue WHERE entry_id=?', $o_result->get('entry_id'));

--- a/app/version.php
+++ b/app/version.php
@@ -3,7 +3,7 @@
 	define('__CollectiveAccess__', '1.5');
 	
 	# Schema revision
-	define('__CollectiveAccess_Schema_Rev__', 118);
+	define('__CollectiveAccess_Schema_Rev__', 120);
 	
 	# Release type
 	define('__CollectiveAccess_Release_Type__', 'GIT');

--- a/index.php
+++ b/index.php
@@ -57,6 +57,12 @@
 		exit();
 	}
 
+	if(isset($_REQUEST['processIndexingQueue']) && $_REQUEST['processIndexingQueue']) {
+		require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
+		ca_search_indexing_queue::process();
+		exit();
+	}
+
 	// run garbage collector
 	GarbageCollection::gc();
 	

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -35,7 +35,6 @@ require_once(__CA_APP_DIR__.'/helpers/utilityHelpers.php');
 require_once(__CA_LIB_DIR__.'/ca/BundlableLabelableBaseModelWithAttributes.php');
 require_once(__CA_MODELS_DIR__.'/ca_users.php');
 require_once(__CA_MODELS_DIR__.'/ca_user_groups.php');
-require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
 
 class Installer {
 	# --------------------------------------------------
@@ -1613,10 +1612,6 @@ class Installer {
 			$this->addError("Errors inserting the storage location root: ".join("; ",$t_storage_location->getErrors()));
 			return;
 		}
-	}
-	# --------------------------------------------------
-	public function processSearchIndexingQueue() {
-		ca_search_indexing_queue::process();
 	}
 	# --------------------------------------------------
 	public function createAdminAccount(){

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -26,15 +26,16 @@
  * ----------------------------------------------------------------------
  */
 
-require_once(__CA_LIB_DIR__."/core/Cache/CompositeCache.php");
-require_once(__CA_LIB_DIR__."/core/Configuration.php");
-require_once(__CA_LIB_DIR__."/core/Datamodel.php");
-require_once(__CA_LIB_DIR__."/core/Db.php");
-require_once(__CA_LIB_DIR__."/core/Media/MediaVolumes.php");
-require_once(__CA_APP_DIR__."/helpers/utilityHelpers.php");
-require_once(__CA_LIB_DIR__."/ca/BundlableLabelableBaseModelWithAttributes.php");
-require_once(__CA_MODELS_DIR__."/ca_users.php");
-require_once(__CA_MODELS_DIR__."/ca_user_groups.php");
+require_once(__CA_LIB_DIR__.'/core/Cache/CompositeCache.php');
+require_once(__CA_LIB_DIR__.'/core/Configuration.php');
+require_once(__CA_LIB_DIR__.'/core/Datamodel.php');
+require_once(__CA_LIB_DIR__.'/core/Db.php');
+require_once(__CA_LIB_DIR__.'/core/Media/MediaVolumes.php');
+require_once(__CA_APP_DIR__.'/helpers/utilityHelpers.php');
+require_once(__CA_LIB_DIR__.'/ca/BundlableLabelableBaseModelWithAttributes.php');
+require_once(__CA_MODELS_DIR__.'/ca_users.php');
+require_once(__CA_MODELS_DIR__.'/ca_user_groups.php');
+require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
 
 class Installer {
 	# --------------------------------------------------
@@ -1614,6 +1615,10 @@ class Installer {
 		}
 	}
 	# --------------------------------------------------
+	public function processSearchIndexingQueue() {
+		ca_search_indexing_queue::process();
+	}
+	# --------------------------------------------------
 	public function createAdminAccount(){
 		require_once(__CA_MODELS_DIR__."/ca_users.php");
 
@@ -1635,6 +1640,11 @@ class Installer {
 		}
 
 		return $ps_password;
+	}
+	# --------------------------------------------------
+	public function __destruct() {
+		// when done installing, process search indexing queue
+		ca_search_indexing_queue::process();
 	}
 	# --------------------------------------------------
 	private function _processSettings($pt_instance, $po_settings_node) {
@@ -1704,4 +1714,3 @@ class Installer {
 	}
 	# --------------------------------------------------
 }
-?>

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -1642,11 +1642,6 @@ class Installer {
 		return $ps_password;
 	}
 	# --------------------------------------------------
-	public function __destruct() {
-		// when done installing, process search indexing queue
-		ca_search_indexing_queue::process();
-	}
-	# --------------------------------------------------
 	private function _processSettings($pt_instance, $po_settings_node) {
 		$va_settings = array();
 		if($po_settings_node){

--- a/install/inc/page2.php
+++ b/install/inc/page2.php
@@ -72,14 +72,14 @@
 			caSetMessage("There were errors loading the database schema: ".join("; ", $vo_installer->getErrors()));
 		} else {
 		
-			$vn_progress += 5;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Processing locales");
 			$vo_installer->processLocales();
 
 			caIncrementProgress($vn_progress, "Processing lists");
 			$vo_installer->processLists('caGetListToBeLoaded');
 			
-			$vn_progress += 5;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Processing relationship types");
 			$vo_installer->processRelationshipTypes();
 
@@ -91,7 +91,7 @@
 			caIncrementProgress($vn_progress, "Processing metadata dictionary");
 			$vo_installer->processMetadataDictionary();
 			
-			$vn_progress += 6;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Processing access roles");
 			$vo_installer->processRoles();
 			
@@ -106,21 +106,17 @@
 			caIncrementProgress($vn_progress, "Processing user interfaces");
 			$vo_installer->processUserInterfaces();
 			
-			$vn_progress += 5;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Processing displays");
 			$vo_installer->processDisplays();
 			
-			$vn_progress += 5;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Processing search forms");
 			$vo_installer->processSearchForms();
 			
-			$vn_progress += 5;
+			$vn_progress += 7;
 			caIncrementProgress($vn_progress, "Setting up hierarchies");
 			$vo_installer->processMiscHierarchicalSetup();
-
-			$vn_progress += 1;
-			caIncrementProgress($vn_progress, "Indexing records for search");
-			$vo_installer->processSearchIndexingQueue();
 			
 			caIncrementProgress(100, "Installation complete");
 			

--- a/install/inc/page2.php
+++ b/install/inc/page2.php
@@ -72,14 +72,14 @@
 			caSetMessage("There were errors loading the database schema: ".join("; ", $vo_installer->getErrors()));
 		} else {
 		
-			$vn_progress += 7;
+			$vn_progress += 5;
 			caIncrementProgress($vn_progress, "Processing locales");
 			$vo_installer->processLocales();
 
 			caIncrementProgress($vn_progress, "Processing lists");
 			$vo_installer->processLists('caGetListToBeLoaded');
 			
-			$vn_progress += 7;
+			$vn_progress += 5;
 			caIncrementProgress($vn_progress, "Processing relationship types");
 			$vo_installer->processRelationshipTypes();
 
@@ -91,7 +91,7 @@
 			caIncrementProgress($vn_progress, "Processing metadata dictionary");
 			$vo_installer->processMetadataDictionary();
 			
-			$vn_progress += 7;
+			$vn_progress += 6;
 			caIncrementProgress($vn_progress, "Processing access roles");
 			$vo_installer->processRoles();
 			
@@ -106,17 +106,21 @@
 			caIncrementProgress($vn_progress, "Processing user interfaces");
 			$vo_installer->processUserInterfaces();
 			
-			$vn_progress += 7;
+			$vn_progress += 5;
 			caIncrementProgress($vn_progress, "Processing displays");
 			$vo_installer->processDisplays();
 			
-			$vn_progress += 7;
+			$vn_progress += 5;
 			caIncrementProgress($vn_progress, "Processing search forms");
 			$vo_installer->processSearchForms();
 			
-			$vn_progress += 7;
+			$vn_progress += 5;
 			caIncrementProgress($vn_progress, "Setting up hierarchies");
 			$vo_installer->processMiscHierarchicalSetup();
+
+			$vn_progress += 1;
+			caIncrementProgress($vn_progress, "Indexing records for search");
+			$vo_installer->processSearchIndexingQueue();
 			
 			caIncrementProgress(100, "Installation complete");
 			

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -6542,7 +6542,6 @@ create table ca_search_indexing_queue
   field_data      LONGTEXT          not null default '',
   reindex         tinyint unsigned  not null default 0,
   changed_fields  LONGTEXT          not null default '',
-  old_values      LONGTEXT          not null default '',
   options         LONGTEXT          not null default '',
 
   primary key (entry_id),

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -6543,6 +6543,8 @@ create table ca_search_indexing_queue
   reindex         tinyint unsigned  not null default 0,
   changed_fields  LONGTEXT          not null default '',
   options         LONGTEXT          not null default '',
+  is_unindex      tinyint unsigned  not null default 0,
+  dependencies    LONGTEXT          not null default '',
 
   primary key (entry_id),
   index i_table_num_row_id (table_num, row_id)

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -6533,6 +6533,21 @@ create table ca_metadata_dictionary_rule_violations (
       references ca_metadata_dictionary_rules (rule_id) on delete restrict on update restrict
 ) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
 
+/*==========================================================================*/
+create table ca_search_indexing_queue
+(
+  entry_id        int unsigned      not null AUTO_INCREMENT,
+  table_num       tinyint unsigned  not null,
+  row_id          int unsigned      not null,
+  field_data      LONGTEXT          not null default '',
+  reindex         tinyint unsigned  not null default 0,
+  changed_fields  LONGTEXT          not null default '',
+  old_values      LONGTEXT          not null default '',
+  options         LONGTEXT          not null default '',
+
+  primary key (entry_id),
+  index i_table_num_row_id (table_num, row_id)
+) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 /*==========================================================================*/
 /* Schema update tracking                                                   */
@@ -6546,4 +6561,4 @@ create table ca_schema_updates (
 
 /* Indicate up to what migration this schema definition covers */
 /* CURRENT MIGRATION: 116 */
-INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (118, unix_timestamp());
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (120, unix_timestamp());

--- a/support/sql/migrations/120.sql
+++ b/support/sql/migrations/120.sql
@@ -14,6 +14,8 @@ create table ca_search_indexing_queue
   reindex         tinyint unsigned  not null default 0,
   changed_fields  TEXT              not null default '',
   options         LONGTEXT          not null default '',
+  is_unindex      tinyint unsigned  not null default 0,
+  dependencies    LONGTEXT          not null default '',
 
   primary key (entry_id),
   index i_table_num_row_id (table_num, row_id)

--- a/support/sql/migrations/120.sql
+++ b/support/sql/migrations/120.sql
@@ -1,0 +1,24 @@
+/*
+	Date: 2 July 2015
+	Migration: 120
+	Description: Add search indexing queue table
+*/
+
+/*==========================================================================*/
+create table ca_search_indexing_queue
+(
+  entry_id        int unsigned      not null AUTO_INCREMENT,
+  table_num       tinyint unsigned  not null,
+  row_id          int unsigned      not null,
+  field_data      LONGTEXT          not null default '',
+  reindex         tinyint unsigned  not null default 0,
+  changed_fields  LONGTEXT          not null default '',
+  old_values      LONGTEXT          not null default '',
+  options         LONGTEXT          not null default '',
+
+  primary key (entry_id),
+  index i_table_num_row_id (table_num, row_id)
+) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+/* Always add the update to ca_schema_updates at the end of the file */
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (120, unix_timestamp());

--- a/support/sql/migrations/120.sql
+++ b/support/sql/migrations/120.sql
@@ -12,8 +12,7 @@ create table ca_search_indexing_queue
   row_id          int unsigned      not null,
   field_data      LONGTEXT          not null default '',
   reindex         tinyint unsigned  not null default 0,
-  changed_fields  LONGTEXT          not null default '',
-  old_values      LONGTEXT          not null default '',
+  changed_fields  TEXT              not null default '',
   options         LONGTEXT          not null default '',
 
   primary key (entry_id),

--- a/tests/lib/core/Db/DbTest.php
+++ b/tests/lib/core/Db/DbTest.php
@@ -166,7 +166,7 @@ class DbTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertContains('foo', $va_tables);
 		$this->assertContains('bar', $va_tables);
-		$this->assertEquals(205, sizeof($va_tables)); // 203 CA tables plus 2 we created!
+		$this->assertEquals(212, sizeof($va_tables)); // 210 CA tables plus 2 we created!
 	}
 
 	public function testQuote() {

--- a/tests/lib/core/Db/DbTest.php
+++ b/tests/lib/core/Db/DbTest.php
@@ -166,7 +166,7 @@ class DbTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertContains('foo', $va_tables);
 		$this->assertContains('bar', $va_tables);
-		$this->assertEquals(204, sizeof($va_tables)); // 202 CA tables plus 2 we created!
+		$this->assertEquals(205, sizeof($va_tables)); // 203 CA tables plus 2 we created!
 	}
 
 	public function testQuote() {

--- a/tests/testsWithData/BaseTestWithData.php
+++ b/tests/testsWithData/BaseTestWithData.php
@@ -90,7 +90,6 @@ abstract class BaseTestWithData extends PHPUnit_Framework_TestCase {
 
 		$this->opa_record_map[$ps_table][] = $vn_return = array_shift($va_return);
 
-		ca_search_indexing_queue::process();
 		return $vn_return;
 	}
 	# -------------------------------------------------------

--- a/tests/testsWithData/BaseTestWithData.php
+++ b/tests/testsWithData/BaseTestWithData.php
@@ -31,7 +31,8 @@
  */
 
 require_once(__CA_LIB_DIR__.'/ca/Service/ItemService.php');
-require_once(__CA_LIB_DIR__."/core/Search/SearchIndexer.php");
+require_once(__CA_LIB_DIR__.'/core/Search/SearchIndexer.php');
+require_once(__CA_MODELS_DIR__.'/ca_search_indexing_queue.php');
 
 abstract class BaseTestWithData extends PHPUnit_Framework_TestCase {
 	/**
@@ -88,6 +89,8 @@ abstract class BaseTestWithData extends PHPUnit_Framework_TestCase {
 		}
 
 		$this->opa_record_map[$ps_table][] = $vn_return = array_shift($va_return);
+
+		ca_search_indexing_queue::process();
 		return $vn_return;
 	}
 	# -------------------------------------------------------


### PR DESCRIPTION
The default behavior is still to do it in place, but if you pass the queueIndexing=true option to insert(), update() or delete(), it'll defer indexing using the ca_search_indexing_queue table.

There's a new "micro service" in index.php that runs the queue using a static function in the ca_search_indexing_queue model. It's not pretty to do it there but I figured we may not want to run this trough the full-blown MVC structure. The service gets called with a non-blocking async fsockopen() call during RequestHTTP::close(). There's also a CLI utility to run the queue by hand, just in case.

The queue processor uses semaphores to make sure only one processor is running at a time. I would love to change this to a non-blocking solution soon. I wasn't quite able to figure it out using flock(). The lock would just not get released in some cases and then nobody could get a new one. Will look into it.

All the calls in saveBundlesForScreen() now use queueing. I hope. That function is insane.

The last noteworthy thing is that the SearchIndexer keeps the queue in memory until it's destructed. Then it inserts the entries into the ca_search_indexing_queue table. We do a fairly good job at not instantiating unnecessary SearchIndexers so this works pretty well.