### PR TITLE
NOJIRA : add representation through ItemService WebService

### DIFF
--- a/app/lib/ca/Service/ItemService.php
+++ b/app/lib/ca/Service/ItemService.php
@@ -939,18 +939,53 @@ class ItemService extends BaseJSONService {
             }
         }
 
+        if ($va_post["remove_representations"]) {
+            foreach($va_post["remove_representations"] as $va_representation_id) {
+                $t_instance->removeRepresentation($va_representation_id);
+            }
+        }
+
         if(is_array($va_post["add_representations"])) {
             if($this->getTableName() == "ca_objects") {
-                //die("we have a representation and the object is in ca_objects.");
-                foreach($va_post["add_representations"] as $va_representation) {
-                    // Media path is mandatory
-                    if (!isset($va_representation["media_path"])) continue;
-                    // Only URL are supported for now
-                    if (!isURL($va_representation["media_path"])) continue;
+                // Numbering the representations to allow temp file easier naming
+                $vn_representation_file = 1;
 
+                foreach($va_post["add_representations"] as $va_representation) {
+                    // One of media path or media content is mandatory
+                    if (!(isset($va_representation["media_path"]) || isset($va_representation["media_content"]))) continue;
+
+                    // If we have a submitted filename, add it to the options
+                    if ($va_representation["filename"]) {
+                        $va_options = array("original_filename" => $va_representation["filename"]);
+                    } else {
+                        $va_options = array();
+                    }
+
+                    if (isURL($va_representation["media_path"])) {
+                        // We have an URL
+                        $vs_media_path = $va_representation["media_path"];
+                    } elseif ($va_representation["media_content"]) {
+                        // We have a base64 media encoded
+                        $vs_temp_extension = pathinfo($va_representation["filename"], PATHINFO_EXTENSION);
+                        $vs_temp_path = caGetTempFileName("media".$vn_representation_file, $vs_temp_extension);
+                        $vs_temp_file_pointer = fopen($vs_temp_path, 'w');
+                        if (!fwrite($vs_temp_file_pointer, base64_decode($va_representation["media_content"]))) {
+                            $vs_error = join("; ", _t("unable to write media to temp file:").$vs_temp_path);
+                        }
+                        fclose($vs_temp_file_pointer);
+                        $vs_media_path = $vs_temp_path;
+
+                        // Avoid treating empty temp files
+                        if (!filesize($vs_temp_path)) {
+                            $vs_error = join("; ", _t("empty temp file:").$vs_temp_path);
+                            continue;
+                        }
+                    }
+
+                    // Inserting the representation
                     if (!($t_instance->addRepresentation(
                         // media_path - the path to the media you want to add
-                        $va_representation["media_path"],
+                        $vs_media_path,
                         // type_id - the item_id of the representation type, in the ca_list with list_code 'object_represention_types'
                         isset($va_representation["type_id"]) ? $va_representation["type_id"] : caGetDefaultItemID('object_representation_types'),
                         // locale_id - the locale_id of the locale of the representation
@@ -961,17 +996,20 @@ class ItemService extends BaseJSONService {
                         caGetDefaultItemID('access_statuses'),
                         // is_primary - if set to true, representation is designated "primary." Primary representation are used in cases where only one representation is required (such as search results). If a primary representation is already attached to this item, then it will be changed to non-primary as only one representation can be primary at any given time. If no primary representations exist, then the new representation will always be marked primary no matter what the setting of this parameter (there must always be a primary representation, if representations are defined).
                         (isset($va_representation["primary"]) && ($va_representation["primary"])) ? true : false,
-                        // values - array of attributes to attach to new representation ; not supported for now
+                        // values - array of attributes to attach to new representation ; not handled here for now
                         array(),
                         /* options
                          * original_filename (the name of the file being uploaded) ; rank (numeric rank used to order the representations when listed) ;
                          * centerX (Horizontal position of image center used when cropping as a percentage expressed as a decimal between 0 and 1) ;
                          * center Y (same for vertical position)
                          */
-                        array()))
+                        $va_options
+                        ))
                     ) {
                         $vs_error = join("; ", $t_subject->getErrors());
                     }
+                        // file numbering for temp file easier naming
+                    $vn_representation_file++;
                 }
             }
         }


### PR DESCRIPTION
Hi @skeidel  & @SethKaufman 

This PR implements addRepresentation to ca_objects through Web Services (ItemService).
I'm bringing it to allow representation upload through my Titanium mobile app for ipad (called Newport, I thought a Rhode Island city name could be a tribute to Seth huge work).

This is fairly working through my tests, this is a early pull request to have your look inside this piece of code, and see if this could manage to go to the master branch in the future.

Syntax for the body request to http://providence.dev/service.php/item/ca_objects/id/14 is this one :
````json
{
    "intrinsic_fields" : {
        "idno" : "TEST-123",
        "type_id" : 24
    },
    "preferred_labels" : [
        {
            "locale" : "en_US",
          "name" : "test 1"
        }
    ],
    "add_representations" : [
      {
        "filename" : "icon.jpg",
        "media_content" : "/9j/4AAQSkZJRgABAQAAAQABAAD//gA7Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcgSlBFRyB2NjIpLCBxdWFsaXR5ID0gOTMK/9sAQwACAgICAgECAgICAwICAwMGBAMDAwMHBQUEBggHCQgIBwgICQoNCwkKDAoICAsPCwwNDg4PDgkLEBEQDhENDg4O/9sAQwECAwMDAwMHBAQHDgkICQ4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4O/8AAEQgAMAAwAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/Xjxv8f9P8MfGq28BaL4dk8Ta29tNPM/9oR2sMXkmIOm4hiWHnxnGO5xnBxNa/FXxzqCKbbwLolsT/z8eJ5mI/BLMj9a+YfjzZQeGP2/PDmtL8raleQbyScLHNA9qVHYbpmibnGdnqBXc6X4p8cWvihrOLwxoSaX5pW3vb/xa1vJMvZvKW0fB9t341uoxtcxcnex9C22v/EvUFULaeHtMyeSpubn+ax10VvY/EKWESXHinSISeSkXh9z+puf6Vw2ieL7eOaK31HxR4TttQlDGK0h1cSuAoyxGSpfGRnCjFegWesNckNHr0Nyp7WmmvIPzBNZNq9kaK/U3tHmvXsp7fUZo7m7t5vLeaOLy1kBVWDbcnH3sde1a9c5ausPj6WMB8XliJAWBABibB4PQkSrx/s+xro6Q0fAX7b9nd2OneFvFNlGXe0t5ZpChCszWk0VxFGD6sxOB3xjvWnryeDNO1PSfETt8PtDmvrUJFq/iqyjkubhB86pG7PGzqA+du/jd05r1f8Aao0KDVv2X31CeHzotI1GK7lABJKENEVwOoLOnHtXgnwx8Qardfsj+CbqLX7Tw7qFhANN1G7utOa83Pas9pIqKJEwxkiBDfMMcbTkEax1iZy0Zq+LNavNZ+HsNx4a8eadd+INHnF9pTeFfAt5KC6qVeMPHJNw6M68Y6jpjNdJ4C+JfxTuvh/Z6v8A2FqPjnQ5UP2i40/SpdN1OzcH50a3nULNjGNyHewwQgzVT+2dTn1BYo/HvxK1WRsfuNE8F28Fvk56TTWGB06+d+Ndb4H8N3+manfG28IeOWtLt/OZta8XRQR+bjr5dtdsAG4yPLHQcV8pmmQYPMqyxF5U60VZVIO0kuz3Ul5ST8rHq4THSw0XTlCM4PdSX5NWa+T163PQPDnxF8N+LNe0mTRdTZ9U0+58vUdOvswX0SurKwkhkw6lSytjGcLXuKOkibkYOvqDXztr/wANF8VeHdQHiTwVo+i3qWzNpWsad4guLzUoJznBErQRMgHynAkYMeCCOur4W8BeN7Lxf4W1ez+KF7eeCIYzcyaTf6fG93ciSLCRSXAxuRd24YRTkDJNeZhf9ZsDiIUcQo4ii3bnXuTiu8ovSS84u7fRHbUhldeDnRm6ckr8stU/KMkuvmkvM634s2dtrf7N3jjSSySXEujTvbxtzmZEMkf/AI+q1+dvwa8e2vh2K10a7lV9O1WFb+xbzgrvKQI7kxlyFdfNjldlBDKSSN4kxH+iPj7w7qN7oE93oshF4qHMJPyye1fBOifAvVde+C6eC/FPgm9aTS9SlfR7m1uBDJbpkMsiyA5Vt5c46YODwSK+8i0j56SufX/hvV7TWPD9lqVlL51rcRh4274PYjsQeCOxBFegWd0rMqq3yDqa+T/AfwL+MHhS2Npo/iwWWlvIXlh1GIXDPweSPuhsnJZApY43bsDHs9l8IPGVxEBr3xEvpQeq2Si22/Qx4NW3ESTPbLm6tf7FPmXEaYHdxVDwZfQXfhW4gguFulsr6a38xWDKRu3qAR6K6r+FcDB8CvCToP7bnvvET5zu1G5aY/m2TXq+jaNp2gaBBpelW62tlCMRxL0UVlpYvW5//9k=",
        "primary" : "true"
      },
     {
        "media_path" : "http://www.collectiveaccess.org/sites/all/themes/collectiveaccess/img/body_logo.png",
        "primary" : "false"
     }
    ]
}
````

It brings the usual base64 overweight to the request, but everything is sent in the body.

Wishing you a sunny sunday,
Bye,

Gautier