### PR TITLE
LDAP authentication refactor

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -83,7 +83,7 @@ ldap_users_auto_active = 1
 # It defines the name of the user record attribute that contains a list of
 # groups the user belongs to. It is used to check for group membership if the above
 # ldap_group_cn_list is set and not empty.
-ldap_attribute_member_of = memberof
+ldap_attribute_member_of = memberOf
 
 # Uncomment to display a 'manage account' link on the login page
 # ldap_manage_account_url = http://www.mysite.org/ldap/manage

--- a/app/controllers/system/AuthController.php
+++ b/app/controllers/system/AuthController.php
@@ -46,7 +46,7 @@
  		public function DoLogin() {
  			global $g_ui_locale;
 			$vs_redirect_url = $this->request->getParameter('redirect', pString) ?: caNavUrl($this->request, null, null, null);
-			if (!$this->request->doAuthentication(array('dont_redirect' => true, 'noPublicUsers' => true, 'user_name' => $this->request->getParameter('username', pString), 'password' => $this->request->getParameter('password', pString)))) {
+			if (!$this->request->doAuthentication(array('redirect' => $vs_redirect_url, 'noPublicUsers' => true, 'user_name' => $this->request->getParameter('username', pString), 'password' => $this->request->getParameter('password', pString)))) {
 				$this->notification->addNotification(_t("Login was invalid"), __NOTIFICATION_TYPE_ERROR__);
  				
  				$this->view->setVar('notifications', $this->notification->getNotifications());

--- a/app/lib/core/Auth/AbstractLDAPAuthAdapter.php
+++ b/app/lib/core/Auth/AbstractLDAPAuthAdapter.php
@@ -1,0 +1,306 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/core/Auth/AbstractLDAPAuthAdapter.php : Abstract base class for LDAP adapters
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2014 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Auth
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+require_once(__CA_LIB_DIR__.'/core/Auth/BaseAuthAdapter.php');
+require_once(__CA_LIB_DIR__.'/core/Auth/PasswordHash.php');
+
+abstract class AbstractLDAPAuthAdapter extends BaseAuthAdapter {
+    private $opo_auth_config;
+    private $opo_ldap;
+    # --------------------------------------------------------------------------------
+    public function __construct() {
+        if (!function_exists("ldap_connect")){
+            throw new LDAPException(_t("PHP's LDAP module is required for LDAP authentication!"));
+        }
+
+        $this->opo_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
+        $this->opo_ldap = ldap_connect($this->getConfigValue("ldap_host"), $this->getConfigValue("ldap_port"));
+
+        if (!$this->opo_ldap) {
+            throw new LDAPException(_t("Could not connect to LDAP server."));
+        }
+
+        foreach ($this->getLDAPOptions() as $key => $value) {
+            ldap_set_option($this->opo_ldap, $key, $value);
+        }
+    }
+    # --------------------------------------------------------------------------------
+    public function __destruct() {
+        if ($this->opo_ldap) {
+            ldap_close($this->opo_ldap);
+        }
+    }
+    # --------------------------------------------------------------------------------
+    public function authenticate($ps_username, $ps_password = '', $pa_options=null) {
+        $vo_bind = $this->bindToDirectory($ps_username, $ps_password);
+        if (!$vo_bind) {
+            if (ldap_get_option($this->getLinkIdentifier(), 0x0032, $extended_error)) {
+                $vs_bind_rdn = $this->getProcessedConfigValue("ldap_bind_rdn_format", $ps_username, "", "");
+                caLogEvent("ERR", "LDAP ERROR (".ldap_errno($this->getLinkIdentifier()).") {$extended_error} [{$vs_bind_rdn}]", "OpenLDAP::Authenticate");
+            }
+            return false;
+        }
+
+        // check group membership
+        if (!$this->hasRequiredGroupMembership($ps_username)) {
+            return false;
+        }
+
+        // user role and group membership syncing with directory
+        $this->syncWithDirectory($ps_username);
+
+        return true;
+    }
+    # --------------------------------------------------------------------------------
+    public function getUserInfo($ps_username, $ps_password) {
+        // ldap config
+        $vs_base_dn = $this->getConfigValue("ldap_base_dn");
+        $vs_user_ou = $this->getConfigValue("ldap_user_ou");
+        $vs_search_dn = $this->getProcessedConfigValue("ldap_user_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
+        $vs_search_filter = $this->getProcessedConfigValue("ldap_user_search_filter_format", $ps_username, $vs_user_ou, $vs_base_dn);
+
+        $vo_bind = $this->bindToDirectory($ps_username, $ps_password);
+        if (!$vo_bind) {
+            // wrong credentials
+            throw new LDAPException(_t("User could not be authenticated with LDAP server."));
+        }
+
+        // check group membership
+        if (!$this->hasRequiredGroupMembership($ps_username)) {
+            throw new LDAPException(_t("User is not member of at least one of the required groups."));
+        }
+
+        /* query directory service for additional info on user */
+        $vo_results = @ldap_search($this->getLinkIdentifier(), $vs_search_dn, $vs_search_filter);
+        if (!$vo_results) {
+            // search error
+            $vs_message = _t("LDAP search error: %1", ldap_error($this->getLinkIdentifier()));
+            throw new LDAPException($vs_message);
+        }
+
+        $vo_entry = ldap_first_entry($this->getLinkIdentifier(), $vo_results);
+        if (!$vo_entry) {
+            // no results returned
+            throw new LDAPException(_t("User could not be found."));
+        }
+
+        $va_attrs = ldap_get_attributes($this->getLinkIdentifier(), $vo_entry);
+
+        return array(
+            'user_name' => $ps_username,
+            'email' => $va_attrs[$this->getConfigValue("ldap_attribute_email")][0],
+            'fname' => $va_attrs[$this->getConfigValue("ldap_attribute_fname")][0],
+            'lname' => $va_attrs[$this->getConfigValue("ldap_attribute_lname")][0],
+            'active' => $this->getConfigValue("ldap_users_auto_active"),
+            'roles' => array_merge($this->getConfigValue("ldap_users_default_roles", array()), $this->getRolesToAddFromDirectory($ps_username)),
+            'groups' => array_merge($this->getConfigValue("ldap_users_default_groups", array()), $this->getGroupsToAddFromDirectory($ps_username))
+        );
+    }
+    # --------------------------------------------------------------------------------
+    public function createUserAndGetPassword($ps_username, $ps_password) {
+        // We don't create users in directories, we assume they're already there
+
+        // TODO FIXME The following is insecure!
+        // We will create a password hash that is compatible with the CaUsers authentication adapter though
+        // That way users could, in theory, turn off LDAP authentication later. The hash will not be used
+        // for authentication in this adapter though.
+        return create_hash($ps_password);
+    }
+    # --------------------------------------------------------------------------------
+    protected function getLinkIdentifier() {
+        return $this->opo_ldap;
+    }
+    # --------------------------------------------------------------------------------
+    protected function getConfigValue($ps_key, $pm_default_value = null) {
+        $vm_result = $this->opo_auth_config->get($ps_key);
+        if ($pm_default_value && !$vm_result) {
+            $vm_result = $pm_default_value;
+        }
+        return $vm_result;
+    }
+    # --------------------------------------------------------------------------------
+    protected function getProcessedConfigValue($ps_key, $ps_user_group_name, $ps_user_ou, $ps_base_dn) {
+        $result = $this->getConfigValue($ps_key);
+        $result = str_replace('{username}', $ps_user_group_name, $result);
+        $result = str_replace('{groupname}', $ps_user_group_name, $result);
+        $result = str_replace('{user_ou}', $ps_user_ou, $result);
+        $result = str_replace('{base_dn}', $ps_base_dn, $result);
+        return $result;
+    }
+    # --------------------------------------------------------------------------------
+    public function supports($pn_feature) {
+        switch($pn_feature){
+            case __CA_AUTH_ADAPTER_FEATURE_AUTOCREATE_USERS__:
+                return true;
+            case __CA_AUTH_ADAPTER_FEATURE_RESET_PASSWORDS__:
+            case __CA_AUTH_ADAPTER_FEATURE_UPDATE_PASSWORDS__:
+            default:
+                return false;
+        }
+    }
+    # --------------------------------------------------------------------------------
+    public function deleteUser($ps_username) {
+        // do something?
+        return true;
+    }
+    # --------------------------------------------------------------------------------
+    public function getAccountManagementLink() {
+        if($vs_link = $this->getConfigValue('ldap_manage_account_url')) {
+            return $vs_link;
+        }
+        return false;
+    }
+    # --------------------------------------------------------------------------------
+    /**
+     * Determine if the user has at least one required group membership.  If no required group list is configured, this
+     * method should always return `true`.  By default, this method always returns `true`.
+     *
+     * @param $ps_username string The username
+     *
+     * @return boolean
+     */
+    protected function hasRequiredGroupMembership($ps_username){
+        $va_group_cn_list = $this->getConfigValue("ldap_group_cn_list");
+        if (!is_array($va_group_cn_list) || sizeof($va_group_cn_list) === 0) {
+            // if no list is configured, all is good
+            return true;
+        }
+        return $this->isUserInAnyGroup($ps_username, $va_group_cn_list);
+    }
+    # --------------------------------------------------------------------------------
+    /**
+     * Generate a map of keys and values to pass to `ldap_set_option()`.  As a minimum, this should specify the LDAP
+     * protocol version to use.  By default it specifies an LDAP protocol version of 3 and no other options.
+     *
+     * @return array
+     */
+    protected abstract function getLDAPOptions();
+    # --------------------------------------------------------------------------------
+    /**
+     * Determine whether the given user is in any of the given groups, using the given LDAP connection.
+     *
+     * @param $ps_username string
+     * @param $pa_group_cn_list array[string]
+     *
+     * @return bool True if the user is in the group, otherwise false.
+     */
+    protected abstract function isUserInAnyGroup($ps_username, $pa_group_cn_list);
+    # --------------------------------------------------------------------------------
+    /**
+     * Get an array of CA role names to add to the given user after logging in, based on security group assignments in
+     * the directory.
+     *
+     * @param $ps_username string
+     *
+     * @return array
+     */
+    protected abstract function getRolesToAddFromDirectory($ps_username);
+    # --------------------------------------------------------------------------------
+    /**
+     * Get an array of CA group names to add to the given user after logging in, based on security group assignments
+     * in the directory.
+     *
+     * @param $ps_username string
+     *
+     * @return array
+     */
+    protected abstract function getGroupsToAddFromDirectory($ps_username);
+    # --------------------------------------------------------------------------------
+    private function bindToDirectory($ps_username, $ps_password) {
+        if (!$ps_username) {
+            return false;
+        }
+
+        // ldap config
+        $vs_user_ou = $this->getConfigValue("ldap_user_ou");
+        $vs_base_dn = $this->getConfigValue("ldap_base_dn");
+        $vs_bind_rdn = $this->getProcessedConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
+        $vs_bind_rdn_filter = $this->getProcessedConfigValue("ldap_bind_rdn_filter", $ps_username, $vs_user_ou, $vs_base_dn);
+
+        // apply filter to bind, if there is one
+        if (strlen($vs_bind_rdn_filter) > 0) {
+            $vo_dn_search_results = ldap_search($this->getLinkIdentifier(), $vs_base_dn, $vs_bind_rdn_filter);
+            $va_dn_search_results = ldap_get_entries($this->getLinkIdentifier(), $vo_dn_search_results);
+            if (isset($va_dn_search_results[0]['dn'])) {
+                $vs_bind_rdn = $va_dn_search_results[0]['dn'];
+            }
+        }
+
+        // log in
+        return @ldap_bind($this->getLinkIdentifier(), $vs_bind_rdn, $ps_password);
+    }
+    # --------------------------------------------------------------------------------
+    private function syncWithDirectory($ps_username) {
+        $va_default_roles = $this->getConfigValue("ldap_users_default_roles", array());
+        $va_default_groups = $this->getConfigValue("ldap_users_default_groups", array());
+        $t_user = new ca_users();
+
+        // don't try to sync roles for non-existing users (the first auth call is before the user is actually created)
+        if (!$t_user->load($ps_username)) {
+            return;
+        }
+
+        if ($this->getConfigValue('ldap_sync_user_roles')) {
+            $va_expected_roles = array_merge($va_default_roles, $this->getRolesToAddFromDirectory($ps_username));
+
+            foreach($va_expected_roles as $vs_role) {
+                if(!$t_user->hasUserRole($vs_role)) {
+                    $t_user->addRoles($vs_role);
+                }
+            }
+
+            foreach($t_user->getUserRoles() as $vn_id => $va_role_info) {
+                if(!in_array($va_role_info['code'], $va_expected_roles)) {
+                    $t_user->removeRoles($vn_id);
+                }
+            }
+        }
+
+        if ($this->getConfigValue('ldap_sync_user_groups')) {
+            $va_expected_groups = array_merge($va_default_groups, $this->getGroupsToAddFromDirectory($ps_username));
+
+            foreach($va_expected_groups as $vs_group) {
+                if(!$t_user->inGroup($vs_group)) {
+                    $t_user->addToGroups($vs_group);
+                }
+            }
+
+            foreach($t_user->getUserGroups() as $vn_id => $va_group_info) {
+                if(!in_array($va_group_info['code'], $va_expected_groups)) {
+                    $t_user->removeFromGroups($vn_id);
+                }
+            }
+        }
+    }
+}
+
+class LDAPException extends Exception {}

--- a/app/lib/core/Auth/Adapters/ActiveDirectory.php
+++ b/app/lib/core/Auth/Adapters/ActiveDirectory.php
@@ -30,234 +30,66 @@
  * ----------------------------------------------------------------------
  */
 
-require_once(__CA_LIB_DIR__.'/core/Auth/BaseAuthAdapter.php');
-require_once(__CA_LIB_DIR__.'/core/Auth/PasswordHash.php');
+require_once(__CA_LIB_DIR__.'/core/Auth/AbstractLDAPAuthAdapter.php');
 
-class ActiveDirectoryAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
-	# --------------------------------------------------------------------------------
-	public static function authenticate($ps_username, $ps_password = '', $pa_options=null) {
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-		
-		if(!function_exists("ldap_connect")){
-			throw new ActiveDirectoryException(_t("PHP's LDAP module is required for LDAP authentication!"));
-		}
-
-		if(!$ps_username) {
-			return false;
-		}
-
-		// ldap config
-		$vs_ldaphost = $o_auth_config->get("ldap_host");
-		$vs_ldapport = $o_auth_config->get("ldap_port");
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-		$vs_user_ou = $o_auth_config->get("ldap_user_ou");
-		$vs_bind_rdn = self::postProcessLDAPConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-
-		$vo_ldap = ldap_connect($vs_ldaphost,$vs_ldapport);
-		
-		ldap_set_option($vo_ldap, LDAP_OPT_REFERRALS, 0);
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-
-		if (!$vo_ldap) {
-			return false;
-		}
-		
-		$vs_bind_rdn_filter = self::postProcessLDAPConfigValue("ldap_bind_rdn_filter", $ps_username, $vs_user_ou, $vs_base_dn);
-		if(strlen($vs_bind_rdn_filter)>0) {
-			
-			$vo_filter_bind = @ldap_bind($vo_ldap, $o_auth_config->get("ldap_bind_rdn_filter_rdn"), $o_auth_config->get("ldap_bind_rdn_filter_password"));
-			$vo_dn_search_results = ldap_search($vo_ldap, $vs_base_dn, $vs_bind_rdn_filter);
-			$va_dn_search_results = ldap_get_entries($vo_ldap, $vo_dn_search_results);
-			if(isset($va_dn_search_results[0]['dn'])) {
-				$vs_bind_rdn = $va_dn_search_results[0]['dn'];
-			}
-		}
-
-		// log in
-		$vo_bind = @ldap_bind($vo_ldap, $vs_bind_rdn, $ps_password);
-
-		if(!$vo_bind) { // wrong credentials
-			ldap_unbind($vo_ldap);
-			return false;
-		}
-
-		// check group membership
-		if(!self::isMemberinAtLeastOneGroup($ps_username, $vo_ldap)) {
-			ldap_unbind($vo_ldap);
-			return false;
-		}
-
-		ldap_unbind($vo_ldap);
-		return true;
+class ActiveDirectoryAuthAdapter extends AbstractLDAPAuthAdapter {
+	protected function getLDAPOptions() {
+		return array(
+			LDAP_OPT_PROTOCOL_VERSION => 3,
+			LDAP_OPT_REFERRALS => 0
+		);
 	}
 	# --------------------------------------------------------------------------------
-	public static function createUserAndGetPassword($ps_username, $ps_password) {
-		// We don't create users in directories, we assume they're already there
+	protected function isUserInAnyGroup($ps_username, $pa_group_cn_list){
+		$vs_base_dn = $this->getConfigValue("ldap_base_dn");
+		$vs_user_ou = $this->getConfigValue("ldap_user_ou");
+		$vs_user_search_dn = $this->getProcessedConfigValue("ldap_user_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
+		$vs_user_search_filter = $this->getProcessedConfigValue("ldap_user_search_filter_format", $ps_username, $vs_user_ou, $vs_base_dn);
 
-		// We will create a password hash that is compatible with the CaUsers authentication adapter though
-		// That way users could, in theory, turn off LDAP authentication later. The hash will not be used
-		// for authentication in this adapter though.
-		return create_hash($ps_password);
-	}
-	# --------------------------------------------------------------------------------
-	public static function getUserInfo($ps_username, $ps_password) {
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		if(!function_exists("ldap_connect")){
-			throw new ActiveDirectoryException(_t("PHP's LDAP module is required for LDAP authentication!"));
-		}
-
-		// ldap config
-		$vs_ldaphost = $o_auth_config->get("ldap_host");
-		$vs_ldapport = $o_auth_config->get("ldap_port");
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-		$vs_user_ou = $o_auth_config->get("ldap_user_ou");
-		//$va_group_cn = $o_auth_config->getList("ldap_group_cn");
-		$vs_attribute_email = $o_auth_config->get("ldap_attribute_email");
-		$vs_attribute_fname = $o_auth_config->get("ldap_attribute_fname");
-		$vs_attribute_lname = $o_auth_config->get("ldap_attribute_lname");
-		$vs_bind_rdn = self::postProcessLDAPConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_user_search_dn = self::postProcessLDAPConfigValue("ldap_user_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_user_search_filter = self::postProcessLDAPConfigValue("ldap_user_search_filter_format", $ps_username, $vs_user_ou, $vs_base_dn);
-
-		$vo_ldap = ldap_connect($vs_ldaphost,$vs_ldapport);
-		if (!$vo_ldap) {
-			throw new ActiveDirectoryException(_t("Could not connect to LDAP server."));
-		}
-		
-		ldap_set_option($vo_ldap, LDAP_OPT_REFERRALS, 0);
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-		
-		$vs_bind_rdn_filter = self::postProcessLDAPConfigValue("ldap_bind_rdn_filter", $ps_username, $vs_user_ou, $vs_base_dn);
-		if(strlen($vs_bind_rdn_filter)>0) {
-			$vo_filter_bind = @ldap_bind($vo_ldap, $o_auth_config->get("ldap_bind_rdn_filter_rdn"), $o_auth_config->get("ldap_bind_rdn_filter_password"));
-			
-			$vo_dn_search_results = ldap_search($vo_ldap, $vs_base_dn, $vs_bind_rdn_filter);
-			$va_dn_search_results = ldap_get_entries($vo_ldap, $vo_dn_search_results);
-			if(isset($va_dn_search_results[0]['dn'])) {
-				$vs_bind_rdn = $va_dn_search_results[0]['dn'];
-			}
-		}
-
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-		$vo_bind = @ldap_bind($vo_ldap, $vs_bind_rdn, $ps_password);
-		if (!$vo_bind) {
-			// wrong credentials
-			ldap_unbind($vo_ldap);
-			throw new ActiveDirectoryException(_t("User could not be authenticated with LDAP server."));
-		}
-
-		// check group membership
-		if(!self::isMemberinAtLeastOneGroup($ps_username, $vo_ldap)) {
-			ldap_unbind($vo_ldap);
-			throw new ActiveDirectoryException(_t("User is not member of at least one of the required groups."));
-		}
-
-		/* query directory service for additional info on user */
-		$vo_results = @ldap_search($vo_ldap, $vs_user_search_dn, $vs_user_search_filter);
+		$vo_results = ldap_search($this->getLinkIdentifier(), $vs_user_search_dn, $vs_user_search_filter);
 		if (!$vo_results) {
 			// search error
-			$vs_message = _t("LDAP search error: %1", ldap_error($vo_ldap));
-			ldap_unbind($vo_ldap);
-			throw new ActiveDirectoryException($vs_message);
+			return false;
 		}
 
-		$vo_entry = ldap_first_entry($vo_ldap, $vo_results);
+		$vo_entry = ldap_first_entry($this->getLinkIdentifier(), $vo_results);
 		if (!$vo_entry) {
 			// no results returned
-			ldap_unbind($vo_ldap);
-			throw new ActiveDirectoryException(_t("User could not be found."));
+			return false;
 		}
 
-		$va_attrs = ldap_get_attributes($vo_ldap, $vo_entry);
-
+		$va_attrs = ldap_get_attributes($this->getLinkIdentifier(), $vo_entry);
+		$vs_member_of_attr = $this->getConfigValue("ldap_attribute_member_of");
+		return sizeof(array_intersect(array_map('strtolower', $pa_group_cn_list), array_map('strtolower', $va_attrs[$vs_member_of_attr]))) > 0;
+	}
+	# --------------------------------------------------------------------------------
+	protected function getRolesToAddFromDirectory($ps_username) {
 		$va_return = array();
-
-		$va_return['email'] = $va_attrs[$vs_attribute_email][0];
-		$va_return['fname'] = $va_attrs[$vs_attribute_fname][0];
-		$va_return['lname'] = $va_attrs[$vs_attribute_lname][0];
-		$va_return['user_name'] = $ps_username;
-		$va_return['active'] = $o_auth_config->get("ldap_users_auto_active");
-
-		$va_return['roles'] = $o_auth_config->get("ldap_users_default_roles");
-		$va_return['groups'] = $o_auth_config->get("ldap_users_default_groups");
-
+		$va_roles_map = $this->getConfigValue('ldap_roles_group_map');
+		if (is_array($va_roles_map) && sizeof($va_roles_map) > 0) {
+			foreach ($va_roles_map as $vs_ldap_group => $va_ca_roles) {
+				if (is_array($va_ca_roles) && sizeof($va_ca_roles) > 0) {
+					if ($this->isUserInAnyGroup($ps_username, array( $vs_ldap_group ))) {
+						$va_return = array_merge($va_return, $va_ca_roles);
+					}
+				}
+			}
+		}
 		return $va_return;
 	}
 	# --------------------------------------------------------------------------------
-	private static function postProcessLDAPConfigValue($key, $ps_user_group_name, $ps_user_ou, $ps_base_dn) {
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		$result = $o_auth_config->get($key);
-		$result = str_replace('{username}', $ps_user_group_name, $result);
-		$result = str_replace('{groupname}', $ps_user_group_name, $result);
-		$result = str_replace('{user_ou}', $ps_user_ou, $result);
-		$result = str_replace('{base_dn}', $ps_base_dn, $result);
-		return $result;
-	}
-	# --------------------------------------------------------------------------------
-	private static function isMemberinAtLeastOneGroup($ps_user, $po_ldap){
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		$va_group_cn = $o_auth_config->getList("ldap_group_cn_list");
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-		$vs_user_ou = $o_auth_config->get("ldap_user_ou");
-		$vs_attribute_member_of = $o_auth_config->get("ldap_attribute_member_of");
-		$vs_user_search_dn = self::postProcessLDAPConfigValue("ldap_user_search_dn_format", $ps_user, $vs_user_ou, $vs_base_dn);
-		$vs_user_search_filter = self::postProcessLDAPConfigValue("ldap_user_search_filter_format", $ps_user, $vs_user_ou, $vs_base_dn);
-
-		$vo_results = ldap_search($po_ldap, $vs_user_search_dn, $vs_user_search_filter);
-		if (!$vo_results) {
-			// search error
-			ldap_unbind($po_ldap);
-			return false;
-		}
-
-		$vo_entry = ldap_first_entry($po_ldap, $vo_results);
-		if (!$vo_entry) {
-			// no results returned
-			ldap_unbind($po_ldap);
-			return false;
-		}
-
-		$va_attrs = ldap_get_attributes($po_ldap, $vo_entry);
-		if(is_array($va_group_cn) && sizeof($va_group_cn)>0) {
-			if (sizeof(array_intersect(array_map('strtolower', $va_group_cn), array_map('strtolower', $va_attrs[$vs_attribute_member_of]))) === 0) {
-				// user is not in any relevant groups
-				ldap_unbind($po_ldap);
-				return false;
+	protected function getGroupsToAddFromDirectory($ps_username) {
+		$va_return = array();
+		$va_groups_map = $this->getConfigValue('ldap_groups_group_map');
+		if (is_array($va_groups_map) && sizeof($va_groups_map) > 0) {
+			foreach ($va_groups_map as $vs_ldap_group => $va_ca_groups) {
+				if (is_array($va_ca_groups) && sizeof($va_ca_groups) > 0) {
+					if ($this->isUserInAnyGroup($ps_username, array( $vs_ldap_group ))) {
+						$va_return = array_merge($va_return, $va_ca_groups);
+					}
+				}
 			}
 		}
-		return true;
+		return $va_return;
 	}
-	# --------------------------------------------------------------------------------
-	public static function supports($pn_feature) {
-		switch($pn_feature){
-			case __CA_AUTH_ADAPTER_FEATURE_AUTOCREATE_USERS__:
-				return true;
-			case __CA_AUTH_ADAPTER_FEATURE_RESET_PASSWORDS__:
-			case __CA_AUTH_ADAPTER_FEATURE_UPDATE_PASSWORDS__:
-			default:
-				#return false;
-				return true; // TODO: temporary hack to allow display of password change fields in user auth config for fallback logins
-		}
-	}
-	# --------------------------------------------------------------------------------
-	public static function deleteUser($ps_username) {
-		// do something?
-		return true;
-	}
-	# --------------------------------------------------------------------------------
-	public static function getAccountManagementLink() {
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		if($vs_link = $o_auth_config->get('ldap_manage_account_url')) {
-			return $vs_link;
-		}
-
-		return false;
-	}
-	# --------------------------------------------------------------------------------
 }
-
-class ActiveDirectoryException extends Exception {}

--- a/app/lib/core/Auth/Adapters/CaUsers.php
+++ b/app/lib/core/Auth/Adapters/CaUsers.php
@@ -36,7 +36,7 @@ require_once(__CA_MODELS_DIR__.'/ca_users.php');
 
 class CaUsersAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 	# --------------------------------------------------------------------------------
-	public static function authenticate($ps_username, $ps_password = '', $pa_options=null) {
+	public function authenticate($ps_username, $ps_password = '', $pa_options=null) {
 
 		$t_user = new ca_users();
 
@@ -66,12 +66,12 @@ class CaUsersAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		}
 	}
 	# --------------------------------------------------------------------------------
-	public static function createUserAndGetPassword($ps_username, $ps_password) {
+	public function createUserAndGetPassword($ps_username, $ps_password) {
 		// ca_users takes care of creating the backend record for us. There's nothing else to do here
 		return create_hash($ps_password);
 	}
 	# --------------------------------------------------------------------------------
-	public static function supports($pn_feature) {
+	public function supports($pn_feature) {
 		switch($pn_feature){
 			case __CA_AUTH_ADAPTER_FEATURE_RESET_PASSWORDS__:
 			case __CA_AUTH_ADAPTER_FEATURE_UPDATE_PASSWORDS__:
@@ -82,12 +82,12 @@ class CaUsersAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		}
 	}
 	# --------------------------------------------------------------------------------
-	public static function updatePassword($ps_username, $ps_password) {
+	public function updatePassword($ps_username, $ps_password) {
 		// ca_users takes care of creating the backend record for us. There's nothing else to do here
 		return create_hash($ps_password);
 	}
 	# --------------------------------------------------------------------------------
-	public static function deleteUser($ps_username) {
+	public function deleteUser($ps_username) {
 		// ca_users takes care of deleting the db row for us. Nothing else to do here.
 		return true;
 	}

--- a/app/lib/core/Auth/Adapters/ExternalDB.php
+++ b/app/lib/core/Auth/Adapters/ExternalDB.php
@@ -35,7 +35,7 @@ require_once(__CA_LIB_DIR__.'/core/Auth/PasswordHash.php');
 
 class ExternalDBAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 	# --------------------------------------------------------------------------------
-	public static function authenticate($ps_username, $ps_password = '', $pa_options=null) {
+	public function authenticate($ps_username, $ps_password = '', $pa_options=null) {
 		if(!$ps_username) {
 			return false;
 		}
@@ -97,7 +97,7 @@ class ExternalDBAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		return false;
 	}
 	# --------------------------------------------------------------------------------
-	public static function createUserAndGetPassword($ps_username, $ps_password) {
+	public function createUserAndGetPassword($ps_username, $ps_password) {
 		// We don't create users in external databases, we assume they're already there
 
 		// We will create a password hash that is compatible with the CaUsers authentication adapter though
@@ -106,7 +106,7 @@ class ExternalDBAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		return create_hash($ps_password);
 	}
 	# --------------------------------------------------------------------------------
-	public static function getUserInfo($ps_username, $ps_password) {
+	public function getUserInfo($ps_username, $ps_password) {
 		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
 
 		// external database config
@@ -241,7 +241,7 @@ class ExternalDBAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		return $va_return;
 	}
 	# --------------------------------------------------------------------------------
-	public static function supports($pn_feature) {
+	public function supports($pn_feature) {
 		switch($pn_feature){
 			case __CA_AUTH_ADAPTER_FEATURE_AUTOCREATE_USERS__:
 				return true;
@@ -252,12 +252,12 @@ class ExternalDBAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		}
 	}
 	# --------------------------------------------------------------------------------
-	public static function deleteUser($ps_username) {
+	public function deleteUser($ps_username) {
 		// do something?
 		return true;
 	}
 	# --------------------------------------------------------------------------------
-	public static function getAccountManagementLink() {
+	public function getAccountManagementLink() {
 		$o_auth_cfg = Configuration::load(Configuration::load()->get('authentication_config'));
 
 		if($vs_link = $o_auth_cfg->get('extdb_manage_account_url')) {

--- a/app/lib/core/Auth/Adapters/OpenLDAP.php
+++ b/app/lib/core/Auth/Adapters/OpenLDAP.php
@@ -30,272 +30,62 @@
  * ----------------------------------------------------------------------
  */
 
-require_once(__CA_LIB_DIR__.'/core/Auth/BaseAuthAdapter.php');
-require_once(__CA_LIB_DIR__.'/core/Auth/PasswordHash.php');
+require_once(__CA_LIB_DIR__.'/core/Auth/AbstractLDAPAuthAdapter.php');
 
-class OpenLDAPAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
-	# --------------------------------------------------------------------------------
-	public static function authenticate($ps_username, $ps_password = '', $pa_options=null) {
-		$po_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-		
-		if(!function_exists("ldap_connect")){
-			throw new OpenLDAPException(_t("PHP's LDAP module is required for LDAP authentication!"));
-		}
-
-		if(!$ps_username) {
-			return false;
-		}
-
-		// ldap config
-		$vs_ldaphost = $po_auth_config->get("ldap_host");
-		$vs_ldapport = $po_auth_config->get("ldap_port");
-		$vs_base_dn = $po_auth_config->get("ldap_base_dn");
-		$vs_user_ou = $po_auth_config->get("ldap_user_ou");
-		$vs_bind_rdn = self::postProcessLDAPConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$va_default_roles = $po_auth_config->get("ldap_users_default_roles");
-		if(!is_array($va_default_roles)) { $va_default_roles = array(); }
-		$va_default_groups = $po_auth_config->get("ldap_users_default_groups");
-		if(!is_array($va_default_groups)) { $va_default_groups = array(); }
-
-
-		$vo_ldap = ldap_connect($vs_ldaphost,$vs_ldapport);
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-
-		if (!$vo_ldap) {
-			return false;
-		}
-
-		$vs_bind_rdn_filter = self::postProcessLDAPConfigValue("ldap_bind_rdn_filter", $ps_username, $vs_user_ou, $vs_base_dn);
-		if(strlen($vs_bind_rdn_filter)>0) {
-			$vo_dn_search_results = ldap_search($vo_ldap, $vs_base_dn, $vs_bind_rdn_filter);
-			$va_dn_search_results = ldap_get_entries($vo_ldap, $vo_dn_search_results);
-			if(isset($va_dn_search_results[0]['dn'])) {
-				$vs_bind_rdn = $va_dn_search_results[0]['dn'];
-			}
-		}
-
-		// log in
-		$vo_bind = @ldap_bind($vo_ldap, $vs_bind_rdn, $ps_password);
-		if(!$vo_bind) { // wrong credentials
-			if (ldap_get_option($vo_ldap, 0x0032, $extended_error)) {
-				caLogEvent("ERR", "LDAP ERROR (".ldap_errno($vo_ldap).") {$extended_error} [{$vs_bind_rdn}]", "OpenLDAP::Authenticate");
-			}
-			ldap_unbind($vo_ldap);
-			return false;
-		}
-
-		// check group membership
-		if(!self::isMemberinAtLeastOneGroup($ps_username, $vo_ldap)) {
-			ldap_unbind($vo_ldap);
-			return false;
-		}
-
-		// user role and group membership syncing with directory
-		$t_user = new ca_users();
-		if($t_user->load($ps_username)) { // don't try to sync roles for non-existing users (the first auth call is before the user is actually created)
-
-			if($po_auth_config->get('ldap_sync_user_roles')) {
-				$va_expected_roles = array_merge($va_default_roles, self::getRolesToAddFromDirectory($ps_username, $vo_ldap));
-
-				foreach($va_expected_roles as $vs_role) {
-					if(!$t_user->hasUserRole($vs_role)) {
-						$t_user->addRoles($vs_role);
-					}
-				}
-
-				foreach($t_user->getUserRoles() as $vn_id => $va_role_info) {
-					if(!in_array($va_role_info['code'], $va_expected_roles)) {
-						$t_user->removeRoles($vn_id);
-					}
-				}
-			}
-
-			if($po_auth_config->get('ldap_sync_user_groups')) {
-				$va_expected_groups = array_merge($va_default_groups, self::getGroupsToAddFromDirectory($ps_username, $vo_ldap));
-
-				foreach($va_expected_groups as $vs_group) {
-					if(!$t_user->inGroup($vs_group)) {
-						$t_user->addToGroups($vs_group);
-					}
-				}
-
-				foreach($t_user->getUserGroups() as $vn_id => $va_group_info) {
-					if(!in_array($va_group_info['code'], $va_expected_groups)) {
-						$t_user->removeFromGroups($vn_id);
-					}
-				}
-			}
-
-		}
-
-		ldap_unbind($vo_ldap);
-		return true;
+class OpenLDAPAuthAdapter extends AbstractLDAPAuthAdapter {
+	protected function getLDAPOptions() {
+		return array(
+			LDAP_OPT_PROTOCOL_VERSION => 3
+		);
 	}
 	# --------------------------------------------------------------------------------
-	public static function createUserAndGetPassword($ps_username, $ps_password) {
-		// We don't create users in directories, we assume they're already there
+	protected function isUserInAnyGroup($ps_username, $pa_group_cn_list){
+		$vs_base_dn = $this->getConfigValue("ldap_base_dn");
+		$vs_group_search_dn = $this->getProcessedConfigValue("ldap_group_search_dn_format", '', '', $vs_base_dn);
 
-		// We will create a password hash that is compatible with the CaUsers authentication adapter though
-		// That way users could, in theory, turn off LDAP authentication later. The hash will not be used
-		// for authentication in this adapter though.
-		return create_hash($ps_password);
-	}
-	# --------------------------------------------------------------------------------
-	public static function getUserInfo($ps_username, $ps_password) {
-		$po_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
+		foreach ($pa_group_cn_list as $vs_group_cn) {
+			$vs_search_filter = $this->getProcessedConfigValue("ldap_group_search_filter_format", $vs_group_cn, '', $vs_base_dn);
+			$vo_result = @ldap_search($this->getLinkIdentifier(), $vs_group_search_dn, $vs_search_filter, array("memberuid"));
 
-		if(!function_exists("ldap_connect")){
-			throw new OpenLDAPException(_t("PHP's LDAP module is required for LDAP authentication!"));
-		}
-
-		// ldap config
-		$vs_ldaphost = $po_auth_config->get("ldap_host");
-		$vs_ldapport = $po_auth_config->get("ldap_port");
-		$vs_base_dn = $po_auth_config->get("ldap_base_dn");
-		$vs_user_ou = $po_auth_config->get("ldap_user_ou");
-		$vs_attribute_email = $po_auth_config->get("ldap_attribute_email");
-		$vs_attribute_fname = $po_auth_config->get("ldap_attribute_fname");
-		$vs_attribute_lname = $po_auth_config->get("ldap_attribute_lname");
-		$vs_bind_rdn = self::postProcessLDAPConfigValue("ldap_bind_rdn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_search_dn = self::postProcessLDAPConfigValue("ldap_user_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$vs_search_filter = self::postProcessLDAPConfigValue("ldap_user_search_filter_format", $ps_username, $vs_user_ou, $vs_base_dn);
-		$va_default_roles = $po_auth_config->get("ldap_users_default_roles");
-		if(!is_array($va_default_roles)) { $va_default_roles = array(); }
-		$va_default_groups = $po_auth_config->get("ldap_users_default_groups");
-		if(!is_array($va_default_groups)) { $va_default_groups = array(); }
-
-		$vo_ldap = ldap_connect($vs_ldaphost,$vs_ldapport);
-		if (!$vo_ldap) {
-			throw new OpenLDAPException(_t("Could not connect to LDAP server."));
-		}
-		ldap_set_option($vo_ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
-
-		$vs_bind_rdn_filter = self::postProcessLDAPConfigValue("ldap_bind_rdn_filter", $ps_username, $vs_user_ou, $vs_base_dn);
-		if(strlen($vs_bind_rdn_filter)>0) {
-			$vo_dn_search_results = ldap_search($vo_ldap, $vs_base_dn, $vs_bind_rdn_filter);
-			$va_dn_search_results = ldap_get_entries($vo_ldap, $vo_dn_search_results);
-			if(isset($va_dn_search_results[0]['dn'])) {
-				$vs_bind_rdn = $va_dn_search_results[0]['dn'];
+			if (!$vo_result) {
+				// search error
+				$vs_message = _t("LDAP search error: %1", ldap_error($this->getLinkIdentifier()));
+				throw new LDAPException($vs_message);
 			}
-		}
 
-		$vo_bind = @ldap_bind($vo_ldap, $vs_bind_rdn, $ps_password);
-		if (!$vo_bind) {
-			// wrong credentials
-			ldap_unbind($vo_ldap);
-			throw new OpenLDAPException(_t("User could not be authenticated with LDAP server."));
-		}
-
-		// check group membership
-		if(!self::isMemberinAtLeastOneGroup($ps_username, $vo_ldap)) {
-			ldap_unbind($vo_ldap);
-			throw new OpenLDAPException(_t("User is not member of at least one of the required groups."));
-		}
-
-		/* query directory service for additional info on user */
-		$vo_results = @ldap_search($vo_ldap, $vs_search_dn, $vs_search_filter);
-		if (!$vo_results) {
-			// search error
-			$vs_message = _t("LDAP search error: %1", ldap_error($vo_ldap));
-			ldap_unbind($vo_ldap);
-			throw new OpenLDAPException($vs_message);
-		}
-
-		$vo_entry = ldap_first_entry($vo_ldap, $vo_results);
-		if (!$vo_entry) {
-			// no results returned
-			ldap_unbind($vo_ldap);
-			throw new OpenLDAPException(_t("User could not be found."));
-		}
-
-		$va_attrs = ldap_get_attributes($vo_ldap, $vo_entry);
-
-		$va_return = array();
-
-		$va_return['email'] = $va_attrs[$vs_attribute_email][0];
-		$va_return['fname'] = $va_attrs[$vs_attribute_fname][0];
-		$va_return['lname'] = $va_attrs[$vs_attribute_lname][0];
-		$va_return['user_name'] = $ps_username;
-		$va_return['active'] = $po_auth_config->get("ldap_users_auto_active");
-
-		$va_return['roles'] = array_merge($va_default_roles, self::getRolesToAddFromDirectory($ps_username, $vo_ldap));
-		$va_return['groups'] = array_merge($va_default_groups, self::getGroupsToAddFromDirectory($ps_username, $vo_ldap));
-
-		ldap_unbind($vo_ldap);
-
-		return $va_return;
-	}
-	# --------------------------------------------------------------------------------
-	private static function postProcessLDAPConfigValue($key, $ps_user_group_name, $ps_user_ou, $ps_base_dn) {
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		$result = $o_auth_config->get($key);
-		$result = str_replace('{username}', $ps_user_group_name, $result);
-		$result = str_replace('{groupname}', $ps_user_group_name, $result);
-		$result = str_replace('{user_ou}', $ps_user_ou, $result);
-		$result = str_replace('{base_dn}', $ps_base_dn, $result);
-		return $result;
-	}
-	# --------------------------------------------------------------------------------
-	private static function isMemberinAtLeastOneGroup($ps_user, $po_ldap){
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-
-		$vs_group_search_dn = self::postProcessLDAPConfigValue("ldap_group_search_dn_format", '', '', $vs_base_dn);
-		$va_group_cns = $o_auth_config->get('ldap_group_cn_list');
-
-		if(is_array($va_group_cns) && sizeof($va_group_cns)>0){
-			foreach($va_group_cns as $vs_group_cn) {
-				$vs_search_filter = self::postProcessLDAPConfigValue("ldap_group_search_filter_format", $vs_group_cn, '', $vs_base_dn);
-				$vo_result = @ldap_search($po_ldap, $vs_group_search_dn, $vs_search_filter, array("memberuid"));
-
-				if (!$vo_result) {
-					// search error
-					$vs_message = _t("LDAP search error: %1", ldap_error($po_ldap));
-					ldap_unbind($po_ldap);
-					throw new OpenLDAPException($vs_message);
-				}
-
-				$va_entries = ldap_get_entries($po_ldap, $vo_result);
-				if($va_members = $va_entries[0]["memberuid"]){
-					if(in_array($ps_user, $va_members)){ // found group
-						return true;
-					}
+			$va_entries = ldap_get_entries($this->getLinkIdentifier(), $vo_result);
+			if ($va_members = $va_entries[0]["memberuid"]){
+				if (in_array($ps_username, $va_members)){
+					// found group
+					return true;
 				}
 			}
-		} else { // if no list is configured, all is good
-			return true;
 		}
-
 		return false;
 	}
 	# --------------------------------------------------------------------------------
-	private static function getRolesToAddFromDirectory($ps_user, $po_ldap) {
+	protected function getRolesToAddFromDirectory($ps_username) {
 		$va_return = array();
 
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-
-		$vs_group_search_dn = self::postProcessLDAPConfigValue("ldap_group_search_dn_format", '', '', $vs_base_dn);
-		$va_roles_map = $o_auth_config->get('ldap_roles_group_map');
+		$vs_user_ou = $this->getConfigValue("ldap_user_ou");
+		$vs_base_dn = $this->getConfigValue("ldap_base_dn");
+		$vs_group_search_dn = $this->getProcessedConfigValue("ldap_group_search_dn_format", $ps_username, $vs_user_ou, $vs_base_dn);
+		$va_roles_map = $this->getConfigValue('ldap_roles_group_map');
 
 		if(is_array($va_roles_map) && sizeof($va_roles_map)>0) {
 			foreach ($va_roles_map as $vs_ldap_group => $va_ca_roles) {
 				if(is_array($va_ca_roles) && sizeof($va_ca_roles)>0) {
-
-					$vs_search_filter = self::postProcessLDAPConfigValue("ldap_group_search_filter_format", $vs_ldap_group, '', $vs_base_dn);
-					$vo_result = @ldap_search($po_ldap, $vs_group_search_dn, $vs_search_filter, array("memberuid"));
-
+					$vs_search_filter = $this->getProcessedConfigValue("ldap_group_search_filter_format", $vs_ldap_group, '', $vs_base_dn);
+					$vo_result = @ldap_search($this->getLinkIdentifier(), $vs_group_search_dn, $vs_search_filter, array("memberuid"));
 					if (!$vo_result) {
 						// search error
-						$vs_message = _t("LDAP search error: %1", ldap_error($po_ldap));
-						ldap_unbind($po_ldap);
-						throw new OpenLDAPException($vs_message);
+						$vs_message = _t("LDAP search error: %1", ldap_error($this->getLinkIdentifier()));
+						throw new LDAPException($vs_message);
 					}
 
-					$va_entries = ldap_get_entries($po_ldap, $vo_result);
+					$va_entries = ldap_get_entries($this->getLinkIdentifier(), $vo_result);
 					if($va_members = $va_entries[0]["memberuid"]){
-						if(in_array($ps_user, $va_members)){ // found group
+						if(in_array($ps_username, $va_members)){ // found group
 							$va_return = array_merge($va_return, $va_ca_roles);
 						}
 					}
@@ -306,32 +96,28 @@ class OpenLDAPAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		return $va_return;
 	}
 	# --------------------------------------------------------------------------------
-	private static function getGroupsToAddFromDirectory($ps_user, $po_ldap) {
+	protected function getGroupsToAddFromDirectory($ps_username) {
 		$va_return = array();
 
-		$o_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-		$vs_base_dn = $o_auth_config->get("ldap_base_dn");
-
-		$vs_group_search_dn = self::postProcessLDAPConfigValue("ldap_group_search_dn_format", '', '', $vs_base_dn);
-		$va_groups_map = $o_auth_config->get('ldap_groups_group_map');
+		$vs_base_dn = $this->getConfigValue("ldap_base_dn");
+		$vs_group_search_dn = $this->getProcessedConfigValue("ldap_group_search_dn_format", '', '', $vs_base_dn);
+		$va_groups_map = $this->getConfigValue('ldap_groups_group_map');
 
 		if(is_array($va_groups_map) && sizeof($va_groups_map)>0) {
 			foreach ($va_groups_map as $vs_ldap_group => $va_ca_groups) {
 				if(is_array($va_ca_groups) && sizeof($va_ca_groups)>0) {
-
-					$vs_search_filter = self::postProcessLDAPConfigValue("ldap_group_search_filter_format", $vs_ldap_group, '', $vs_base_dn);
-					$vo_result = @ldap_search($po_ldap, $vs_group_search_dn, $vs_search_filter, array("memberuid"));
+					$vs_search_filter = $this->getProcessedConfigValue("ldap_group_search_filter_format", $vs_ldap_group, '', $vs_base_dn);
+					$vo_result = @ldap_search($this->getLinkIdentifier(), $vs_group_search_dn, $vs_search_filter, array("memberuid"));
 
 					if (!$vo_result) {
 						// search error
-						$vs_message = _t("LDAP search error: %1", ldap_error($po_ldap));
-						ldap_unbind($po_ldap);
-						throw new OpenLDAPException($vs_message);
+						$vs_message = _t("LDAP search error: %1", ldap_error($this->getLinkIdentifier()));
+						throw new LDAPException($vs_message);
 					}
 
-					$va_entries = ldap_get_entries($po_ldap, $vo_result);
+					$va_entries = ldap_get_entries($this->getLinkIdentifier(), $vo_result);
 					if($va_members = $va_entries[0]["memberuid"]){
-						if(in_array($ps_user, $va_members)){ // found group
+						if(in_array($ps_username, $va_members)){ // found group
 							$va_return = array_merge($va_return, $va_ca_groups);
 						}
 					}
@@ -341,33 +127,4 @@ class OpenLDAPAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 
 		return $va_return;
 	}
-	# --------------------------------------------------------------------------------
-	public static function supports($pn_feature) {
-		switch($pn_feature){
-			case __CA_AUTH_ADAPTER_FEATURE_AUTOCREATE_USERS__:
-				return true;
-			case __CA_AUTH_ADAPTER_FEATURE_RESET_PASSWORDS__:
-			case __CA_AUTH_ADAPTER_FEATURE_UPDATE_PASSWORDS__:
-			default:
-				return false;
-		}
-	}
-	# --------------------------------------------------------------------------------
-	public static function deleteUser($ps_username) {
-		// do something?
-		return true;
-	}
-	# --------------------------------------------------------------------------------
-	public static function getAccountManagementLink() {
-		$po_auth_config = Configuration::load(Configuration::load()->get('authentication_config'));
-
-		if($vs_link = $po_auth_config->get('ldap_manage_account_url')) {
-			return $vs_link;
-		}
-
-		return false;
-	}
-	# --------------------------------------------------------------------------------
 }
-
-class OpenLDAPException extends Exception {}

--- a/app/lib/core/Auth/BaseAuthAdapter.php
+++ b/app/lib/core/Auth/BaseAuthAdapter.php
@@ -42,7 +42,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 * @throws AuthClassFeatureException
 	 * @return string
 	 */
-	public static function createUserAndGetPassword($ps_username, $ps_password) {
+	public function createUserAndGetPassword($ps_username, $ps_password) {
 		throw new AuthClassFeatureException(_t("Authentication back-end doesn't support creating new users programmatically."));
 	}
 
@@ -54,7 +54,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 * @return array
 	 * @throws AuthClassFeatureException
 	 */
-	public static function getUserInfo($ps_username, $ps_password) {
+	public function getUserInfo($ps_username, $ps_password) {
 		throw new AuthClassFeatureException();
 	}
 
@@ -66,7 +66,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 * @throws AuthClassFeatureException
 	 * @return bool
 	 */
-	public static function deleteUser($ps_username) {
+	public function deleteUser($ps_username) {
 		throw new AuthClassFeatureException(_t("Authentication back-end doesn't support deleting users programmatically."));
 	}
 
@@ -79,7 +79,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 * @throws AuthClassFeatureException
 	 * @return string
 	 */
-	public static function updatePassword($ps_username, $ps_password) {
+	public function updatePassword($ps_username, $ps_password) {
 		throw new AuthClassFeatureException(_t("Authentication back-end doesn't updating existing users programmatically."));
 	}
 
@@ -89,7 +89,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 * @param int $pn_feature
 	 * @return bool
 	 */
-	public static function supports($pn_feature) {
+	public function supports($pn_feature) {
 		return false;
 	}
 
@@ -98,7 +98,7 @@ abstract class BaseAuthAdapter implements IAuthAdapter {
 	 *
 	 * @return false|string
 	 */
-	public static function getAccountManagementLink() {
+	public function getAccountManagementLink() {
 		return false;
 	}
 }

--- a/app/lib/core/Auth/IAuthAdapter.php
+++ b/app/lib/core/Auth/IAuthAdapter.php
@@ -44,7 +44,7 @@ interface IAuthAdapter {
 	 * @param null $pa_options Associative array of options
 	 * @return boolean
 	 */
-	public static function authenticate($ps_username, $ps_password="", $pa_options=null);
+	public function authenticate($ps_username, $ps_password="", $pa_options=null);
 
 	/**
 	 * Creates new user in back-end. Should throw AuthClassFeatureException if not implemented. Note that while this is
@@ -59,7 +59,7 @@ interface IAuthAdapter {
 	 * back-ends where it doesn't make any sense to store a password locally (e.g. LDAP or OAuth). Can also be used to store
 	 * authentication tokens. The password you store here will be passed to authenticate() as-is.
 	 */
-	public static function createUserAndGetPassword($ps_username, $ps_password);
+	public function createUserAndGetPassword($ps_username, $ps_password);
 
 	/**
 	 * Get array containing field_name/value pairs for newly created records in the ca_users table, e.g. email, fname, lname.
@@ -68,7 +68,7 @@ interface IAuthAdapter {
 	 * @param $ps_password
 	 * @return array
 	 */
-	public static function getUserInfo($ps_username, $ps_password);
+	public function getUserInfo($ps_username, $ps_password);
 
 	/**
 	 * Deletes user. Should throw AuthClassFeatureException if not implemented.
@@ -76,7 +76,7 @@ interface IAuthAdapter {
 	 * @param string $ps_username user name
 	 * @return bool delete successful or not?
 	 */
-	public static function deleteUser($ps_username);
+	public function deleteUser($ps_username);
 
 	/**
 	 * Updates password for existing user and returns it. Should throw AuthClassFeatureException if not implemented.
@@ -86,7 +86,7 @@ interface IAuthAdapter {
 	 * @return string|null The password to store in the ca_users table. Can be left empty for
 	 * back-ends where it doesn't make any sense to store a password locally (e.g. LDAP or OAuth).
 	 */
-	public static function updatePassword($ps_username, $ps_password);
+	public function updatePassword($ps_username, $ps_password);
 
 
 	/**
@@ -100,7 +100,7 @@ interface IAuthAdapter {
 	 * @param int $pn_feature The feature to check for
 	 * @return bool Is it implemented or not?
 	 */
-	public static function supports($pn_feature);
+	public function supports($pn_feature);
 
 	/**
 	 * Gives implementations an option to place an account management link on the CollectiveAccess
@@ -111,7 +111,7 @@ interface IAuthAdapter {
 	 *
 	 * @return false|string
 	 */
-	public static function getAccountManagementLink();
+	public function getAccountManagementLink();
 
 }
 

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -727,7 +727,7 @@ class RequestHTTP extends Request {
 				$this->opo_response->setRedirect($pa_options['redirect']);
 				$this->opo_response->sendResponse();
 				exit;
-		}
+			}
 
 			if (!$pa_options["dont_redirect_to_welcome"]) {
 				// redirect to "welcome" page

--- a/app/lib/core/Controller/Request/RequestHTTP.php
+++ b/app/lib/core/Controller/Request/RequestHTTP.php
@@ -721,12 +721,19 @@ class RequestHTTP extends Request {
 			
 			//$this->user->close(); ** will be called externally **
 			$AUTH_CURRENT_USER_ID = $vn_user_id;
+
 			if ($pa_options['redirect']) {
-				$this->opo_response->addHeader("Location", $pa_options['redirect']);
-			} elseif (!$pa_options["dont_redirect_to_welcome"]) {
-				//header("Location: ".$this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_welcome_path"));				// redirect to "welcome" page
-				$this->opo_response->addHeader("Location", $this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_welcome_path"));
-				//exit;
+				// redirect to specified URL
+				$this->opo_response->setRedirect($pa_options['redirect']);
+				$this->opo_response->sendResponse();
+				exit;
+		}
+
+			if (!$pa_options["dont_redirect_to_welcome"]) {
+				// redirect to "welcome" page
+				$this->opo_response->setRedirect($this->getBaseUrlPath().'/'.$this->getScriptName().'/'.$this->config->get("auth_login_welcome_path"));
+				$this->opo_response->sendResponse();
+				exit;
 			}
 			
 			return true;


### PR DESCRIPTION
This is a refactor of the new authentication code. There are three outcomes:

1. It actually works for ActiveDirectory configurations.
2. The post-authentication HTTP behaviour is fixed (see 0ce6f51 for details).
3. Improvements to the code style.

The major code style improvement is changing `IAuthAdapter` from a "static interface" to a normal interface that defines non-static methods. This means that the implementations have also changed to normal classes with instances, and `AuthenticationManager` holds a reference to an instance of the applicable implementation and calls methods on that instance, rather than calling static methods on a class identified by name.

I also created `AbstractLDAPAuthAdapter` which contains the LDAP functionality that is common between OpenLDAP and AD (which is most of it).
