### PR TITLE
Fix circular dependency.

### DIFF
--- a/app/lib/ca/BaseObjectLocationModel.php
+++ b/app/lib/ca/BaseObjectLocationModel.php
@@ -35,8 +35,6 @@
   */
   
  	require_once(__CA_LIB_DIR__.'/ca/RepresentableBaseModel.php');
-	require_once(__CA_MODELS_DIR__.'/ca_movements.php');
-	require_once(__CA_MODELS_DIR__.'/ca_storage_locations.php');
 	require_once(__CA_MODELS_DIR__.'/ca_objects.php');
  
 	class BaseObjectLocationModel extends RepresentableBaseModel {


### PR DESCRIPTION
+ `BaseObjectLocationModel` was `require`ing `ca_movements` and `ca_movements` was `require`ing `BaseObjectLocationModel` -- circular dependency.
+ It was not necessary to `require` `ca_movements` from `BaseObjectLocationModel` so this has now been removed.
