### PR TITLE
NOJIRA : allows to hook TimeExpressionParser preprocess

### DIFF
--- a/app/lib/core/Parsers/TimeExpressionParser.php
+++ b/app/lib/core/Parsers/TimeExpressionParser.php
@@ -687,6 +687,14 @@ class TimeExpressionParser {
 	}
 	# -------------------------------------------------------------------
 	private function preprocess($ps_expression) {
+
+		// Trigger TimeExpressionParser preprocess hook
+		$o_app_plugin_manager = new ApplicationPluginManager();
+		$va_hook_result = $o_app_plugin_manager->hookTimeExpressionParserPreprocessBefore(array("expression"=>$ps_expression));
+		if ($va_hook_result["expression"] != $ps_expression) {
+			$ps_expression = $va_hook_result["expression"];
+		}
+
 		# convert
 		$va_dict = $this->opo_datetime_settings->getAssoc("expressions");
 		$vs_lc_expression = mb_strtolower($ps_expression);
@@ -820,7 +828,7 @@ class TimeExpressionParser {
 
 		// Trigger TimeExpressionParser preprocess hook
 		$o_app_plugin_manager = new ApplicationPluginManager();
-		$va_hook_result = $o_app_plugin_manager->hookTimeExpressionParserPreprocess(array("expression"=>$ps_expression));
+		$va_hook_result = $o_app_plugin_manager->hookTimeExpressionParserPreprocessAfter(array("expression"=>$ps_expression));
 		if ($va_hook_result["expression"] != $ps_expression) {
 			$ps_expression = $va_hook_result["expression"];
 		}

--- a/app/lib/core/Parsers/TimeExpressionParser.php
+++ b/app/lib/core/Parsers/TimeExpressionParser.php
@@ -36,6 +36,7 @@
 
 require_once(__CA_LIB_DIR__."/core/Configuration.php");
 require_once(__CA_APP_DIR__."/helpers/utilityHelpers.php");
+require_once(__CA_LIB_DIR__."/ca/ApplicationPluginManager.php");
 
 # --- Token types
 define("TEP_TOKEN_INTEGER", 0);
@@ -816,6 +817,13 @@ class TimeExpressionParser {
 
 		// support date entry in the form yyyy-mm-dd/yyy-mm-dd (HSP)
 		$ps_expression = preg_replace("/([\d]{4}#[\d]{2}#[\d]{2})\/([\d]{4}#[\d]{2}#[\d]{2})/", "$1 - $2", $ps_expression);
+
+		// Trigger TimeExpressionParser preprocess hook
+		$o_app_plugin_manager = new ApplicationPluginManager();
+		$va_hook_result = $o_app_plugin_manager->hookTimeExpressionParserPreprocess(array("expression"=>$ps_expression));
+		if ($va_hook_result["expression"] != $ps_expression) {
+			$ps_expression = $va_hook_result["expression"];
+		}
 
 		return trim($ps_expression);
 	}


### PR DESCRIPTION
This allows me to develop into a plugin a preparser for French Revolutionary Calendar dates.
The plugin would allow me to parse dates like "12 thermidor an II" (https://en.wikipedia.org/wiki/French_Republican_Calendar) before sending a normal date to the TEP class. This is only for input now.

In the future, it would allow the development of plugins for date entering from Hebrew, Islamic, persian, chinese calendars, probably with a special text mark to distinguish the calendar if the month names don't help. Going through plugins seems me a prudent way of digging into those.