### PR TITLE
Fix GitHub issue #224 - slow rendering of UI Screen Editor.

### DIFF
--- a/assets/ca/ca.bundlelisteditor.js
+++ b/assets/ca/ca.bundlelisteditor.js
@@ -49,7 +49,7 @@ var caUI = caUI || {};
 			
 			settingsIcon: null
 		}, options);
-		
+
 		// ------------------------------------------------------------------------------------
 		that.initDisplayList = function() {
 			if (!that.initialDisplayList) { return; }
@@ -112,13 +112,15 @@ var caUI = caUI || {};
 				id = id + '_0'; 
 			}
 
+			// Store the settings form HTML for lazy insertion.
+			// TODO Use namespaces to prevent id collisions with multiple of this plugin on a single page.
+			caUI.bundlelisteditor.settingsForms[id] = settingsForm;
+
 			output =  "<div id='displayElement_" + id +"' class='" + that.displayItemClass + "'>";
-			output += " <div class='bundleDisplayElementSettingsControl'><a href='#' onclick='jQuery(\".elementSettingsUI\").fadeOut(250); jQuery(\"#displayElementSettings_" +  id.replace(/\./g, "\\\\.") +"\").fadeIn(250); return false; '>" + that.settingsIcon + "</a></div>";
+			output += "<div class='bundleDisplayElementSettingsControl'><a href='#' onclick='caUI.bundlelisteditor.initSettingsForm(\"" + id + "\"); jQuery(\".elementSettingsUI\").fadeOut(250); jQuery(\"#displayElementSettings_" +  id.replace(/\./g, "\\\\.") +"\").fadeIn(250); return false; '>" + that.settingsIcon + "</a></div>";
 			output += "<div style='width:75%'>" + label + " </div>";
 			output += "</div>\n";			
-			output += "<div id='displayElementSettings_" + id +"' class='elementSettingsUI' style='display: none;'>"+ label + settingsForm + "<a href='#' onclick='jQuery(\"#displayElementSettings_" +  id.replace(/\./g, "\\\\.") +"\").fadeOut(250); return false; '>" + that.settingsIcon + "</a></div>";
-
-			
+			output += "<div id='displayElementSettings_" + id +"' class='elementSettingsUI' style='display: none;'>" + label + "<div class='settingsFormContainer'></div><a href='#' onclick='jQuery(\"#displayElementSettings_" +  id.replace(/\./g, "\\\\.") +"\").fadeOut(250); return false; '>" + that.settingsIcon + "</a></div>";
 			return output;
 		}
 		// ------------------------------------------------------------------------------------
@@ -140,4 +142,16 @@ var caUI = caUI || {};
 		that.initDisplayList();
 		return that;
 	};
+
+	// Keys are ids and values are HTML for the popup settings form, stored here and lazily inserted into the DOM.
+	caUI.bundlelisteditor.settingsForms = {};
+
+	// Lazily insert popup settings form HTML from map.
+	caUI.bundlelisteditor.initSettingsForm = function (id) {
+		if (caUI.bundlelisteditor.settingsForms[id]) {
+			$('#displayElementSettings_' + id + ' .settingsFormContainer').html(caUI.bundlelisteditor.settingsForms[id]);
+			delete caUI.bundlelisteditor.settingsForms[id];
+		}
+	}
+
 })(jQuery);


### PR DESCRIPTION
+ Fixes #224 
+ Lazily insert settings form HTML into the DOM when requested
  by the user.
+ Uses a plugin-global (not instance-specific) cache for storing
  the HTML, so there is a TODO about resolving namespace
  conflicts, however this will only be a problem if used multiple
  times on a single page.