### PR TITLE
NOJIRA : allow xml display when clicking on a XML representation

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,6 +10,6 @@ Allow from all
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|ttf|swf|map|m4v)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|ttf|swf|map|m4v|xml)$">
         Allow from all
 </FilesMatch>


### PR DESCRIPTION
If you click on a XML the media, the caMediaDisplayContent can't as htaccess blocks it.