### PR TITLE
NOJIRA : display homonyms in hierarchical browser

### DIFF
--- a/app/lib/ca/BaseLookupController.php
+++ b/app/lib/ca/BaseLookupController.php
@@ -318,7 +318,7 @@
 						
 						$va_sorted_items = array();
 						foreach($va_items_for_locale as $vn_id => $va_node) {
-							$vs_key = preg_replace('![^A-Za-z0-9]!', '_', $va_node['name']);
+							$vs_key = strtolower(preg_replace('![^A-Za-z0-9]!', '_', caRemoveAccents($va_node['name'])))."_".$vn_id;
 						
 							if (isset($va_node['sort']) && $va_node['sort']) {
 								$va_sorted_items[$va_node['sort']][$vs_key] = $va_node;


### PR DESCRIPTION
NOJIRA : display homonyms in hierarchical browser
- changing vs_key to allow having duplicate names : as the keys were based on name, only one of the duplicates was shown, quite hard for the end user to figure out where his duplicates were hidden ; in order to correct that, I've added the item id as a suffix to the key
- adding strtolower to avoid having an alphabetical order with capital letters in the beginning of the list
- adding caremoveaccents to be sure words beginning with an accent are accurately displayed in the alphabetical order

---------

Hello Stefan & Seth,

This small PR handles different problems I had with hierarchies : 
- having an alphabetical order handling capitalized words differently
- pushing accentuated initials at the end of the alphabetical order
- not displaying homonyms in hierarchies : I had users complaining of part of their hierarchies not being displayed in the hierarchy, but still being able to search them

If some parts of this situation are explicitly wanted, please tell me.

Have a nice sunday,

Gautier