### PR TITLE
Getty linked data attribute type improvements

### DIFF
--- a/app/conf/linked_data.conf
+++ b/app/conf/linked_data.conf
@@ -17,10 +17,10 @@ tgn = {
 	search_text = 0,
 
 	# limit number of results returned in autocomplete lookup
-    result_limit = 100,
+	result_limit = 100,
 
-	# Here is an example record that shows you a list of available properties that you can use for both
-	# detail_view_info and additional_indexing_info below.
+	# Here is an example record that shows you a list of available properties that you can use for
+	# detail_view_info, additional_indexing_info and extra_info below.
 	# http://vocab.getty.edu/tgn/7015849.rdf
 
 	# Attributes to show in the extended information panel
@@ -64,6 +64,19 @@ tgn = {
 			literal = <http://vocab.getty.edu/ontology#term>
 		}
 	},
+
+	# Extra attributes to make available for get() and in displays
+	#
+	extra_info = {
+		lat = {
+			uri = <http://xmlns.com/foaf/0.1/focus>,
+			literal = <http://www.w3.org/2003/01/geo/wgs84_pos#lat>
+		},
+		long = {
+			uri = <http://xmlns.com/foaf/0.1/focus>,
+			literal = <http://www.w3.org/2003/01/geo/wgs84_pos#long>
+		},
+	}
 }
 
 aat = {
@@ -74,8 +87,8 @@ aat = {
 	# limit number of results returned in autocomplete lookup
 	result_limit = 100,
 
-	# Here is an example record that shows you a list of available properties that you can use for both
-	# detail_view_info and additional_indexing_info below.
+	# Here is an example record that shows you a list of available properties that you can use for
+	# detail_view_info, additional_indexing_info and extra_info below.
 	# http://vocab.getty.edu/aat/300000831
 
 	# Attributes to show in the extended information panel
@@ -120,10 +133,10 @@ ulan = {
 	search_text = 0,
 
 	# limit number of results returned in autocomplete lookup
-    result_limit = 100,
+	result_limit = 100,
 
-	# Here is an example record that shows you a list of available properties that you can use for both
-	# detail_view_info and additional_indexing_info below.
+	# Here is an example record that shows you a list of available properties that you can use for
+	# detail_view_info, additional_indexing_info and extra_info below.
 	# http://vocab.getty.edu/ulan/500115588
 
 	# Attributes to show in the extended information panel

--- a/app/conf/linked_data.conf
+++ b/app/conf/linked_data.conf
@@ -48,10 +48,6 @@ tgn = {
 	#
 	# Data added here can be used to find records that have associated linked data nodes
 	additional_indexing_info = {
-		parentString = {
-			literal = <http://vocab.getty.edu/ontology#parentString>,
-			stripAfterLastComma = 1,
-		},
 		prefLabel = {
 			uri = <http://vocab.getty.edu/ontology#prefLabelGVP>,
 			literal = <http://vocab.getty.edu/ontology#term>
@@ -62,6 +58,16 @@ tgn = {
 		altLabels = {
 			uri = <http://www.w3.org/2008/05/skos-xl#altLabel>,
 			literal = <http://vocab.getty.edu/ontology#term>
+		},
+		broaderPref = {
+			uri = <http://www.w3.org/2004/02/skos/core#broaderTransitive>,
+			literal = <http://www.w3.org/2004/02/skos/core#prefLabel>,
+			recursive = 1,
+		},
+		broaderNonPref = {
+			uri = <http://www.w3.org/2004/02/skos/core#broaderTransitive>,
+			literal = <http://www.w3.org/2004/02/skos/core#altLabel>,
+			recursive = 1,
 		}
 	},
 

--- a/app/conf/linked_data.conf
+++ b/app/conf/linked_data.conf
@@ -115,10 +115,6 @@ aat = {
 	#
 	# Data added here can be used to find records that have associated linked data nodes
 	additional_indexing_info = {
-		parentString = {
-			literal = <http://vocab.getty.edu/ontology#parentString>,
-			stripAfterLastComma = 1,
-		},
 		prefLabel = {
 			uri = <http://vocab.getty.edu/ontology#prefLabelGVP>,
 			literal = <http://vocab.getty.edu/ontology#term>
@@ -129,6 +125,16 @@ aat = {
 		altLabels = {
 			uri = <http://www.w3.org/2008/05/skos-xl#altLabel>,
 			literal = <http://vocab.getty.edu/ontology#term>
+		},
+		broaderPref = {
+			uri = <http://www.w3.org/2004/02/skos/core#broaderTransitive>,
+			literal = <http://www.w3.org/2004/02/skos/core#prefLabel>,
+			recursive = 1,
+		},
+		broaderNonPref = {
+			uri = <http://www.w3.org/2004/02/skos/core#broaderTransitive>,
+			literal = <http://www.w3.org/2004/02/skos/core#altLabel>,
+			recursive = 1,
 		}
 	},
 }

--- a/app/lib/core/Cache/CompositeCache.php
+++ b/app/lib/core/Cache/CompositeCache.php
@@ -62,11 +62,12 @@ class CompositeCache {
 	 * @param string $ps_key
 	 * @param mixed $pm_data
 	 * @param string $ps_namespace
+	 * @param int $pn_ttl
 	 * @return bool success state
 	 */
-	public static function save($ps_key, $pm_data, $ps_namespace='default') {
+	public static function save($ps_key, $pm_data, $ps_namespace='default', $pn_ttl=null) {
 		MemoryCache::save($ps_key, $pm_data, $ps_namespace);
-		ExternalCache::save($ps_key, $pm_data, $ps_namespace);
+		ExternalCache::save($ps_key, $pm_data, $ps_namespace, $pn_ttl);
 
 		return true;
 	}

--- a/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
+++ b/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
@@ -224,7 +224,7 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 		}
 
 		$vs_return = join('; ', $va_return);
-		CompositeCache::save($vs_cache_key, $vs_return, 'GettyRDFLiterals');
+		CompositeCache::save($vs_cache_key, $vs_return, 'GettyRDFLiterals', 60 * 60 * 24 * 7);
 
 		return $vs_return;
 	}

--- a/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
+++ b/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
@@ -121,11 +121,11 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 		if(!isset($va_service_conf['additional_indexing_info']) || !is_array($va_service_conf['additional_indexing_info'])) { return array(); }
 
 		$va_return = array();
-		foreach($va_service_conf['additional_indexing_info'] as $va_node) {
+		foreach($va_service_conf['additional_indexing_info'] as $vs_key => $va_node) {
 			if(!isset($va_node['literal'])) { continue; }
 
 			$vs_uri_for_pull = isset($va_node['uri']) ? $va_node['uri'] : null;
-			$va_return[] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull));
+			$va_return[$vs_key] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull, $va_node));
 		}
 
 		return $va_return;
@@ -147,7 +147,7 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 			if(!isset($va_node['literal'])) { continue; }
 
 			$vs_uri_for_pull = isset($va_node['uri']) ? $va_node['uri'] : null;
-			$va_return[$vs_key] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull));
+			$va_return[$vs_key] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull, $va_node));
 		}
 
 		return $va_return;
@@ -170,36 +170,24 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 		if(!isURL($ps_base_node)) { return false; }
 		if(!is_array($pa_options)) { $pa_options = array(); }
 
-		$vs_cache_key = md5($ps_base_node . $ps_literal_propery . $ps_node_uri . print_r($pa_options, true));
+		$vs_cache_key = md5($ps_base_node . $ps_literal_propery . $ps_node_uri . serialize($pa_options));
 		if(CompositeCache::contains($vs_cache_key, 'GettyRDFLiterals')) {
-			//return CompositeCache::fetch($vs_cache_key, 'GettyRDFLiterals');
+			return CompositeCache::fetch($vs_cache_key, 'GettyRDFLiterals');
 		}
 
 		$pn_limit = (int) caGetOption('limit', $pa_options, 10);
 		$pb_strip_after_last_comma = (bool) caGetOption('stripAfterLastComma', $pa_options, false);
 		$pb_invert = (bool) caGetOption('invert', $pa_options, false);
+		$pb_recursive = (bool) caGetOption('recursive', $pa_options, false);
 
 		if(!($o_graph = self::getURIAsRDFGraph($ps_base_node))) { return false; }
 
-		$va_pull_graphs = array();
-		// if we're pulling from a related node, add those graphs (technically nodes) to the list
-		// (we pull from all of them)
+		// if we're pulling from a related node, add those graphs (technically nodes) to the list (we pull from all of them)
 		if(strlen($ps_node_uri) > 0) {
-			$o_related_nodes = $o_graph->all($ps_base_node, $ps_node_uri);
-
-			if(is_array($o_related_nodes)) {
-				$vn_i = 0;
-				foreach($o_related_nodes as $o_related_node) {
-					$vs_pull_uri = (string) $o_related_node;
-					if(!($o_pull_graph = self::getURIAsRDFGraph($vs_pull_uri))) { return false; }
-					$va_pull_graphs[$vs_pull_uri] = $o_pull_graph;
-
-					if((++$vn_i) >= $pn_limit) { break; }
-				}
-			}
+			$va_pull_graphs = self::getListOfRelatedGraphs($o_graph, $ps_base_node, $ps_node_uri, $pn_limit, $pb_recursive);
 		} else {
 			// the only graph/node we pull from is the base node
-			$va_pull_graphs[$ps_base_node] = $o_graph;
+			$va_pull_graphs = array($ps_base_node => $o_graph);
 		}
 
 		$va_return = array();
@@ -262,6 +250,41 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 
 		CompositeCache::save($ps_uri, $o_graph, 'GettyLinkedDataRDFGraphs');
 		return $o_graph;
+	}
+	# ------------------------------------------------
+	/**
+	 * @param EasyRdf_Graph $po_graph
+	 * @param string $ps_base_node
+	 * @param string $ps_node_uri
+	 * @param int $pn_limit
+	 * @param bool $pb_recursive
+	 * @return array
+	 */
+	static function getListOfRelatedGraphs($po_graph, $ps_base_node, $ps_node_uri, $pn_limit, $pb_recursive=false) {
+		$va_related_nodes = $po_graph->all($ps_base_node, $ps_node_uri);
+		$va_pull_graphs = array();
+
+		if(is_array($va_related_nodes)) {
+			$vn_i = 0;
+			foreach($va_related_nodes as $o_related_node) {
+				$vs_pull_uri = (string) $o_related_node;
+				if(!($o_pull_graph = self::getURIAsRDFGraph($vs_pull_uri))) { return false; }
+				$va_pull_graphs[$vs_pull_uri] = $o_pull_graph;
+
+				if((++$vn_i) >= $pn_limit) { break; }
+			}
+		}
+
+		if($pb_recursive) {
+			$va_sub_pull_graphs = array();
+			foreach($va_pull_graphs as $vs_pull_uri => $o_pull_graph) {
+				$va_sub_pull_graphs = array_merge($va_sub_pull_graphs, self::getListOfRelatedGraphs($o_pull_graph, $vs_pull_uri, $ps_node_uri, $pn_limit, true));
+			}
+
+			$va_pull_graphs = array_merge($va_pull_graphs, $va_sub_pull_graphs);
+		}
+
+		return $va_pull_graphs;
 	}
 	# ------------------------------------------------
 }

--- a/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
+++ b/app/lib/core/Plugins/InformationService/BaseGettyLODServicePlugin.php
@@ -190,6 +190,8 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 			$va_pull_graphs = array($ps_base_node => $o_graph);
 		}
 
+		if(!is_array($va_pull_graphs)) { return false; }
+
 		$va_return = array();
 
 		$vn_j = 0;

--- a/app/lib/core/Plugins/InformationService/BaseInformationServicePlugin.php
+++ b/app/lib/core/Plugins/InformationService/BaseInformationServicePlugin.php
@@ -181,7 +181,7 @@ abstract class BaseInformationServicePlugin Extends WLPlug {
 	# ------------------------------------------------
 	/**
 	 * Can be overriden in implementation to store addition bits of
-	 * information about the value which is then available via get() and for
+	 * information about the value which is then available via get()
 	 * @param array $pa_settings element settings
 	 * @param string $ps_url
 	 * @return array

--- a/tests/lib/ca/AttributeValues/TGNInformationServiceAttributeValueTest.php
+++ b/tests/lib/ca/AttributeValues/TGNInformationServiceAttributeValueTest.php
@@ -92,4 +92,10 @@ class TGNInformationServiceAttributeValueTest extends PHPUnit_Framework_TestCase
 		$o_service = new WLPlugInformationServiceTGN();
 		$o_service->getExtraInfo(array(), 'http://vocab.getty.edu/tgn/7015849');
 	}
+
+	public function testGetSearchIndexing() {
+		$o_service = new WLPlugInformationServiceTGN();
+		$o_service->getDataForSearchIndexing(array(), 'http://vocab.getty.edu/tgn/7015849');
+	}
+
 }

--- a/tests/lib/ca/AttributeValues/TGNInformationServiceAttributeValueTest.php
+++ b/tests/lib/ca/AttributeValues/TGNInformationServiceAttributeValueTest.php
@@ -87,4 +87,9 @@ class TGNInformationServiceAttributeValueTest extends PHPUnit_Framework_TestCase
 		$o_service = new WLPlugInformationServiceTGN();
 		$o_service->getExtendedInformation(array(), 'gibberish');
 	}
+
+	public function testGetExtraInfo() {
+		$o_service = new WLPlugInformationServiceTGN();
+		$o_service->getExtraInfo(array(), 'http://vocab.getty.edu/tgn/7015849');
+	}
 }

--- a/tests/testsWithData/get/AttributeGetTest.php
+++ b/tests/testsWithData/get/AttributeGetTest.php
@@ -186,8 +186,9 @@ class AttributeGetTest extends BaseTestWithData {
 		// 'flat' informationservice attribues
 		$this->assertEquals('Coney Island', $this->opt_object->get('ca_objects.tgn'));
 		$this->assertContains('Aaron Burr', $this->opt_object->get('ca_objects.wikipedia'));
-		// new subfield notation
+		// subfield notation for "extra info"
 		$this->assertContains('Burr killed his political rival Alexander Hamilton in a famous duel', $this->opt_object->get('ca_objects.wikipedia.abstract'));
+		$this->assertEquals('40.5667', $this->opt_object->get('ca_objects.tgn.lat'));
 
 		// informationservice attributes in container
 		$this->assertEquals('[500024253] Haring, Keith (Persons, Artists) - American painter, muralist, and cartoonist, 1958-1990', $this->opt_object->get('ca_objects.informationservice.ulan_container'));


### PR DESCRIPTION
Now allows adding additional fields for get() availability and also allows traversing relationships recursively, so that you can crawl up/down broader/narrower relationships and pull in data (e.g. for search indexing) in the process.

The new stock linked_data.conf indexes preferred and alt labels for all skos:broaderTransitive relationships for both TGN and AAT. Results can get a little erratic and saving records with tons of new Getty associations can get sloooooow because we actually have to traverse these relationships and load the related resources. It's all cached however, so if a resource for whatever reason was loaded once, it'll get pulled from cache on the second attempt. The cache lasts for a week.