### PR TITLE
Dependent field visibility

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1389,3 +1389,8 @@ annotation_class_element =
 # Switch to disable out of process search indexing
 #
 disable_out_of_process_search_indexing = 0
+
+#
+# Enable dependent field visibility
+#
+enable_dependant_field_visibility = 0

--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1393,4 +1393,4 @@ disable_out_of_process_search_indexing = 0
 #
 # Enable dependent field visibility
 #
-enable_dependant_field_visibility = 0
+enable_dependent_field_visibility = 0

--- a/app/lib/ca/Attributes/Values/ListAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/ListAttributeValue.php
@@ -401,7 +401,7 @@
 			);
 
 			// dependant field visibility
-			if(Configuration::load()->get('enable_dependant_field_visibility')) {
+			if(Configuration::load()->get('enable_dependent_field_visibility')) {
 				$t_list = new ca_lists();
 				foreach($t_list->getItemsForList($pa_element_info['list_id']) as $va_items_by_locale) {
 					foreach ($va_items_by_locale as $vn_locale_id => $va_item) {
@@ -467,7 +467,7 @@
 			 */
 
 			if(
-				Configuration::load()->get('enable_dependant_field_visibility') &&
+				Configuration::load()->get('enable_dependent_field_visibility') &&
 				is_array($pa_element_info) &&
 				isset($pa_element_info['list_id']) &&
 				// select is the default, so empty does count
@@ -517,7 +517,7 @@
 						);
 					}
 				}
-			} elseif(defined('__CollectiveAccess_Installer__') && Configuration::load()->get('enable_dependant_field_visibility')) {
+			} elseif(defined('__CollectiveAccess_Installer__') && Configuration::load()->get('enable_dependent_field_visibility')) {
 				// when installing, UIs, screens and placements are not yet available when we process elementSets, so
 				// we just add the hideIfSelected_* as available settings (without actual settings) so that the validation doesn't fail
 				$t_list = new ca_lists();

--- a/app/lib/ca/Attributes/Values/ListAttributeValue.php
+++ b/app/lib/ca/Attributes/Values/ListAttributeValue.php
@@ -484,14 +484,11 @@
 					$va_ui_list = ca_editor_uis::getAvailableUIs($vn_table_num, $g_request);
 					foreach($va_ui_list as $vn_ui_id => $vs_ui_name) {
 						$t_ui->load($vn_ui_id);
-						// add to list
-						$va_options_for_settings['-- '.$vs_ui_name] = $t_ui->get('editor_code');
-
 						// get screens
 						foreach($t_ui->getScreens() as $va_screen) {
 							// get placements
 							foreach($t_ui->getScreenBundlePlacements($va_screen['screen_id']) as $va_placement) {
-								$va_options_for_settings[$va_screen['idno'] .'/' .$va_placement['placement_code']] = $va_screen['screen_id'] . '/' . $va_placement['placement_id'];
+								$va_options_for_settings[$t_ui->get('editor_code') . '/'. $va_screen['idno'] . '/' . $va_placement['placement_code']] = $va_screen['screen_id'] . '/' . $va_placement['placement_id'];
 							}
 						}
 					}

--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -2307,8 +2307,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 					$va_valid_element_codes = null;
 				}
 			}
-			
-			$vn_c = 0;
+
 			foreach($va_bundles as $va_bundle) {
 				if ($va_bundle['bundle_name'] === $vs_type_id_fld) { continue; }	// skip type_id
 				if ((!$vn_pk_id) && ($va_bundle['bundle_name'] === $vs_hier_parent_id_fld)) { continue; }
@@ -2343,17 +2342,16 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 				
 				$va_bundle['settings']['placement_id'] = $va_bundle['placement_id'];
 				if ($vs_bundle_form_html = $this->getBundleFormHTML($va_bundle['bundle_name'], 'P'.$va_bundle['placement_id'], $va_bundle['settings'], $pa_options, $vs_bundle_display_name)) {
-					$va_bundle_html[$va_bundle['placement_code']] = "<a name=\"{$pm_screen}_{$vn_c}\"></a>{$vs_bundle_form_html}";
+					$va_bundle_html[$va_bundle['placement_code']] = "<a name=\"{$pm_screen}_{$va_bundle['placement_id']}\"></a>{$vs_bundle_form_html}";
 					$va_bundles_present[$va_bundle['bundle_name']] = true;
 					
-					$pa_placements["{$pm_screen}_{$vn_c}"] = array(
+					$pa_placements["{$pm_screen}_{$va_bundle['placement_id']}"] = array(
 						'name' => $vs_bundle_display_name ? $vs_bundle_display_name : $this->getDisplayLabel($vs_table_name.".".$va_bundle['bundle_name']),
 						'placement_id' => $va_bundle['placement_id'],
 						'bundle' => $va_bundle['bundle_name'],
 						'id' => 'P'.$va_bundle['placement_id'].caGetOption('formName', $pa_options, '')
 					);
 				}
-				$vn_c++;
 			}
 		}
 		

--- a/app/lib/ca/Utils/CLIUtils.php
+++ b/app/lib/ca/Utils/CLIUtils.php
@@ -51,6 +51,8 @@
 			require_once(__CA_BASE_DIR__ . '/install/inc/Installer.php');
 			require_once(__CA_BASE_DIR__ . '/install/inc/Updater.php');
 
+			define('__CollectiveAccess_Installer__', 1);
+
 			if ($pb_installing && !$po_opts->getOption('profile-name')) {
 				CLIUtils::addError(_t("Missing required parameter: profile-name"));
 				return false;

--- a/app/lib/core/BaseSettings.php
+++ b/app/lib/core/BaseSettings.php
@@ -514,10 +514,10 @@
 						} else {
 							// Regular drop-down with configured options
 							if ($vn_height > 1) { $va_attr['multiple'] = 1; $vs_input_name .= '[]'; }
-						
+
 							$va_opts = array('id' => $vs_input_id, 'width' => $vn_width, 'height' => $vn_height, 'value' => is_array($vs_value) ? $vs_value[0] : $vs_value, 'values' => is_array($vs_value) ? $vs_value : array($vs_value));
 							if(!isset($va_opts['value'])) { $va_opts['value'] = -1; }		// make sure default list item is never selected
-							$vs_select_element = caHTMLSelect($vs_input_name, $va_properties['options'], array(), $va_opts);
+							$vs_select_element = caHTMLSelect($vs_input_name, $va_properties['options'], $va_attr, $va_opts);
 						}
 					}
 					

--- a/app/models/ca_metadata_elements.php
+++ b/app/models/ca_metadata_elements.php
@@ -392,9 +392,8 @@ class ca_metadata_elements extends LabelableBaseModelWithAttributes implements I
 	 */
 	public function getAvailableSettings() {
 		$t_attr_val = Attribute::getValueInstance((int)$this->get('datatype'));
-		$va_element_info = $this->getSettings();
-		$va_element_info['list_id'] = $this->get('list_id');
-		$va_element_info['element_id'] = $this->getPrimaryKey();
+		$va_element_info = $this->getFieldValuesArray();
+		$va_element_info['settings'] = $this->getSettings();
 		return $t_attr_val ? $t_attr_val->getAvailableSettings($va_element_info) : null;
 	}
 	# ------------------------------------------------------

--- a/app/models/ca_metadata_elements.php
+++ b/app/models/ca_metadata_elements.php
@@ -392,7 +392,10 @@ class ca_metadata_elements extends LabelableBaseModelWithAttributes implements I
 	 */
 	public function getAvailableSettings() {
 		$t_attr_val = Attribute::getValueInstance((int)$this->get('datatype'));
-		return $t_attr_val ? $t_attr_val->getAvailableSettings($this->getSettings()) : null;
+		$va_element_info = $this->getSettings();
+		$va_element_info['list_id'] = $this->get('list_id');
+		$va_element_info['element_id'] = $this->getPrimaryKey();
+		return $t_attr_val ? $t_attr_val->getAvailableSettings($va_element_info) : null;
 	}
 	# ------------------------------------------------------
 	/**

--- a/install/profiles/xml/testing.xml
+++ b/install/profiles/xml/testing.xml
@@ -847,7 +847,7 @@
           <description>An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.</description>
         </label>
       </labels>
-      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-description</documentationUrl>      
+      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-description</documentationUrl>
       <settings>
         <setting name="usewysiwygeditor">1</setting>
         <setting name="fieldWidth">640px</setting>
@@ -1022,7 +1022,7 @@
           <description>A point or period of time associated with an event in the life cycle of the resource.</description>
         </label>
       </labels>
-      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-date</documentationUrl>      
+      <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-date</documentationUrl>
       <elements>
         <metadataElement code="dates_value" datatype="DateRange">
           <labels>
@@ -1230,7 +1230,7 @@
           </settings>
         </restriction>
       </typeRestrictions>
-    </metadataElement>    
+    </metadataElement>
     <!--Coverage Elements-->
     <metadataElement code="georeference" datatype="Geocode">
       <labels>
@@ -1272,7 +1272,7 @@
           </settings>
         </restriction>
       </typeRestrictions>
-    </metadataElement>    
+    </metadataElement>
     <metadataElement code="coverageNotes" datatype="Text">
       <labels>
         <label locale="en_US">
@@ -1409,10 +1409,8 @@
       </labels>
       <documentationUrl>http://dublincore.org/documents/dcmi-terms/#terms-format</documentationUrl>
       <settings>
-        <setting name="fieldWidth">80</setting>
-        <setting name="fieldHeight">1</setting>
-        <setting name="minChars">0</setting>
-        <setting name="maxChars">65535</setting>
+        <setting name="hideIfSelected_image_gif">standard_object_ui/format/ca_attribute_formatNotes</setting>
+        <setting name="hideIfSelected_image_gif">standard_object_ui/format/ca_attribute_dimensions</setting>
       </settings>
       <typeRestrictions>
         <restriction code="r1">
@@ -1514,7 +1512,7 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    
+
     <metadataElement code="formatNotes" datatype="Text">
       <labels>
         <label locale="en_US">
@@ -1691,7 +1689,7 @@
           </settings>
         </restriction>
       </typeRestrictions>
-    </metadataElement>    
+    </metadataElement>
     <!--Subject Elements-->
     <metadataElement code="lcsh_terms" datatype="LCSH">
       <labels>


### PR DESCRIPTION
This is a new feature that allows hiding certain bundles from user interface screens based on values selected for a list metadata element.

Basic documentation is here:

http://docs.collectiveaccess.org/wiki/Dependent_Field_Visibility