### PR TITLE
Fix display template issue

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2742,7 +2742,7 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 				} else {
 					switch(__CA_APP_TYPE__) {
 						case 'PROVIDENCE':
-							$va_links[] = ($vs_link = caEditorLink($g_request, $vs_text, $ps_class, $ps_table_name, $pa_row_ids[$vn_i])) ? $vs_link : $vs_text;
+							$va_links[] = ($vs_link = caEditorLink($g_request, $vs_text, $ps_class, $ps_table_name, $pa_row_ids[$vn_i], ($pb_add_rel ? array('rel' => true) : array()))) ? $vs_link : $vs_text;
 							break;
 						case 'PAWTUCKET':
 							$va_links[] = ($vs_link = caDetailLink($g_request, $vs_text, $ps_class, $ps_table_name, $pa_row_ids[$vn_i])) ? $vs_link : $vs_text;

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2476,7 +2476,7 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 					if ($vs_type_id_fld) {
 						$va_item['type_id'] = $qr_rel_items->get("{$vs_rel_table}.{$vs_type_id_fld}");
 					}
-					
+
 					$va_item['_display'] = caProcessTemplateForIDs($vs_template, $vs_table, array($qr_rel_items->get("{$vs_table}.{$vs_pk}")), array('returnAsArray' => false, 'returnAsLink' => false, 'delimiter' => caGetOption('delimiter', $pa_options, $vs_display_delimiter), 'resolveLinksUsing' => $vs_rel_table, 'primaryIDs' => $va_primary_ids));
 					$va_item['label'] = mb_strtolower($qr_rel_items->get("{$vs_table}.preferred_labels"));
 					
@@ -2513,7 +2513,7 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 				}
 				
                 if ($vs_template) {
-                    $va_items[$va_relation[$vs_rel_pk]]['_display'] = caProcessTemplateForIDs($vs_template, $pt_rel->tableName(), array($va_relation['relation_id'] ? $va_relation['relation_id'] : $va_relation[$vs_pk]), array('returnAsArray' => false, 'returnAsLink' => false, 'delimiter' => caGetOption('delimiter', $pa_options, $vs_display_delimiter), 'resolveLinksUsing' => $vs_rel_table, 'primaryIDs' => $va_primary_ids));
+                    $va_items[$va_relation[$vs_rel_pk]]['_display'] = caProcessTemplateForIDs($vs_template, $vs_rel_table, array($va_relation[$vs_rel_pk]), array('returnAsArray' => false, 'returnAsLink' => false, 'delimiter' => caGetOption('delimiter', $pa_options, $vs_display_delimiter), 'resolveLinksUsing' => $vs_rel_table, 'primaryIDs' => $va_primary_ids));
                 } else {
                     $va_items[$va_relation[$vs_rel_pk]]['_display'] = $va_items[$va_relation[$vs_rel_pk]]['label'];
                 }
@@ -2690,16 +2690,16 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 		if (!$g_request) { return $pa_text; }
 		
 		foreach($pa_text as $vn_i => $vs_text) {
-			$vs_text = preg_replace("!([A-Za-z0-9]+)='([^']*)'!", "$1=\"$2\"", $vs_text);	
+			$vs_text = preg_replace("!([A-Za-z0-9]+)='([^']*)'!", "$1=\"$2\"", $vs_text);
 			$va_l_tags = array();
 			$o_links = $o_doc('l');
-			
+
 			foreach($o_links as $o_link) {
 				if (!$o_link) { continue; }
 				$vs_html = $o_link->html();
 				
-				$vs_content = preg_replace("!^<[^\>]+>!", "", $vs_html);
-				$vs_content = preg_replace("!<[^\>]+>$!", "", $vs_content);
+				$vs_content = preg_replace("!^<[^>]+>!", "", $vs_html);
+				$vs_content = preg_replace("!<[^>]+>$!", "", $vs_content);
 		
 				$va_l_tags[] = array('directive' => html_entity_decode($vs_html), 'content' => $vs_content);	//html_entity_decode
 			}
@@ -2731,7 +2731,7 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 				}
 				$va_links[] = $vs_content;
 			} else {
-				if (isset($pa_options['requireLinkTags']) && $pa_options['requireLinkTags']) { 
+				if (isset($pa_options['requireLinkTags']) && $pa_options['requireLinkTags']) {
 					$va_links[] = $vs_text;
 					continue;
 				}

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2698,8 +2698,8 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^([0-9]+(?=[.,;])|[\/A-Za-
 				if (!$o_link) { continue; }
 				$vs_html = $o_link->html();
 				
-				$vs_content = preg_replace("!^<[^>]+>!", "", $vs_html);
-				$vs_content = preg_replace("!<[^>]+>$!", "", $vs_content);
+				$vs_content = preg_replace("!^<[^\>]+>!", "", $vs_html);
+				$vs_content = preg_replace("!<[^\>]+>$!", "", $vs_content);
 		
 				$va_l_tags[] = array('directive' => html_entity_decode($vs_html), 'content' => $vs_content);	//html_entity_decode
 			}

--- a/tests/testsWithData/get/DisplayTemplateParserTest.php
+++ b/tests/testsWithData/get/DisplayTemplateParserTest.php
@@ -132,7 +132,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		));
 		$this->assertGreaterThan(0, $vn_object_id);
 		$this->opt_object = new ca_objects($vn_object_id);
-
+		
 		$vn_rel_object_id = $this->opn_rel_object_id = $this->addTestRecord('ca_objects', array(
 			'intrinsic_fields' => array(
 				'type_id' => 'image',
@@ -163,7 +163,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 			)
 		));
 		$this->assertGreaterThan(0, $vn_rel_object_id);
-
+		
 		$vn_entity_id = $this->addTestRecord('ca_entities', array(
 			'intrinsic_fields' => array(
 				'type_id' => 'ind',
@@ -200,7 +200,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		));
 
 		$this->assertGreaterThan(0, $vn_entity_id);
-
+		
 		$this->opn_entity_id1 = $vn_entity_id;
 
 		$vn_entity_id = $this->addTestRecord('ca_entities', array(
@@ -251,7 +251,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("Name: ^ca_objects.preferred_labels.name<ifnotdef code='ca_objects.idno'> (^ca_objects.idno)</ifnotdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('Name: My test image', $vm_ret[0]);
-	}
+	}	
 	# -------------------------------------------------------
 	public function testBasicAttributesSingleRowWithIfDef() {
 		// Get fields for primary rows (single row)
@@ -269,7 +269,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertEquals('Name: Another image (TEST.2)', $vm_ret[1]);
 	}
 	# -------------------------------------------------------
-	public function testBasicFieldsWithIfDefMultipleRows() {
+	public function testBasicFieldsWithIfDefMultipleRows() {	
 		// Get fields for primary rows with <ifdef> (multiple row)
 		$vm_ret = DisplayTemplateParser::evaluate("Name: ^ca_objects.preferred_labels.name<ifdef code='ca_objects.idno'> (^ca_objects.idno)</ifdef>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -278,7 +278,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertEquals('Name: Another image (TEST.2)', $vm_ret[1]);
 	}
 	# -------------------------------------------------------
-	public function testBasicFieldsWithIfNotDefMultipleRows() {
+	public function testBasicFieldsWithIfNotDefMultipleRows() {	
 		// Get fields for primary rows with <ifnotdef> (multiple row)
 		$vm_ret = DisplayTemplateParser::evaluate("Name: ^ca_objects.preferred_labels.name<ifnotdef code='ca_objects.idno'> (^ca_objects.idno)</ifnotdef>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -287,14 +287,14 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertEquals('Name: Another image', $vm_ret[1]);
 	}
 	# -------------------------------------------------------
-	public function testBasicFormatWithRelated() {
+	public function testBasicFormatWithRelated() {	
 		// Get related values
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => ^ca_entities.preferred_labels.displayname", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson;Bart Simpson', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testBasicFormatWithRelatedAndTagOpts() {
+	public function testBasicFormatWithRelatedAndTagOpts() {	
 		// Get related values with tag-option delimiter
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => ^ca_entities.preferred_labels.displayname%delimiter=,_", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -312,7 +312,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' delimiter=', ' restrictToTypes='ind'>^ca_entities.preferred_labels.displayname (^ca_entities.lifespan)</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson (after December 17 1989), Bart Simpson ()', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' delimiter=', ' restrictToTypes='org'>^ca_entities.preferred_labels.displayname (^ca_entities.lifespan)</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => ', $vm_ret[0]);
@@ -322,41 +322,41 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' delimiter=', ' excludeTypes='org'>^ca_entities.preferred_labels.displayname (^ca_entities.lifespan)</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson (after December 17 1989), Bart Simpson ()', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' delimiter=', ' excludeTypes='ind'>^ca_entities.preferred_labels.displayname (^ca_entities.lifespan)</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => ', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testUnitsWithRelatedValuesAndIfDef() {
+	public function testUnitsWithRelatedValuesAndIfDef() {		
 		// Get related values in <unit> with <ifdef>
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' delimiter=', '>^ca_entities.preferred_labels.displayname<ifdef code='ca_entities.lifespan'> (^ca_entities.lifespan)</ifdef></unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson (after December 17 1989), Bart Simpson', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testUnitsWithRelatedValuesAndIfDefAndRestrictToRelationshipTypes() {
+	public function testUnitsWithRelatedValuesAndIfDefAndRestrictToRelationshipTypes() {		
 		// Get related values in <unit> with <ifdef> and restrictToRelationshipTypes
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' restrictToRelationshipTypes='creator' delimiter=', '>^ca_entities.preferred_labels.displayname<ifdef code='ca_entities.lifespan'> (^ca_entities.lifespan)</ifdef></unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson (after December 17 1989)', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testUnitsWithRelatedValuesAndIfDefAndMultRestrictToRelationshipTypes() {
+	public function testUnitsWithRelatedValuesAndIfDefAndMultRestrictToRelationshipTypes() {		
 		// Get related values in <unit> with <ifdef> and restrictToRelationshipTypes
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' restrictToRelationshipTypes='creator,publisher' delimiter=', '>^ca_entities.preferred_labels.displayname<ifdef code='ca_entities.lifespan'> (^ca_entities.lifespan)</ifdef></unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Homer J. Simpson (after December 17 1989), Bart Simpson', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testUnitsWithRelatedValuesAndIfDefAndExcludeRelationshipTypes() {
+	public function testUnitsWithRelatedValuesAndIfDefAndExcludeRelationshipTypes() {		
 		// Get related values in <unit> with <ifdef> and excludeRelationshipTypes
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' excludeRelationshipTypes='creator' delimiter=', '>^ca_entities.preferred_labels.displayname<ifdef code='ca_entities.lifespan'> (^ca_entities.lifespan)</ifdef></unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Bart Simpson', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
-	public function testUnitsWithRelatedValuesAndIfDefAndMultExcludeRelationshipTypes() {
+	public function testUnitsWithRelatedValuesAndIfDefAndMultExcludeRelationshipTypes() {		
 		// Get related values in <unit> with <ifdef> and excludeRelationshipTypes
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name (^ca_objects.idno) => <unit relativeTo='ca_entities' excludeRelationshipTypes='creator,publisher' delimiter=', '>^ca_entities.preferred_labels.displayname<ifdef code='ca_entities.lifespan'> (^ca_entities.lifespan)</ifdef></unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -377,14 +377,14 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('My test image (TEST.1) => Another image', $vm_ret[0]);
-	}
+	}	
 	# -------------------------------------------------------
 	public function testFormatsWithIfCount() {
 		// <ifcount>
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount code='ca_entities' min='0' max='2'>^ca_entities.preferred_labels.displayname</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('Homer J. Simpson, Bart Simpson', $vm_ret[0]);
-
+		
 		// <ifcount>
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
@@ -396,7 +396,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount restrictToRelationshipTypes='publisher' code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname%restrictToRelationshipTypes=publisher</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount restrictToRelationshipTypes='publisher,creator' code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname%restrictToRelationshipTypes=creator,publisher</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
@@ -407,7 +407,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount excludeRelationshipTypes='publisher' code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname%restrictToRelationshipTypes=publisher</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount excludeRelationshipTypes='publisher,creator' code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname%restrictToRelationshipTypes=publisher</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', '));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
@@ -418,7 +418,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', ', 'includeBlankValuesInArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(2, $vm_ret);
-
+		
 		// <ifcount> with restrictToRelationshipTypes
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount restrictToRelationshipTypes='publisher' code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname%restrictToRelationshipTypes=publisher</ifcount>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true, 'delimiter' => ', ', 'includeBlankValuesInArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -436,8 +436,8 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true, 'delimiter' => ', ', 'includeBlankValuesInArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertEquals('Idno was TEST.1', trim($vm_ret[0]));		// <case> includes whitespace we need to get rid of for comparison
-
-
+		
+		
 		$vm_ret = DisplayTemplateParser::evaluate("
 			<case>
 				<ifcount code='ca_entities' min='1' max='1'>^ca_entities.preferred_labels.displayname</ifcount>
@@ -477,7 +477,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("Name: <b>^ca_objects.preferred_labels.name</b> (^ca_objects.idno)", "ca_objects", array($this->opn_object_id), array('skipIfExpression' => '^ca_objects.description =~ /First/', 'returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("Name: <b>^ca_objects.preferred_labels.name</b> (^ca_objects.idno)", "ca_objects", array($this->opn_object_id), array('skipIfExpression' => '^ca_objects.description =~ /NICHTS/', 'returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
@@ -488,12 +488,12 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("URL: <l>^ca_objects.preferred_labels.name</l> (^ca_objects.idno)", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertContains("editor/objects/ObjectEditor/Summary/object_id/{$this->opn_object_id}\">My test image</a> (TEST.1)", $vm_ret[0]);
-
+		$this->assertContains("editor/objects/ObjectEditor/Summary/object_id/{$this->opn_object_id}/rel/1\">My test image</a> (TEST.1)", $vm_ret[0]);
+		
 		$vm_ret = DisplayTemplateParser::evaluate("URL: ^ca_objects.preferred_labels.name (^ca_objects.idno)", "ca_objects", array($this->opn_object_id), array('requireLinkTags' => false, 'returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertContains("editor/objects/ObjectEditor/Summary/object_id/{$this->opn_object_id}'>URL: My test image (TEST.1)</a>", $vm_ret[0]);
+		$this->assertContains("editor/objects/ObjectEditor/Summary/object_id/{$this->opn_object_id}/rel/1'>URL: My test image (TEST.1)</a>", $vm_ret[0]);
 	}
 	# -------------------------------------------------------
 	public function testFormatsWithPlaceholderPrefixOption() {
@@ -509,7 +509,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertCount(2, $vm_ret);
 		$this->assertEquals('10.0 in X 2.0000 lb; 5.0 in X 3.0000 lb', $vm_ret[0]);
 		$this->assertEquals('1.0 in', trim($vm_ret[1]));
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit>^ca_objects.dimensions.dimensions_weight <between>X</between> ^ca_objects.dimensions.dimensions_length</unit>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(2, $vm_ret);
@@ -523,7 +523,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertCount(2, $vm_ret);
 		$this->assertEquals('10.0 in X 2.0000 lb; 5.0 in X 3.0000 lb', $vm_ret[0]);
 		$this->assertEquals('1.0 in', trim($vm_ret[1]));
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_objects'>^ca_objects.dimensions.dimensions_weight <more>X</more> ^ca_objects.dimensions.dimensions_length</unit>", "ca_objects", array($this->opn_object_id, $this->opn_rel_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(2, $vm_ret);
@@ -536,7 +536,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Description: First description, Second description, Third description', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("Description: <if rule='^ca_objects.description =~ /Fourth/'>^ca_objects.description%delimiter=,_</if>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
@@ -559,10 +559,10 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 	# -------------------------------------------------------
 	public function testFormatsWithRepeatingAttributeUnit() {
 		$vm_ret = DisplayTemplateParser::evaluate("Dimensions are: <unit delimiter='; ' relativeTo='ca_objects.dimensions'>^ca_objects.dimensions.dimensions_length / ^ca_objects.dimensions.dimensions_weight / ^ca_objects.dimensions.measurement_notes</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
-
+		
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-
+		
 		$this->assertEquals('Dimensions are: 10.0 in / 2.0000 lb / foo; 5.0 in / 3.0000 lb / meow', $vm_ret[0]);
 	}
 	# -------------------------------------------------------
@@ -577,36 +577,36 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$vm_ret = DisplayTemplateParser::evaluate("The current primary is ^primary. This has nothing to do with object ^ca_objects.idno", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("The current primary is ca_objects. This has nothing to do with object TEST.1", $vm_ret[0]);
-
+		$this->assertEquals("The current primary is ca_objects. This has nothing to do with object TEST.1", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' '>The current primary is ^primary.</unit> This has nothing to do with object ^ca_objects.idno", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("The current primary is ca_entities. The current primary is ca_entities. This has nothing to do with object TEST.1", $vm_ret[0]);
+		$this->assertEquals("The current primary is ca_entities. The current primary is ca_entities. This has nothing to do with object TEST.1", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 	public function testFormatsWithCount() {
 		$vm_ret = DisplayTemplateParser::evaluate("The current count is ^count. This has nothing to do with object ^ca_objects.idno", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("The current count is 1. This has nothing to do with object TEST.1", $vm_ret[0]);
-
+		$this->assertEquals("The current count is 1. This has nothing to do with object TEST.1", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' '>The current count is ^count.</unit> This has nothing to do with object ^ca_objects.idno", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("The current count is 2. The current count is 2. This has nothing to do with object TEST.1", $vm_ret[0]);
+		$this->assertEquals("The current count is 2. The current count is 2. This has nothing to do with object TEST.1", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 	public function testFormatsWithIndex() {
 		$vm_ret = DisplayTemplateParser::evaluate("This is row ^index of ^count", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("This is row 1 of 1", $vm_ret[0]);
-
+		$this->assertEquals("This is row 1 of 1", $vm_ret[0]);	
+			
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' '>^ca_entities.preferred_labels.displayname is row ^index of ^count.</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson is row 1 of 2. Bart Simpson is row 2 of 2.", $vm_ret[0]);
+		$this->assertEquals("Homer J. Simpson is row 1 of 2. Bart Simpson is row 2 of 2.", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 	public function testFormatsWithDate() {
@@ -615,7 +615,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals("The current date is {$vs_date}. This has nothing to do with object TEST.1", $vm_ret[0]);
-
+		
 		$vs_date = date('M:d:Y'); // you execute this test right at the stroke of midnight it might fail...
 		$vm_ret = DisplayTemplateParser::evaluate("The current date is ^DATE%format=M:d:Y. This has nothing to do with object ^ca_objects.idno", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
@@ -628,29 +628,29 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Value was detected', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifdef code='ca_objects.formatNotes;ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifdef code='ca_objects.preferred_labels.name;ca_objects.idno;ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Value was detected', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifdef code='ca_objects.preferred_labels.name;ca_objects.idno;ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Value was detected', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifnotdef code='ca_objects.preferred_labels.name;ca_objects.idno;ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifnotdef code='ca_objects.formatNotes,ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifnotdef code='ca_objects.formatNotes|ca_objects.description'>Value was detected</ifdef>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
@@ -662,7 +662,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Value was detected', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount code='ca_objects.formatNotes|ca_objects.preferred_labels.name' min='1' max='4'>Value was detected</ifcount>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(0, $vm_ret);
@@ -678,58 +678,58 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 	public function testDirectivesNestedInStaticHTMLForDisplay() {
 		// Relative to relationship table as is done for displays
 		$va_relation_ids = $this->opt_object->get('ca_objects_x_entities.relation_id', ['returnAsArray' => true]);
-
+	
 		$vm_ret = DisplayTemplateParser::evaluate('<ul style="list-style-type:none"><li><unit relativeTo="ca_entities"><l>^ca_entities.preferred_labels.displayname</l> (^ca_entities.idno)</li></unit></ul>', "ca_objects_x_entities", $va_relation_ids, array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(2, $vm_ret);
 		$this->assertInternalType('string', $vm_ret[0]);
 		$this->assertInternalType('string', $vm_ret[1]);
-
-		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id1."\">Homer J. Simpson</a> (hjs)</li></ul>", $vm_ret[0]);
-		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id2."\">Bart Simpson</a> (bs)</li></ul>", $vm_ret[1]);
+	
+		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id1."/rel/1\">Homer J. Simpson</a> (hjs)</li></ul>", $vm_ret[0]);
+		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id2."/rel/1\">Bart Simpson</a> (bs)</li></ul>", $vm_ret[1]);
 	}
 	# -------------------------------------------------------
 	public function testStringFormattingTagOpts() {
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%toUpper=1", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("MY TEST IMAGE", $vm_ret[0]);
-
+		$this->assertEquals("MY TEST IMAGE", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%toLower=1", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("my test image", $vm_ret[0]);
-
+		$this->assertEquals("my test image", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%toUpper&start=1&length=5", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Y TES", $vm_ret[0]);
-
+		$this->assertEquals("Y TES", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=10&ellipsis", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("My test...", $vm_ret[0]);
-
+		$this->assertEquals("My test...", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=13&ellipsis", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals("My test image", $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=12&ellipsis=1", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("My test i...", $vm_ret[0]);
-
+		$this->assertEquals("My test i...", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=11&ellipsis=1&toLower", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("my test ...", $vm_ret[0]);
-
+		$this->assertEquals("my test ...", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=11&ellipsis=1&toLower&trim", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("my test...", $vm_ret[0]);
-
+		$this->assertEquals("my test...", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("^ca_objects.preferred_labels.name%length=11&ellipsis=0&toLower=1", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
@@ -743,66 +743,66 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
 		$this->assertEquals('Here are the descriptions: First description', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("Here are the descriptions: <unit delimiter='... ' start='1' length='2'>^ca_objects.description</unit><whenunitomits>omit=^omitcount</whenunitomits>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
-		$this->assertCount(1, $vm_ret);
+		$this->assertCount(1, $vm_ret); 
 		$this->assertEquals('Here are the descriptions: Second description... Third description', $vm_ret[0]);
 
 		// Related tables
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='0' length='1'>^ca_entities.preferred_labels.displayname is row ^index of ^count.</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson is row 1 of 2.", $vm_ret[0]);
+		$this->assertEquals("Homer J. Simpson is row 1 of 2.", $vm_ret[0]);	
 		}
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='1' length='1'>^ca_entities.preferred_labels.displayname is row ^index of ^count.</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Bart Simpson is row 2 of 2.", $vm_ret[0]);
-
+		$this->assertEquals("Bart Simpson is row 2 of 2.", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='0' length='2'>^ca_entities.preferred_labels.displayname is row ^index of ^count.</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson is row 1 of 2. Bart Simpson is row 2 of 2.", $vm_ret[0]);
-
+		$this->assertEquals("Homer J. Simpson is row 1 of 2. Bart Simpson is row 2 of 2.", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='1' length='2'>^ca_entities.preferred_labels.displayname</unit><whenunitomits> and ^omitcount more</whenunitomits>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Bart Simpson and 1 more", $vm_ret[0]);
-
+		$this->assertEquals("Bart Simpson and 1 more", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='0' length='2'>^ca_entities.preferred_labels.displayname</unit><whenunitomits> and ^omitcount more</whenunitomits>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson Bart Simpson", $vm_ret[0]);
-
+		$this->assertEquals("Homer J. Simpson Bart Simpson", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter=' ' start='0' length='1'>^ca_entities.preferred_labels.displayname</unit><whenunitomits> and ^omitcount more</whenunitomits>; <unit relativeTo='ca_entities' delimiter=' ' start='1' length='2'>^ca_entities.preferred_labels.displayname</unit><whenunitomits> and ^omitcount more</whenunitomits>; <unit relativeTo='ca_entities' delimiter=' ' start='0' length='2'>^ca_entities.preferred_labels.displayname</unit><whenunitomits> and ^omitcount more</whenunitomits>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson and 1 more; Bart Simpson and 1 more; Homer J. Simpson Bart Simpson", $vm_ret[0]);
+		$this->assertEquals("Homer J. Simpson and 1 more; Bart Simpson and 1 more; Homer J. Simpson Bart Simpson", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 	public function testTemplateWithNewLines() {
-
+	
 		$vm_ret = DisplayTemplateParser::evaluate('<ifcount code="ca_entities" min="1"><p><strong>People</strong><br/><unit delimiter="; " relativeTo="ca_entities"><a href="/index.php/MultiSearch/Index/search/ca_entities.entity_id:^ca_entities.entity_id">^ca_entities.preferred_labels.displayname</a></unit></p></ifcount>', "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-
+		
 		$this->assertContains("/MultiSearch/Index/search/ca_entities.entity_id:".$this->opn_entity_id1."\">Homer J. Simpson</a>", $vm_ret[0]);
 		$this->assertContains("/MultiSearch/Index/search/ca_entities.entity_id:".$this->opn_entity_id2."\">Bart Simpson</a>", $vm_ret[0]);
-
-
+		
+		
 		$vm_ret = DisplayTemplateParser::evaluate('<ifcount code="ca_entities.related" min="1">
 				<ifcount code="ca_entities.related" min="1" max="1"><img src="left1.png"><strong>Related person</strong><img src="right1.png"><br/></ifcount>
 				<ifcount code="ca_entities.related" min="2"><img src="left2.png"><strong>Related people</strong><img src="right2.png"><br/></ifcount>
 				<unit relativeTo="ca_entities.related" delimiter="<br/>"><l>^ca_entities.preferred_labels.displayname</l></unit><br/><br/>
 				</ifcount>', "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
-
+		
 		$this->assertInternalType('array', $vm_ret);
-		$this->assertCount(1, $vm_ret);
-		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id1."\">Homer J. Simpson</a>", $vm_ret[0]);
-		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id2."\">Bart Simpson</a>", $vm_ret[0]);
+		$this->assertCount(1, $vm_ret);	
+		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id1."/rel/1\">Homer J. Simpson</a>", $vm_ret[0]);
+		$this->assertContains("editor/entities/EntityEditor/Summary/entity_id/".$this->opn_entity_id2."/rel/1\">Bart Simpson</a>", $vm_ret[0]);
 		$this->assertContains('<img src="left2.png" /><strong>Related people</strong><img src="right2.png" />', $vm_ret[0]);
-
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<ifcount code=\"ca_entities\" min=\"1\">
 			<script type='text/javascript'>
 				jQuery(document).ready(function() {
@@ -813,7 +813,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 						.jcarousel({
 							// Options go here
 						});
-
+			
 					/*
 					 Prev control initialization
 					 */
@@ -828,7 +828,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 							// Options go here
 							target: '-=1'
 						});
-
+			
 					/*
 					 Next control initialization
 					 */
@@ -845,10 +845,10 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 						});
 				});
 			</script></ifcount>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
-
+	
 		$this->assertInternalType('array', $vm_ret);
-		$this->assertCount(1, $vm_ret);
-
+		$this->assertCount(1, $vm_ret);	
+		
 		$this->assertEquals("
 			<script type=\"text/javascript\">
 				jQuery(document).ready(function() {
@@ -859,7 +859,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 						.jcarousel({
 							// Options go here
 						});
-
+			
 					/*
 					 Prev control initialization
 					 */
@@ -874,7 +874,7 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 							// Options go here
 							target: '-=1'
 						});
-
+			
 					/*
 					 Next control initialization
 					 */
@@ -890,26 +890,19 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 							target: '+=1'
 						});
 				});
-			</script>", $vm_ret[0]);
+			</script>", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 	public function testAttributesWithHTML() {
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter='<br/>'>^ca_entities.preferred_labels.displayname</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson<br/>Bart Simpson", $vm_ret[0]);
-
+		$this->assertEquals("Homer J. Simpson<br/>Bart Simpson", $vm_ret[0]);	
+		
 		$vm_ret = DisplayTemplateParser::evaluate("<unit relativeTo='ca_entities' delimiter='  <br/>  '>^ca_entities.preferred_labels.displayname</unit>", "ca_objects", array($this->opn_object_id), array('returnAsArray' => true));
 		$this->assertInternalType('array', $vm_ret);
 		$this->assertCount(1, $vm_ret);
-		$this->assertEquals("Homer J. Simpson  <br/>  Bart Simpson", $vm_ret[0]);
-	}
-	# -------------------------------------------------------
-	public function testStartLength() {
-		$this->assertEquals('5.0 in x 3.0000 lb', trim(DisplayTemplateParser::evaluate("
-		<unit relativeTo='ca_objects.dimensions' start='1' length='1'>
-			^ca_objects.dimensions.dimensions_length x ^ca_objects.dimensions.dimensions_weight
-		</unit>", 'ca_objects', array($this->opn_object_id))));
+		$this->assertEquals("Homer J. Simpson  <br/>  Bart Simpson", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
 }

--- a/tests/testsWithData/get/DisplayTemplateParserTest.php
+++ b/tests/testsWithData/get/DisplayTemplateParserTest.php
@@ -905,4 +905,11 @@ class DisplayTemplateParserTest extends BaseTestWithData {
 		$this->assertEquals("Homer J. Simpson  <br/>  Bart Simpson", $vm_ret[0]);	
 	}
 	# -------------------------------------------------------
+	public function testStartLength() {
+		$this->assertEquals('5.0 in x 3.0000 lb', trim(DisplayTemplateParser::evaluate("
+		<unit relativeTo='ca_objects.dimensions' start='1' length='1'>
+			^ca_objects.dimensions.dimensions_length x ^ca_objects.dimensions.dimensions_weight
+		</unit>", 'ca_objects', array($this->opn_object_id))));
+	}
+	# -------------------------------------------------------
 }


### PR DESCRIPTION
+ When processing related records, link (`<l>`) tags
  were not working correctly, then never generated an
  HTML link (`<a>`) tag.
+ This fixes the issue by passing the related table and
  primary key, instead of the relationship table and
  primary key.

IDE also auto-fixed a bunch of whitespace, append `?w=1` to the github URL to ignore it.