### PR TITLE
NOJIRA fix fatal error class ca_metadata_elements is not defined

### DIFF
--- a/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/ca/BundlableLabelableBaseModelWithAttributes.php
@@ -93,7 +93,8 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		require_once(__CA_MODELS_DIR__."/ca_editor_uis.php");
 		require_once(__CA_MODELS_DIR__."/ca_acl.php");
 		require_once(__CA_MODELS_DIR__.'/ca_metadata_dictionary_entries.php');
-		
+		require_once(__CA_MODELS_DIR__.'/ca_metadata_elements.php');
+
 		parent::__construct($pn_id);	# call superclass constructor
 		
 		if ($pn_id) {


### PR DESCRIPTION
Fixes for PROV-1566 seem to have broken quick add, and also possibly the hierarchy browser due to undefined class `ca_metadata_elements`.

I've added the include in `__construct()` as a number of other files are included there.