### PR TITLE
PROV-1618 Related items can now be sorted by arbitrary values in relationship bundles

### DIFF
--- a/app/controllers/administrate/setup/BrowseListItemsController.php
+++ b/app/controllers/administrate/setup/BrowseListItemsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-
-			$this->opa_sorts = array_merge(array(
-				'_natural' => _t('relevance'),
-				'ca_list_item_labels.name_singular' => _t('name'),
-				'ca_list_items.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/administrate/setup/ListsController.php
+++ b/app/controllers/administrate/setup/ListsController.php
@@ -47,12 +47,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -65,13 +59,7 @@
 			$this->opa_views = array(
 				'list' => _t('list'),
 				'editable' => _t('editable')
-			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_list_item_labels.name_singular' => _t('name'),
-				'ca_list_items.idno_sort' => _t('idno')
-			), $this->opa_sorts);
+			);
 			
 			$this->opo_browse = new ListItemBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 			

--- a/app/controllers/administrate/setup/RelationshipTypesController.php
+++ b/app/controllers/administrate/setup/RelationshipTypesController.php
@@ -46,12 +46,6 @@
  		 */
  		protected $opa_views;
  		
- 		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
  		protected $ops_find_type = 'basic_search';
  		
  		# -------------------------------------------------------
@@ -60,10 +54,6 @@
 			$this->opa_views = array(
 				'list' => _t('list')
 			 );
-			 
-			 $this->opa_sorts = array(
-				'ca_relationship_type_labels.typename' => _t('type name')
-			);
 		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseCollectionsController.php
+++ b/app/controllers/find/BrowseCollectionsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_collection_labels.name' => _t('name'),
-			 	'ca_collections.type_id' => _t('type'),
-			 	'ca_collections.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseEntitiesController.php
+++ b/app/controllers/find/BrowseEntitiesController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,15 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_entity_labels.name_sort' => _t('display name'),
-			 	'ca_entity_labels.surname;ca_entity_labels.forename' => _t('surname, forename'),
-			 	'ca_entity_labels.forename' => _t('forename'),
-			 	'ca_entities.type_id;ca_entity_labels.surname;ca_entity_labels.forename' => _t('type'),
-			 	'ca_entities.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseLoansController.php
+++ b/app/controllers/find/BrowseLoansController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_loan_labels.displayname' => _t('name'),
-			 	'ca_loans.type_id' => _t('type'),
-			 	'ca_loans.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseMovementsController.php
+++ b/app/controllers/find/BrowseMovementsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_movement_labels.name' => _t('short description'),
-			 	'ca_movements.type_id' => _t('type'),
-			 	'ca_movements.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseObjectLotsController.php
+++ b/app/controllers/find/BrowseObjectLotsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_object_lot_labels.name' => _t('name'),
-			 	'ca_object_lots.type_id' => _t('type'),
-			 	'ca_object_lots.idno_stub_sort' => _t('lot idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseObjectRepresentationsController.php
+++ b/app/controllers/find/BrowseObjectRepresentationsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_object_representation_labels.name' => _t('name'),
-			 	'ca_object_representations.type_id' => _t('type'),
-			 	'ca_object_representations.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseObjectsController.php
+++ b/app/controllers/find/BrowseObjectsController.php
@@ -47,13 +47,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -73,12 +66,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_object_labels.name' => _t('title'),
-			 	'ca_objects.type_id' => _t('type'),
-			 	'ca_objects.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		public function Index($pa_options=null) {

--- a/app/controllers/find/BrowseOccurrencesController.php
+++ b/app/controllers/find/BrowseOccurrencesController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,11 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_occurrence_labels.name' => _t('name'),
-			 	'ca_occurrences.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowsePlacesController.php
+++ b/app/controllers/find/BrowsePlacesController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,12 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_place_labels.name' => _t('name'),
-			 	'ca_places.type_id' => _t('type'),
-			 	'ca_places.idno_sort' => _t('idno')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseStorageLocationsController.php
+++ b/app/controllers/find/BrowseStorageLocationsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,11 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'ca_storage_location_labels.name' => _t('name'),
-			 	'ca_storage_locations.type_id' => _t('type')
-			 ), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseTourStopsController.php
+++ b/app/controllers/find/BrowseTourStopsController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,10 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_tour_stop_labels.displayname' => _t('name')
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/BrowseToursController.php
+++ b/app/controllers/find/BrowseToursController.php
@@ -46,13 +46,6 @@
  		 * Is associative array: keys are view labels, values are view specifier to be incorporated into view name
  		 */ 
  		protected $opa_views;
- 		 
- 		 
- 		/**
- 		 * List of available result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
  		
  		/**
  		 * Name of "find" used to defined result context for ResultContext object
@@ -69,10 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'ca_tour_labels.name' => _t('name'),
-			), $this->opa_sorts);
  		}
  		# -------------------------------------------------------
  		/**

--- a/app/controllers/find/ObjectTableController.php
+++ b/app/controllers/find/ObjectTableController.php
@@ -53,12 +53,6 @@ class ObjectTableController extends BaseSearchController {
 	protected $opa_views;
 
 	/**
-	 * List of available search-result sorting fields
-	 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
-	 */
-	protected $opa_sorts;
-
-	/**
 	 * Name of "find" used to defined result context for ResultContext object
 	 * Must be unique for the table and have a corresponding entry in find_navigation.conf
 	 */
@@ -71,13 +65,6 @@ class ObjectTableController extends BaseSearchController {
 		$this->opa_views = array(
 			'list' => _t('list'),
 		);
-
-		$this->opa_sorts = array_merge(array(
-			'_natural' => _t('relevance'),
-			'ca_object_labels.name_sort' => _t('title'),
-			'ca_objects.type_id' => _t('type'),
-			'ca_objects.idno_sort' => _t('idno')
-		), $this->opa_sorts);
 
 		$this->opo_browse = new ObjectBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 

--- a/app/controllers/find/SearchCollectionsAdvancedController.php
+++ b/app/controllers/find/SearchCollectionsAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_collection_labels.name_sort' => _t('name'),
-			 	'ca_collections.type_id' => _t('type'),
-			 	'ca_collections.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new CollectionBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchCollectionsController.php
+++ b/app/controllers/find/SearchCollectionsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,12 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_collection_labels.name_sort' => _t('name'),
-				'ca_collections.idno_sort' => _t('idno')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new CollectionBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchEntitiesAdvancedController.php
+++ b/app/controllers/find/SearchEntitiesAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,15 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_entity_labels.name_sort' => _t('display name'),
-			 	'ca_entity_labels.surname;ca_entity_labels.forename' => _t('surname, forename'),
-			 	'ca_entity_labels.forename' => _t('forename'),
-			 	'ca_entities.type_id;ca_entity_labels.surname;ca_entity_labels.forename' => _t('type'),
-			 	'ca_entities.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 		
 			$this->opo_browse = new EntityBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchEntitiesController.php
+++ b/app/controllers/find/SearchEntitiesController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -65,16 +59,7 @@
 			$this->opa_views = array(
 				'list' => _t('list'),
 				'editable' => _t('editable')
-			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_entity_labels.name_sort' => _t('display name'),
-			 	'ca_entity_labels.surname;ca_entity_labels.forename' => _t('surname, forename'),
-			 	'ca_entity_labels.forename' => _t('forename'),
-			 	'ca_entities.type_id;ca_entity_labels.surname;ca_entity_labels.forename' => _t('type'),
-			 	'ca_entities.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
+			);
 			 
 			 $this->opo_browse = new EntityBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchLoansAdvancedController.php
+++ b/app/controllers/find/SearchLoansAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_loan_labels.name_sort' => _t('short description'),
-			 	'ca_loans.type_id' => _t('type'),
-			 	'ca_loans.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 		
 			$this->opo_browse = new LoanBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchLoansController.php
+++ b/app/controllers/find/SearchLoansController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,13 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_loan_labels.name' => _t('short description'),
-			 	'ca_loans.type_id' => _t('type'),
-			 	'ca_loans.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new LoanBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchMovementsAdvancedController.php
+++ b/app/controllers/find/SearchMovementsAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_movement_labels.name' => _t('short description'),
-			 	'ca_movements.type_id' => _t('type'),
-			 	'ca_movements.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 		
 			$this->opo_browse = new MovementBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchMovementsController.php
+++ b/app/controllers/find/SearchMovementsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,13 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_movement_labels.name' => _t('short description'),
-			 	'ca_movements.type_id;ca_movement_labels.name' => _t('type'),
-			 	'ca_movements.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new MovementBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchObjectLotsAdvancedController.php
+++ b/app/controllers/find/SearchObjectLotsAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_object_lot_labels.name_sort' => _t('name'),
-			 	'ca_object_lots.type_id' => _t('type'),
-			 	'ca_object_lots.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new ObjectLotBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchObjectLotsController.php
+++ b/app/controllers/find/SearchObjectLotsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,12 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			
-			$this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_object_lot_labels.name_sort' => _t('name'),
-				'ca_object_lots.idno_stub_sort' => _t('idno')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new ObjectLotBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchObjectRepresentationsAdvancedController.php
+++ b/app/controllers/find/SearchObjectRepresentationsAdvancedController.php
@@ -49,12 +49,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -67,13 +61,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_object_representation_labels.name_sort' => _t('name'),
-			 	'ca_object_representations.type_id' => _t('type'),
-			 	'ca_object_representations.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new ObjectRepresentationBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchObjectRepresentationsController.php
+++ b/app/controllers/find/SearchObjectRepresentationsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,12 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			 
-			$this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_object_representation_labels.name_sort' => _t('name'),
-				'ca_object_representations.idno_sort' => _t('idno')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new ObjectRepresentationBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchObjectsAdvancedController.php
+++ b/app/controllers/find/SearchObjectsAdvancedController.php
@@ -51,12 +51,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -71,13 +65,7 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_object_labels.name_sort' => _t('title'),
-			 	'ca_objects.type_id' => _t('type'),
-			 	'ca_objects.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
+
 			 $this->opo_browse = new ObjectBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}
  		# -------------------------------------------------------

--- a/app/controllers/find/SearchObjectsController.php
+++ b/app/controllers/find/SearchObjectsController.php
@@ -53,12 +53,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -73,13 +67,7 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_object_labels.name_sort' => _t('title'),
-			 	'ca_objects.type_id' => _t('type'),
-			 	'ca_objects.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
+
 			 $this->opo_browse = new ObjectBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}
  		# -------------------------------------------------------

--- a/app/controllers/find/SearchOccurrencesAdvancedController.php
+++ b/app/controllers/find/SearchOccurrencesAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_occurrence_labels.name_sort' => _t('name'),
-			 	'ca_occurrences.type_id' => _t('type'),
-			 	'ca_occurrences.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new OccurrenceBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchOccurrencesController.php
+++ b/app/controllers/find/SearchOccurrencesController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,12 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			
-			$this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_occurrence_labels.name_sort' => _t('name'),
-				'ca_occurrences.idno_sort' => _t('idno')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new OccurrenceBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 			 

--- a/app/controllers/find/SearchPlacesAdvancedController.php
+++ b/app/controllers/find/SearchPlacesAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_place_labels.name_sort' => _t('name'),
-			 	'ca_places.type_id' => _t('type'),
-			 	'ca_places.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new PlaceBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchPlacesController.php
+++ b/app/controllers/find/SearchPlacesController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,12 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_place_labels.name_sort' => _t('name'),
-				'ca_places.idno_sort' => _t('idno')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new PlaceBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchStorageLocationsAdvancedController.php
+++ b/app/controllers/find/SearchStorageLocationsAdvancedController.php
@@ -50,12 +50,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -68,13 +62,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_storage_locations_labels.name_sort' => _t('name'),
-			 	'ca_storage_locations.type_id' => _t('type'),
-			 	'ca_storage_locations.idno_sort' => _t('idno')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new StorageLocationBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchStorageLocationsController.php
+++ b/app/controllers/find/SearchStorageLocationsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,11 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			);
-			
-			$this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-				'ca_storage_location_labels.name_sort' => _t('name')
-			), $this->opa_sorts);
 			
 			$this->opo_browse = new StorageLocationBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchTourStopsAdvancedController.php
+++ b/app/controllers/find/SearchTourStopsAdvancedController.php
@@ -49,12 +49,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -67,11 +61,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_tour_stop_labels.name' => _t('name')
-			 ), $this->opa_sorts);
 		
 			$this->opo_browse = new TourStopBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchTourStopsController.php
+++ b/app/controllers/find/SearchTourStopsController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,11 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_tour_stop_labels.name' => _t('name')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new TourStopBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchToursAdvancedController.php
+++ b/app/controllers/find/SearchToursAdvancedController.php
@@ -49,12 +49,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -67,10 +61,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			 $this->opa_sorts = array_merge(array(
-			 	'ca_tour_labels.name_sort' => _t('name')
-			 ), $this->opa_sorts);
 		
 			$this->opo_browse = new TourBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/find/SearchToursController.php
+++ b/app/controllers/find/SearchToursController.php
@@ -48,12 +48,6 @@
  		protected $opa_views;
  		
  		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
- 		/**
  		 * Name of "find" used to defined result context for ResultContext object
  		 * Must be unique for the table and have a corresponding entry in find_navigation.conf
  		 */
@@ -66,11 +60,6 @@
 				'list' => _t('list'),
 				'editable' => _t('editable')
 			 );
-			 
-			  $this->opa_sorts = array_merge(array(
-			 	'_natural' => _t('relevance'),
-			 	'ca_tour_labels.name' => _t('name')
-			 ), $this->opa_sorts);
 			 
 			 $this->opo_browse = new TourBrowse($this->opo_result_context->getParameter('browse_id'), 'providence');
 		}

--- a/app/controllers/manage/CommentsController.php
+++ b/app/controllers/manage/CommentsController.php
@@ -47,12 +47,6 @@
  		 */ 
  		protected $opa_views;
  		
- 		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
  		# -------------------------------------------------------
  		public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
  			parent::__construct($po_request, $po_response, $pa_view_paths);
@@ -60,11 +54,6 @@
  		 	$this->opa_views = array(
 				'list' => _t('list')
 			 );
-			 
-			 $this->opa_sorts = array(
-				'ca_item_comments.created_on' => _t('date'),
-				'ca_item_comments.user_id' => _t('user')
-			);
 			 
  			AssetLoadManager::register('tableList');
  		}

--- a/app/controllers/manage/TagsController.php
+++ b/app/controllers/manage/TagsController.php
@@ -48,12 +48,6 @@
  		 */ 
  		protected $opa_views;
  		
- 		/**
- 		 * List of available search-result sorting fields
- 		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
- 		 */
- 		protected $opa_sorts;
- 		
  		# -------------------------------------------------------
  		public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
  			parent::__construct($po_request, $po_response, $pa_view_paths);
@@ -61,11 +55,6 @@
  		 	$this->opa_views = array(
 				'list' => _t('list')
 			 );
-			 
-			 $this->opa_sorts = array(
-				'ca_items_x_tags.created_on' => _t('date'),
-				'ca_items_x_tags.user_id' => _t('user')
-			);
 			 
  			AssetLoadManager::register('tableList');
  		}

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2927,24 +2927,30 @@ define("__CA_BUNDLE_DISPLAY_TEMPLATE_TAG_REGEX__", "/\^(ca_[A-Za-z]+[A-Za-z0-9_\
 	 *
 	 * @param RequestHTTP $po_request
 	 * @param string $ps_id_prefix
-	 * @param array $pa_settings
+	 * @param string $ps_table
 	 * 
 	 * @return string HTML implementing the control
 	 */
-	function caEditorBundleSortControls($po_request, $ps_id_prefix, $pa_settings) {
-		$vs_buf = "	<div class=\"caItemListSortControlContainer\">
-		<div class=\"caItemListSortControlTrigger\" id=\"{$ps_id_prefix}caItemListSortControlTrigger\">
-			"._t('Sort by')." <img src=\"".$po_request->getThemeUrlPath()."/graphics/icons/bg.gif\" alt=\"Sort\"/>
-		</div>
+	function caEditorBundleSortControls($po_request, $ps_id_prefix, $ps_table) {
+		if(!$ps_table) { $ps_table = 'ca_entities'; }
+		$va_sort_fields = caGetAvailableSortFields($ps_table, null);
+
+		$vs_buf = "
+		<div class=\"caItemListSortControlContainer\">
+			<div class=\"caItemListSortControlTrigger\" id=\"{$ps_id_prefix}caItemListSortControlTrigger\">
+				"._t('Sort by')." <img src=\"".$po_request->getThemeUrlPath()."/graphics/icons/bg.gif\" alt=\"Sort\"/>
+			</div>
 		<div class=\"caItemListSortControls\" id=\"{$ps_id_prefix}caItemListSortControls\">
-			<ul>
-				<li><a href=\"#\" onclick=\"caRelationBundle{$ps_id_prefix}.sort('name'); return false;\" class=\"caItemListSortControl\">"._t('name')."</a><br/></li>
-				<li><a href=\"#\" onclick=\"caRelationBundle{$ps_id_prefix}.sort('idno'); return false;\" class=\"caItemListSortControl\">"._t('idno')."</a><br/></li>
-				<li><a href=\"#\" onclick=\"caRelationBundle{$ps_id_prefix}.sort('type'); return false;\" class=\"caItemListSortControl\">"._t('type')."</a><br/></li>
-				<li><a href=\"#\" onclick=\"caRelationBundle{$ps_id_prefix}.sort('entry'); return false;\" class=\"caItemListSortControl\">"._t('entry')."</a><br/></li>
+			<ul>\n";
+
+		foreach($va_sort_fields as $vs_key => $vs_label) {
+			$vs_buf .= "<li><a href=\"#\" onclick=\"caRelationBundle{$ps_id_prefix}.sort('{$vs_key}'); return false;\" class=\"caItemListSortControl\">".$vs_label."</a><br/></li>\n";
+		}
+
+		$vs_buf .=	"
 			</ul>
 		</div>
-	</div>";
+		</div>";
 		
 		return $vs_buf;
 	}

--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1104,3 +1104,144 @@
 
 		return $va_return;
 	}
+	# ---------------------------------------
+	/**
+	 * get available sort fields for given table
+	 *
+	 * @param string $ps_table
+	 * @param null|int $pn_type_id
+	 * @return array
+	 */
+	function caGetAvailableSortFields($ps_table, $pn_type_id = null) {
+		switch($ps_table) {
+			case 'ca_list_items':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_list_item_labels.name_singular' => _t('name'),
+					'ca_list_items.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_relationship_types':
+				$va_base_fields = array(
+					'ca_relationship_type_labels.typename' => _t('type name')
+				);
+				break;
+			case 'ca_collections':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_collection_labels.name_sort' => _t('name'),
+					'ca_collections.type_id' => _t('type'),
+					'ca_collections.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_loans':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_loan_labels.name_sort' => _t('short description'),
+					'ca_loans.type_id' => _t('type'),
+					'ca_loans.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_movements':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_movement_labels.name' => _t('short description'),
+					'ca_movements.type_id;ca_movement_labels.name' => _t('type'),
+					'ca_movements.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_entities':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_entity_labels.name_sort' => _t('display name'),
+					'ca_entity_labels.surname;ca_entity_labels.forename' => _t('surname, forename'),
+					'ca_entity_labels.forename' => _t('forename'),
+					'ca_entities.type_id;ca_entity_labels.surname;ca_entity_labels.forename' => _t('type'),
+					'ca_entities.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_object_lots':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_object_lot_labels.name_sort' => _t('name'),
+					'ca_object_lots.type_id' => _t('type'),
+					'ca_object_lots.idno_stub_sort' => _t('idno')
+				);
+				break;
+			case 'ca_object_representations':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_object_representation_labels.name_sort' => _t('name'),
+					'ca_object_representations.type_id' => _t('type'),
+					'ca_object_representations.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_objects':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_object_labels.name_sort' => _t('title'),
+					'ca_objects.type_id' => _t('type'),
+					'ca_objects.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_occurrences':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_occurrence_labels.name_sort' => _t('name'),
+					'ca_occurrences.type_id' => _t('type'),
+					'ca_occurrences.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_places':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_place_labels.name_sort' => _t('name'),
+					'ca_places.type_id' => _t('type'),
+					'ca_places.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_storage_locations':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_storage_locations_labels.name_sort' => _t('name'),
+					'ca_storage_locations.type_id' => _t('type'),
+					'ca_storage_locations.idno_sort' => _t('idno')
+				);
+				break;
+			case 'ca_tours':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_tour_labels.name' => _t('name')
+				);
+				break;
+			case 'ca_tour_stops':
+				$va_base_fields = array(
+					'_natural' => _t('relevance'),
+					'ca_tour_stop_labels.name' => _t('name')
+				);
+				break;
+			case 'ca_item_comments':
+				$va_base_fields = array(
+					'ca_item_comments.created_on' => _t('date'),
+					'ca_item_comments.user_id' => _t('user')
+				);
+				break;
+			case 'ca_item_tags':
+				$va_base_fields = array(
+					'ca_items_x_tags.created_on' => _t('date'),
+					'ca_items_x_tags.user_id' => _t('user')
+				);
+			default:
+				$va_base_fields = array();
+				break;
+		}
+
+		$va_sortable_elements = ca_metadata_elements::getSortableElements($ps_table, $pn_type_id);
+
+		foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
+			$va_base_fields[$ps_table.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
+		}
+
+		return $va_base_fields;
+	}
+	# ---------------------------------------

--- a/app/lib/ca/BaseAdvancedSearchController.php
+++ b/app/lib/ca/BaseAdvancedSearchController.php
@@ -48,12 +48,7 @@ class BaseAdvancedSearchController extends BaseRefineableSearchController {
 	public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
 		parent::__construct($po_request, $po_response, $pa_view_paths);
 
-		$va_sortable_elements = ca_metadata_elements::getSortableElements($this->ops_tablename, $this->opn_type_restriction_id);
-
-		$this->opa_sorts = array();
-		foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
-			$this->opa_sorts[$this->ops_tablename.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
-		}
+		$this->opa_sorts = caGetAvailableSortFields($this->ops_tablename, $this->opn_type_restriction_id);
 	}
 	# -------------------------------------------------------
 	public function Index($pa_options=null) {

--- a/app/lib/ca/BaseBrowseController.php
+++ b/app/lib/ca/BaseBrowseController.php
@@ -73,12 +73,7 @@
 					$this->ops_view_default = $vs_view_default;
 				}
 				
-				$va_sortable_elements = ca_metadata_elements::getSortableElements($this->ops_tablename, $this->opn_type_restriction_id);
-		
-				$this->opa_sorts = array();
-				foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
-					$this->opa_sorts[$this->ops_tablename.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
-				}
+				$this->opa_sorts = caGetAvailableSortFields($this->ops_tablename, $this->opn_type_restriction_id);
 			}
  		}
  		# -------------------------------------------------------

--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -2279,4 +2279,34 @@ class BaseEditorController extends ActionController {
 		print json_encode($va_stored_files);
 	}
 	# -------------------------------------------------------
+	/**
+	 * Handle sort requests from form editor.
+	 * Gets passed a table name, a list of ids and a key to sort on. Will return a JSON list of the same IDs, just sorted.
+	 */
+	public function sort() {
+		if (!$this->getRequest()->isLoggedIn() || ((int)$this->getRequest()->user->get('userclass') !== 0)) {
+			$this->getResponse()->setRedirect($this->getRequest()->config->get('error_display_url').'/n/2320?r='.urlencode($this->getRequest()->getFullUrlPath()));
+			return;
+		}
+
+		$vs_table_name = $this->getRequest()->getParameter('table', pString);
+		$t_instance = $this->getAppDatamodel()->getInstance($vs_table_name, true);
+
+		$va_ids = explode(',', $this->getRequest()->getParameter('ids', pString));
+		$va_sort_keys = explode(',', $this->getRequest()->getParameter('sortKeys', pString));
+
+		if(!($vs_sort_direction = strtolower($this->getRequest()->getParameter('sortDirection', pString))) || !in_array($vs_sort_direction, array('asc', 'desc'))) {
+			$vs_sort_direction = 'asc';
+		}
+
+		if(!$t_instance) { return; }
+		if(!is_array($va_ids) || !sizeof($va_ids)) { return; }
+		if(!is_array($va_sort_keys) || !sizeof($va_sort_keys)) { return; }
+
+		$o_res = caMakeSearchResult($t_instance->tableName(), $va_ids, array('sort' => $va_sort_keys, 'sortDirection' => $vs_sort_direction));
+		$va_sorted_ids = $o_res->getAllFieldValues($t_instance->primaryKey());
+
+		print json_encode($va_sorted_ids);
+	}
+	# -------------------------------------------------------
 }

--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -2283,7 +2283,7 @@ class BaseEditorController extends ActionController {
 	 * Handle sort requests from form editor.
 	 * Gets passed a table name, a list of ids and a key to sort on. Will return a JSON list of the same IDs, just sorted.
 	 */
-	public function sort() {
+	public function Sort() {
 		if (!$this->getRequest()->isLoggedIn() || ((int)$this->getRequest()->user->get('userclass') !== 0)) {
 			$this->getResponse()->setRedirect($this->getRequest()->config->get('error_display_url').'/n/2320?r='.urlencode($this->getRequest()->getFullUrlPath()));
 			return;

--- a/app/lib/ca/BaseFindController.php
+++ b/app/lib/ca/BaseFindController.php
@@ -57,6 +57,13 @@
 		
  		protected $opb_type_restriction_has_changed = false;
  		protected $opn_type_restriction_id = null;
+
+		/**
+		 * List of available search-result sorting fields
+		 * Is associative array: values are display names for fields, keys are full fields names (table.field) to be used as sort
+		 */
+		protected $opa_sorts;
+
 		# ------------------------------------------------------------------
 		/**
 		 *
@@ -67,6 +74,7 @@
  			
  			parent::__construct($po_request, $po_response, $pa_view_paths);
  			$this->opo_datamodel = Datamodel::load();
+			$this->opa_sorts = array();
  			
  			if ($this->ops_tablename) {
 				$this->opo_result_context = new ResultContext($po_request, $this->ops_tablename, $this->ops_find_type);
@@ -858,12 +866,7 @@
  			$this->view->setVar('current_view', $vs_view);
  			
  			$vn_type_id 			= $this->opo_result_context->getTypeRestriction($vb_dummy);
- 			$va_sortable_elements = ca_metadata_elements::getSortableElements($this->ops_tablename, $vn_type_id);
- 			
- 			if (!is_array($this->opa_sorts)) { $this->opa_sorts = array(); }
- 			foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
- 				$this->opa_sorts[$this->ops_tablename.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
- 			}
+			$this->opa_sorts = caGetAvailableSortFields($this->ops_tablename, $vn_type_id);
  			
  			$this->view->setVar('sorts', $this->opa_sorts);	// pass sort list to view for rendering
  			$this->view->setVar('current_sort', $vs_sort);
@@ -987,12 +990,7 @@
  			$this->view->setVar('type_id', $this->opn_type_restriction_id);
  			
  			// Get attribute sorts
- 			$va_sortable_elements = ca_metadata_elements::getSortableElements($this->ops_tablename, $this->opn_type_restriction_id);
- 			
- 			if (!is_array($this->opa_sorts)) { $this->opa_sorts = array(); }
- 			foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
- 				$this->opa_sorts[$this->ops_tablename.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
- 			}
+			$this->opa_sorts = caGetAvailableSortFields($this->ops_tablename, $this->opn_type_restriction_id);
  			
  			if ($pa_options['appendToSearch']) {
  				$vs_append_to_search .= " AND (".$pa_options['appendToSearch'].")";

--- a/app/lib/ca/BaseSearchController.php
+++ b/app/lib/ca/BaseSearchController.php
@@ -65,13 +65,8 @@
 				if ($vs_view_default = $po_request->config->get('view_default_for_'.$this->ops_tablename.'_search')) {
 					$this->ops_view_default = $vs_view_default;
 				}
-	
-				$va_sortable_elements = ca_metadata_elements::getSortableElements($this->ops_tablename, $this->opn_type_restriction_id);
-	
-				$this->opa_sorts = array();
-				foreach($va_sortable_elements as $vn_element_id => $va_sortable_element) {
-					$this->opa_sorts[$this->ops_tablename.'.'.$va_sortable_element['element_code']] = $va_sortable_element['display_label'];
-				}
+
+				$this->opa_sorts = caGetAvailableSortFields($this->ops_tablename, $this->opn_type_restriction_id);
 			}
  		}
  		# -------------------------------------------------------

--- a/assets/ca/ca.relationbundle.js
+++ b/assets/ca/ca.relationbundle.js
@@ -225,32 +225,34 @@ var caUI = caUI || {};
 		
 		options.sort = function(key) {
 			var indexedValues = {};
+
 			jQuery.each(jQuery(that.container + ' .bundleContainer .' + that.itemListClassName + ' .roundedRel'), function(k, v) {
 				var id_string = jQuery(v).attr('id');
 				if (id_string) {
-					var indexKey;
-					if(key == 'name') {
-						indexKey = jQuery('#' + id_string + ' .itemName').text() + "/" + id_string;
-					} else {
-						if (key == 'type') {
-							indexKey = jQuery('#' + id_string + ' .itemType').text() + "/" + id_string;
-						} else {
-							if (key == 'idno') {
-								indexKey = jQuery('#' + id_string + ' .itemIdno').text() + "/" + id_string;
-							} else {
-								indexKey = id_string;
-							}
-						}
-					}
-					indexedValues[indexKey] = v;
+					var matches = /_([\d]+)$/.exec(id_string);
+					indexedValues[parseInt(matches[1])] = v;
 				}
 				jQuery(v).detach();
 			});
-			indexedValues = caUI.utils.sortObj(indexedValues, true);
+
+			var sortUrl = that.sortUrl + '/ids/' + Object.keys(indexedValues).join(',') + '/sortKeys/' + key;
+			var sortedValues = {};
+
+			// we actually have to wait for the result here ... hence, ajax() with async=false instead of getJSON()
+			jQuery.ajax({
+				url: sortUrl,
+				dataType: 'json',
+				async: false,
+				success: function(data) {
+					for (var i = 0; i < data.length; i++) {
+						sortedValues[that.fieldNamePrefix + 'Item_' + data[i]] = indexedValues[parseInt(data[i])];
+					}
+				}
+			});
 			
 			var whatsLeft = jQuery(that.container + ' .bundleContainer .' + that.itemListClassName).html();
 			jQuery(that.container + ' .bundleContainer .' + that.itemListClassName).html('');
-			jQuery.each(indexedValues, function(k, v) {
+			jQuery.each(sortedValues, function(k, v) {
 				jQuery(that.container + ' .bundleContainer .' + that.itemListClassName).append(v);
 				var id_string = jQuery(v).attr('id');
 				that.setDeleteButton(id_string);

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -5377,6 +5377,9 @@ div.listRel:first-of-type {
     border: 1px solid #e6e6e6;
 
     z-index: 10000;
+
+    max-height: 350px;
+    overflow: scroll;
 }
 
 .caItemListSortControls ul {

--- a/themes/default/views/bundles/ca_collections.php
+++ b/themes/default/views/bundles/ca_collections.php
@@ -61,7 +61,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -259,6 +259,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/collections', 'CollectionQuickAdd', 'Form', array('collection_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_entities.php
+++ b/themes/default/views/bundles/ca_entities.php
@@ -61,7 +61,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -263,6 +263,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/entities', 'EntityQuickAdd', 'Form', array('entity_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_list_items.php
+++ b/themes/default/views/bundles/ca_list_items.php
@@ -67,7 +67,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -364,6 +364,7 @@
 			itemColor: '<?php print $vs_color; ?>',
 			firstItemColor: '<?php print $vs_first_color; ?>',
 			lastItemColor: '<?php print $vs_last_color; ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_loans.php
+++ b/themes/default/views/bundles/ca_loans.php
@@ -60,7 +60,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -259,6 +259,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/loans', 'LoanQuickAdd', 'Form', array('loan_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_movements.php
+++ b/themes/default/views/bundles/ca_movements.php
@@ -60,7 +60,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -259,6 +259,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/movements', 'MovementQuickAdd', 'Form', array('movement_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_object_lots.php
+++ b/themes/default/views/bundles/ca_object_lots.php
@@ -74,7 +74,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -355,6 +355,7 @@
 			templateValues: ['label', 'idno_stub', 'id', 'type_id'],
 			firstItemColor: '<?php print $vs_first_color; ?>',
 			lastItemColor: '<?php print $vs_last_color; ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_objects.php
+++ b/themes/default/views/bundles/ca_objects.php
@@ -61,7 +61,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -325,6 +325,7 @@
 			
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/objects', 'ObjectQuickAdd', 'Form', array('object_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_occurrences.php
+++ b/themes/default/views/bundles/ca_occurrences.php
@@ -64,7 +64,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -264,6 +264,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/occurrences', 'OccurrenceQuickAdd', 'Form', array('occurrence_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_places.php
+++ b/themes/default/views/bundles/ca_places.php
@@ -64,7 +64,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -346,6 +346,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/places', 'PlaceQuickAdd', 'Form', array('place_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_sets.php
+++ b/themes/default/views/bundles/ca_sets.php
@@ -61,7 +61,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();

--- a/themes/default/views/bundles/ca_storage_locations.php
+++ b/themes/default/views/bundles/ca_storage_locations.php
@@ -65,7 +65,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -327,6 +327,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/storage_locations', 'StorageLocationQuickAdd', 'Form', array('location_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,

--- a/themes/default/views/bundles/ca_tour_stops.php
+++ b/themes/default/views/bundles/ca_tour_stops.php
@@ -61,7 +61,7 @@
 	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix.$t_item->tableNum().'_rel', $va_settings);
 	
 	if(sizeof($this->getVar('initialValues')) && !$vb_read_only && !$vs_sort && ($va_settings['list_format'] != 'list')) {
-		print caEditorBundleSortControls($this->request, $vs_id_prefix, $pa_settings);
+		print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName());
 	}
 	
 	$va_errors = array();
@@ -230,6 +230,7 @@
 			autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
 			quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
 			quickaddUrl: '<?php print caNavUrl($this->request, 'editor/tour_stops', 'TourStopQuickAdd', 'Form', array('stop_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$va_settings['dont_include_subtypes_in_type_restriction'])); ?>',
+			sortUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Sort', array('table' => $t_item->tableName())); ?>',
 			
 			interstitialButtonClassName: 'caInterstitialEditButton',
 			interstitialPanel: caRelationEditorPanel<?php print $vs_id_prefix; ?>,


### PR DESCRIPTION
Like the old sort this is only for the "bubbles" render mode. I also didn't change the controls too much, the underlying service can handle sorting by multiple fields and asc/desc too though, so if we happen to have some time left, we could add that and make the controls nicer.

A lot of these changes are my attempt to streamline the base sort definitions a little bit. Ideally they should probably be either in the models or in a config file somewhere, but for now they're hardcoded in a central helper, which at least makes them reusable outside of search (they weren't before, when they were hardcoded in protected properties in the search classes).