### PR TITLE
NOJIRA Add `daterangepicker` in `browsable` assets class

### DIFF
--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -229,7 +229,7 @@ loadSets = {
 	],
 
 	browsable = [
-		ca/browsePanel, jquery/tools
+		ca/browsePanel, jquery/tools, jquery/moment, jquery/daterangepicker, jquery/daterangepickercss
 	],
 	
 	panel = [


### PR DESCRIPTION
* Fixes an undefined jQuery().daterangepicker when opening an advanced search form with a date element in it

Feel free to decline this PR if this is better fixed elsewhere.