### PR TITLE
Fix: make CSVDelimitedDataReader formats coherent with caUtils import-data help message

### DIFF
--- a/app/lib/ca/Import/DataReaders/CSVDelimitedDataReader.php
+++ b/app/lib/ca/Import/DataReaders/CSVDelimitedDataReader.php
@@ -55,7 +55,7 @@ class CSVDelimitedDataReader extends BaseDelimitedDataReader {
 		$this->ops_display_name = _t('Comma Delimited (CSV)');
 		$this->ops_description = _t('Reads comma delimited (CSV) text files');
 		
-		$this->opa_formats = array('csvdelimited');	// must be all lowercase to allow for case-insensitive matching
+		$this->opa_formats = array('csvdelimited', 'csv');	// must be all lowercase to allow for case-insensitive matching
 	}
 	# -------------------------------------------------------
 }

--- a/app/locale/fr_CA/messages.po
+++ b/app/locale/fr_CA/messages.po
@@ -16210,11 +16210,11 @@ msgstr "Lecture %1"
 
 #: app/models/ca_data_importers.php:1263
 msgid "Could not open source %1 (format=%2)"
-msgstr "Impossible d'ouvrir la source %1 (formation = %2)"
+msgstr "Impossible d'ouvrir la source %1 (format de fichier = %2)"
 
 #: app/models/ca_data_importers.php:1271
 msgid "Could not read source %1 (format=%2)"
-msgstr "Impossible de lire la source %1 (formation = %2)"
+msgstr "Impossible de lire la source %1 (format de fichier = %2)"
 
 #: app/models/ca_data_importers.php:1276
 msgid "Finished reading input source at %1 seconds"

--- a/app/locale/fr_FR/messages.po
+++ b/app/locale/fr_FR/messages.po
@@ -15392,11 +15392,11 @@ msgstr "Lecture %1"
 
 #: app/models/ca_data_importers.php:1263
 msgid "Could not open source %1 (format=%2)"
-msgstr "Impossible d'ouvrir la source %1 (formation = %2)"
+msgstr "Impossible d'ouvrir la source %1 (format de fichier = %2)"
 
 #: app/models/ca_data_importers.php:1271
 msgid "Could not read source %1 (format=%2)"
-msgstr "Impossible de lire la source %1 (formation = %2)"
+msgstr "Impossible de lire la source %1 (format de fichier = %2)"
 
 #: app/models/ca_data_importers.php:1276
 msgid "Finished reading input source at %1 seconds"


### PR DESCRIPTION
Hi,

I was trying to import CSV data file to CA, but was stopped by the following error:

    providence/support/bin$ ./caUtils import-data -m test_import -s 1.csv
    CollectiveAccess 1.6.3 (126/GIT) Utilities
    (c) 2013-2016 Whirl-i-Gig

    Could not open source test.csv (format=)

    providence/support/bin$ ./caUtils import-data -f CSV -m test_import -s 1.csv
    CollectiveAccess 1.6.3 (126/GIT) Utilities
    (c) 2013-2016 Whirl-i-Gig

    Could not open source test.csv (format=CSV)

After looking around, I found that the problem was in `BaseDataReader->canReadFormat()`:

    return in_array(strtolower($ps_format), $this->opa_formats);

But `CSVDelimitedDataReader->opa_formats = ['csvdelimited']` and 'csv' is not in `['csvdelimited']`.

Two ways to make code coherent with doc: 
  - change the doc to make user use `csvdelimited` and not `csv`
  - add `csv` to CSVDelimitedDataReader->opa_formats (solution proposed here)

Its solve the problem.
Thanks