### PR TITLE
NOJIRA Fix allow other plugins to implement `hookRenderMenuBar()`

### DIFF
--- a/app/plugins/ULAN/ULANPlugin.php
+++ b/app/plugins/ULAN/ULANPlugin.php
@@ -69,8 +69,8 @@ class ULANPlugin extends BaseApplicationPlugin {
 	 */
 	public function hookRenderMenuBar($pa_menu_bar) {
 		if ($o_req = $this->getRequest()) {
-			if (!$o_req->user->canDoAction('can_import_ulan')) { return false; }
-			if(!(bool)$this->opo_config->get('enabled')) { return false; }
+			if (!$o_req->user->canDoAction('can_import_ulan')) { return true; }
+			if(!(bool)$this->opo_config->get('enabled')) { return true; }
 
 			if (isset($pa_menu_bar['Import'])) {
 				$va_menu_items = $pa_menu_bar['Import']['navigation'];

--- a/app/plugins/WorldCat/WorldCatPlugin.php
+++ b/app/plugins/WorldCat/WorldCatPlugin.php
@@ -69,8 +69,8 @@
 		 */
 		public function hookRenderMenuBar($pa_menu_bar) {
 			if ($o_req = $this->getRequest()) {
-				if (!$o_req->user->canDoAction('can_import_worldcat')) { return false; }
-				if(!(bool)$this->opo_config->get('enabled')) { return false; }
+				if (!$o_req->user->canDoAction('can_import_worldcat')) { return true; }
+				if(!(bool)$this->opo_config->get('enabled')) { return true; }
 				
 				if (isset($pa_menu_bar['Import'])) {
 					$va_menu_items = $pa_menu_bar['Import']['navigation'];


### PR DESCRIPTION
* WorldCat and ULAN plugins had a change in d79f4e16acb090e7024239dd7484e63c25caedc0 which means that all other plugins
  that implement `hookRenderMenuBar` do not fire
* See documentation about this under http://docs.collectiveaccess.org/wiki/Application_plugins#Hooks - menu plugins are required to
 return a truthy value.