### PR TITLE
PROV-2006

### DIFF
--- a/app/lib/core/BaseModelWithAttributes.php
+++ b/app/lib/core/BaseModelWithAttributes.php
@@ -1737,8 +1737,7 @@
 						if ((bool)$this->getAppConfig()->get('perform_source_access_checking')) {
 							$pa_options['value'] = $this->get($ps_field);
 							$pa_options['disableItemsWithID'] = caGetSourceRestrictionsForUser($this->tableName(), array('access' => __CA_BUNDLE_ACCESS_READONLY__, 'exactAccess' => true));
-							
-							return $this->getSourceListAsHTMLFormElement($ps_field, array(), $pa_options);
+							return $this->getSourceListAsHTMLFormElement($pa_options['name'], array(), $pa_options);
 						}
 						break;
 				}

--- a/app/models/ca_sets.php
+++ b/app/models/ca_sets.php
@@ -1814,7 +1814,7 @@ LEFT JOIN ca_object_representations AS cor ON coxor.representation_id = cor.repr
 		}	
 		$vs_deleted_sql = '';
 		if ($t_rel_table->hasField('deleted')) {
-			$vs_deleted_sql = ' AND deleted = 0';
+			$vs_deleted_sql = ' AND '.$vs_rel_table_name.'deleted = 0';
 		}
 		
 		$qr_res = $o_db->query("


### PR DESCRIPTION
This fix updates the name argument used in method getSourceListAsHTMLFormElement with the actual name of the form element (placement_code+form_prefix+element_name), instead of just "source_id".