### PR TITLE
PROV-2011

### DIFF
--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -1643,19 +1643,18 @@ class BaseEditorController extends ActionController {
 		$va_restrict_to_sources = null;
 		if ($pt_subject->getAppConfig()->get('perform_source_access_checking') && $pt_subject->hasField('source_id')) {
 			if (is_array($va_restrict_to_sources = caGetSourceRestrictionsForUser($this->ops_table_name, array('access' => __CA_BUNDLE_ACCESS_READONLY__)))) {
+				if (is_array($va_restrict_to_sources) && !in_array($pt_subject->get('source_id'), $va_restrict_to_sources)) {
+					$this->response->setRedirect($this->request->config->get('error_display_url').'/n/2562?r='.urlencode($this->request->getFullUrlPath()));
+					return;
+				}
 				if (
 					(!$pt_subject->get('source_id'))
 					||
-					($pt_subject->get('source_id') && in_array($pt_subject->get('source_id'), $va_restrict_to_sources))
+					($pt_subject->get('source_id') && !in_array($pt_subject->get('source_id'), $va_restrict_to_sources))
 					||
 					((strlen($vn_source_id = $this->request->getParameter('source_id', pInteger))) && !in_array($vn_source_id, $va_restrict_to_sources))
 				) {
 					$pt_subject->set('source_id', $pt_subject->getDefaultSourceID(array('request' => $this->request)));
-				}
-
-				if (is_array($va_restrict_to_sources) && !in_array($pt_subject->get('source_id'), $va_restrict_to_sources)) {
-					$this->response->setRedirect($this->request->config->get('error_display_url').'/n/2562?r='.urlencode($this->request->getFullUrlPath()));
-					return;
 				}
 			}
 		}


### PR DESCRIPTION
This commit fixes the reported behavior in PROV-2011.
The problem with the original code was not the fix in BaseEditorController.php originally submitted in commit [e6831](https://github.com/collectiveaccess/providence/commit/e68311239d833f61cecf45c86baa17a6628ba2b7) but the order of events. This commit rolls back the fix in e6831 and suggests an update of the order of validations.

The original code, before e6831, was setting the object source to user default in case the source was not in source restrictions, thus never actually triggering the validation below.

This commit first checks if the source is authorized, and returns error if not. This is only done when sources is an array, maintaining the standard behavior for new object creation.

