### PR TITLE
PROV-2011 - Fix for new object creation with souce_access_checking

### DIFF
--- a/app/lib/ca/BaseEditorController.php
+++ b/app/lib/ca/BaseEditorController.php
@@ -1643,7 +1643,7 @@ class BaseEditorController extends ActionController {
 		$va_restrict_to_sources = null;
 		if ($pt_subject->getAppConfig()->get('perform_source_access_checking') && $pt_subject->hasField('source_id')) {
 			if (is_array($va_restrict_to_sources = caGetSourceRestrictionsForUser($this->ops_table_name, array('access' => __CA_BUNDLE_ACCESS_READONLY__)))) {
-				if (is_array($va_restrict_to_sources) && !in_array($pt_subject->get('source_id'), $va_restrict_to_sources)) {
+				if (is_array($va_restrict_to_sources) && $pt_subject->get('source_id') && !in_array($pt_subject->get('source_id'), $va_restrict_to_sources)) {
 					$this->response->setRedirect($this->request->config->get('error_display_url').'/n/2562?r='.urlencode($this->request->getFullUrlPath()));
 					return;
 				}


### PR DESCRIPTION
The previous commit [9bcae](https://github.com/collectiveaccess/providence/commit/9bcae6b8cc3e69b5e0faafb2ef1a84b953def7aa) not let a new object be created, contrary to initial message.
This fixes it and will only display wrong source error if the object has indeed a source different from the allowed sources of the user (if object is accessed by URL, for example), checking the source only if source exists. If not, then a new object is being created and will set the source value to user's default source.