### PR TITLE
Pass hierarchy parameters with units

### DIFF
--- a/app/lib/core/Parsers/DisplayTemplateParser.php
+++ b/app/lib/core/Parsers/DisplayTemplateParser.php
@@ -487,8 +487,10 @@ class DisplayTemplateParser {
 					$va_get_options['restrictToTypes'] = DisplayTemplateParser::_getCodesFromAttribute($o_node, ['attribute' => 'restrictToTypes']); 
 					$va_get_options['excludeTypes'] = DisplayTemplateParser::_getCodesFromAttribute($o_node, ['attribute' => 'excludeTypes']); 
 					$va_get_options['restrictToRelationshipTypes'] = DisplayTemplateParser::_getCodesFromAttribute($o_node, ['attribute' => 'restrictToRelationshipTypes']); 
-					$va_get_options['excludeRelationshipTypes'] = DisplayTemplateParser::_getCodesFromAttribute($o_node, ['attribute' => 'excludeRelationshipTypes']); 
-					
+					$va_get_options['excludeRelationshipTypes'] = DisplayTemplateParser::_getCodesFromAttribute($o_node, ['attribute' => 'excludeRelationshipTypes']);
+					$va_get_options['hierarchyDirection'] = (string)$o_node->hierarchyDirection ?: null;
+					$va_get_options['maxLevelsFromTop'] = (int)$o_node->maxLevelsFromTop ?: null;
+					$va_get_options['maxLevelsFromBottom'] = (int)$o_node->maxLevelsFromBottom ?: null;
 					
 					if ($o_node->sort) {
 						$va_get_options['sort'] = preg_split('![ ,;]+!', $o_node->sort);


### PR DESCRIPTION
Makes it possible to do:

```xml
<unit relativeTo="ca_places.hierarchy" hierarchyDirection="desc" maxLevelsFromBottom="2" delimiter=" &rArr; ">
^ca_places.preferred_labels
</unit>
```
