### PR TITLE
add table alias to type limit part of sql

### DIFF
--- a/app/lib/core/BaseModel.php
+++ b/app/lib/core/BaseModel.php
@@ -9538,7 +9538,7 @@ $pa_options["display_form_field_tips"] = true;
 		
 		$vs_relationship_type_limit_sql = '';
 		if (is_array($pa_relationship_type_ids) && (sizeof($pa_relationship_type_ids) > 0)) {
-			$vs_relationship_type_limit_sql = " AND type_id IN (?)";
+			$vs_relationship_type_limit_sql = " AND r.type_id IN (?)";	//type_id in the relationship table
 			$va_sql_params[] = $pa_relationship_type_ids;
 		}
 		


### PR DESCRIPTION
The sql query that is being used to remove relationships, when relationship type_ids are provided, needs to be contextualized by adding alias (of the relationship table) to the type_id column. All columns used in this query are being prefix with corresponding alias, except type_id. Because type_id belongs to the relationship table therefore its alias ‘r’ (defined in the query) needs to be used.
The above mentioned query is constructed and executed in function ‘removeRelationships’. This function is used while batch editing relationships. We had some trouble in removing and replacing relationships in batch editing. Adding alias to type_id solves the problem.
