### PR TITLE
put bundle editor popup screen atop

### DIFF
--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -4671,6 +4671,7 @@ span.bundleDisplayEditorPlacementListItemTitle {
 	-moz-box-shadow: 0 0 5px #888;
 	-webkit-box-shadow: 0 0 5px#888;
 	box-shadow: 0 0 5px #888;
+	z-index: 100;
 }
 .elementSettingsUI a{
 	float:right;


### PR DESCRIPTION
Sometimes display bundle editor popup screen cannot be closed because bottom of the screen (that contains the control to close it) is underneath the next parent screen component (see an example screen below). Only way to close this popup screen is to refresh the page, which is quite annoying. This problem can be solved by putting popup screen at the top of the components stack. Fix in this pull request does that.

Screenshot without the fix:
![1](https://cloud.githubusercontent.com/assets/3896702/24299535/d4804b3a-10a9-11e7-96c2-ae5d6bbd52df.JPG)



Screenshot with the fix:
![2](https://cloud.githubusercontent.com/assets/3896702/24299587/fb6816ec-10a9-11e7-939e-a6f7c68c386f.JPG)
