### PR TITLE
Fix search parsing infinite loop / memory-overflow error.

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1617,7 +1617,7 @@
 		$o_query_parser->setEncoding($o_config->get('character_set'));
 		$o_query_parser->setDefaultOperator(LuceneSyntaxParser::B_AND);
 		
-		$ps_search = preg_replace('![\']+!', '', $ps_search);
+		$ps_search = preg_replace('![\'()]+!', '', $ps_search);
 		try {
 			$o_parsed_query = $o_query_parser->parse($ps_search, $vs_char_set);
 		} catch (Exception $e) {


### PR DESCRIPTION
When attempting to determine whether a given search includes Sets, it is parsing the search but when there are parentheses `()` present, it runs into an infinite loop.

This resolves the infinite loop by removing the parentheses from the search text.  This doesn't actually affect whether or not the search is for sets.