### PR TITLE
Support SSL by detection rather than global.conf

### DIFF
--- a/app/conf/global.conf
+++ b/app/conf/global.conf
@@ -58,8 +58,8 @@ ca_lib_dir =  __CA_LIB_DIR__
 ca_models_dir = __CA_MODELS_DIR__
 
 # You MUST change these next three entries to match your web setup.
-site_protocol = http
-site_hostname =__CA_SITE_HOSTNAME__
+site_protocol = __CA_SITE_PROTOCOL__
+site_hostname = __CA_SITE_HOSTNAME__
 site_host = <site_protocol>://<site_hostname>
 
 # Leave 'ca_url_root' BLANK if the CollectiveAccess directory is the web server root.

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -233,6 +233,15 @@ if (!defined("__CA_SITE_HOSTNAME__")) {
 	define("__CA_SITE_HOSTNAME__", isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
 }
 
+#
+# __CA_SITE_HOSTNAME__ = the protocol your system should be accessed with
+#
+#		The default value is based on the URL being used to access the site.  To force a protocol, set it explicitly.
+#
+if (!defined("__CA_SITE_PROTOCOL__")) {
+	define("__CA_SITE_PROTOCOL__", isset($_SERVER['HTTPS']) ? 'https' : 'http');
+}
+
 # --------------------------------------------------------------------------------------------
 # IT IS VERY UNLIKELY THAT YOU WILL NEED TO CHANGE ANYTHING UNDER THIS LINE
 # --------------------------------------------------------------------------------------------

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -234,7 +234,7 @@ if (!defined("__CA_SITE_HOSTNAME__")) {
 }
 
 #
-# __CA_SITE_HOSTNAME__ = the protocol your system should be accessed with
+# __CA_SITE_PROTOCOL__ = the protocol your system should be accessed with
 #
 #		The default value is based on the URL being used to access the site.  To force a protocol, set it explicitly.
 #


### PR DESCRIPTION
`global.conf` variables cannot be overridden, so this is in lieu of changing the variable locally in that file. This way CA detects if it's using SSL from the server.