### PR TITLE
Refine list export options when exporting configuration.

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -7,33 +7,33 @@
 #       | |   | |
 #       |_|   |_|
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Providence 
+# Providence
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 #
 # Info @ http://docs.collectiveaccess.org/wiki/App.conf#App.conf
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# 
-#    WHAT: This is the main application configuration file for Providence, designed so that users can easy manage various 
+#
+#    WHAT: This is the main application configuration file for Providence, designed so that users can easy manage various
 #          system-wide settings in one convenient location.
 #
 #    WHEN TO CUSTOMIZE:  App.conf handles most customizations that are not controlled through the UI or profile (with
 #          the notable exceptions of: browse, id number configurations, and additional settings for dates, media and search).
-#          This document is broken into the following sections: Disable, Hierarchies, Titles & Ids, Search, 
-#		   Feature Settings, Access Control, Styling, Mapping, System Defaults, Media, Admin Configuration and Export 
+#          This document is broken into the following sections: Disable, Hierarchies, Titles & Ids, Search,
+#		   Feature Settings, Access Control, Styling, Mapping, System Defaults, Media, Admin Configuration and Export
 #
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   __  __                      
-#  |  \/  |                     
-#  | \  / | ___ _ __  _   _ ___ 
+#   __  __
+#  |  \/  |
+#  | \  / | ___ _ __  _   _ ___
 #  | |\/| |/ _ \ '_ \| | | / __|
 #  | |  | |  __/ | | | |_| \__ \
 #  |_|  |_|\___|_| |_|\__,_|___/
-#                              
-#  Control the "New" and "Find" menus in Providence                           
+#
+#  Control the "New" and "Find" menus in Providence
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # --------------------
@@ -155,19 +155,19 @@ ca_movements_dont_show_in_new_menu = 0
 #
 do_menu_bar_caching = 1
 
-                                      
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   _____  _           _     _      
-#  |  __ \(_)         | |   | |     
-#  | |  | |_ ___  __ _| |__ | | ___ 
+#   _____  _           _     _
+#  |  __ \(_)         | |   | |
+#  | |  | |_ ___  __ _| |__ | | ___
 #  | |  | | / __|/ _` | '_ \| |/ _ \
 #  | |__| | \__ \ (_| | |_) | |  __/
 #  |_____/|_|___/\__,_|_.__/|_|\___|
-#                                  
+#
 #  Turn off (or on) various features and database areas.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                              
+
 # -------------------------
 # Editor "disable" switches
 # -------------------------
@@ -205,7 +205,7 @@ ca_movements_disable_quickadd = 0
 
 
 # ----------------------------------
-# Disable "Add new <object> to lot" 
+# Disable "Add new <object> to lot"
 # ----------------------------------
 # (in the object lot editor inspector)
 #
@@ -241,7 +241,7 @@ ca_tour_stops_show_add_child_control_in_inspector = 0
 
 # -------------------------
 # Set duplication disable
-# ------------------------- 
+# -------------------------
 # If you want to disable the ability to duplicate all items in a set across the board set this
 #
 ca_sets_disable_duplication_of_items = 0
@@ -255,9 +255,9 @@ enable_set_type_controls = 0
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   _    _ _                         _     _           
-#  | |  | (_)                       | |   (_)          
-#  | |__| |_  ___ _ __ __ _ _ __ ___| |__  _  ___  ___ 
+#   _    _ _                         _     _
+#  | |  | (_)                       | |   (_)
+#  | |__| |_  ___ _ __ __ _ _ __ ___| |__  _  ___  ___
 #  |  __  | |/ _ \ '__/ _` | '__/ __| '_ \| |/ _ \/ __|
 #  | |  | | |  __/ | | (_| | | | (__| | | | |  __/\__ \
 #  |_|  |_|_|\___|_|  \__,_|_|  \___|_| |_|_|\___||___/
@@ -347,14 +347,14 @@ ca_movements_hierarchy_browser_sort_values = [ca_movements.preferred_labels.name
 ca_movements_hierarchy_browser_sort_direction = asc
 
 # ---------------------------------------------
-#  Collection hierarchies on the Summary screen 
+#  Collection hierarchies on the Summary screen
 # ---------------------------------------------
 #
-# The summary screen includes a visual hierarchy by default for hierarchical collections. 
+# The summary screen includes a visual hierarchy by default for hierarchical collections.
 # Use these directives to set the sort value for the hierarchical display, as well as the display
 # template used for format data. If nothing is set below the system will default to the settings
 # outlined in ca_collections_hierarchy_browser_sort_values.
-#                                                   
+#
 ca_collections_hierarchy_summary_display_settings =
 ca_collections_hierarchy_summary_sort_values =
 
@@ -369,8 +369,8 @@ ca_collections_hierarchy_summary_sort_values =
 #
 ca_storage_locations_hierarchy_browser_hide_root = 0
 ca_places_locations_hierarchy_browser_hide_root = 0
-                          
-                          
+
+
 # ------------------------------------
 # Show/Hide child records in search/browse results
 # ------------------------------------
@@ -391,14 +391,14 @@ ca_objects_children_display_mode_in_results = alwaysShow
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   _______ _ _   _                     _____    _     
-#  |__   __(_) | | |              _    |_   _|  | |    
-#     | |   _| |_| | ___  ___   _| |_    | |  __| |___ 
+#   _______ _ _   _                     _____    _
+#  |__   __(_) | | |              _    |_   _|  | |
+#     | |   _| |_| | ___  ___   _| |_    | |  __| |___
 #     | |  | | __| |/ _ \/ __| |_   _|   | | / _` / __|
 #     | |  | | |_| |  __/\__ \   |_|    _| || (_| \__ \
 #     |_|  |_|\__|_|\___||___/         |_____\__,_|___/
-#                                                     
-#   Set whether or not titles and identifiers are required and unique.                                                      
+#
+#   Set whether or not titles and identifiers are required and unique.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ---------------------------------------------------
@@ -524,8 +524,8 @@ ca_objects_dont_use_labels = 0
 # -----------------
 # Label-specific sort
 # -----------------
-# Set to assume a specific language when generating sortable titles regardless of the locale set for the title. This can be useful when content 
-# has been entered specific (or accurate) locale settings. The value can be a specific locale (Ex. "en_US") or a language code (Ex. "en") 
+# Set to assume a specific language when generating sortable titles regardless of the locale set for the title. This can be useful when content
+# has been entered specific (or accurate) locale settings. The value can be a specific locale (Ex. "en_US") or a language code (Ex. "en")
 #
 use_locale_for_sortable_titles =
 
@@ -533,15 +533,15 @@ use_locale_for_sortable_titles =
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#    _____                     _     
-#   / ____|                   | |    
-#  | (___   ___  __ _ _ __ ___| |__  
-#   \___ \ / _ \/ _` | '__/ __| '_ \ 
+#    _____                     _
+#   / ____|                   | |
+#  | (___   ___  __ _ _ __ ___| |__
+#   \___ \ / _ \/ _` | '__/ __| '_ \
 #   ____) |  __/ (_| | | | (__| | | |
 #  |_____/ \___|\__,_|_|  \___|_| |_|
-#                                   
 #
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -------------------
 # Search engine configuration
@@ -550,7 +550,7 @@ use_locale_for_sortable_titles =
 search_engine_plugin = SqlSearch
 
 # -------------------
-# Browse Panel Styles 
+# Browse Panel Styles
 # -------------------
 # (for best results, choose a number between 1 and 5)
 #
@@ -561,7 +561,7 @@ browse_row_size = 4
 # -------------------
 #
 # What sorts of results does Quicksearch return?
-# List table names here to include them in the search, in the order they should appear. This is only the default 
+# List table names here to include them in the search, in the order they should appear. This is only the default
 # display configuration, which can be overriden by user preferences. Syntax is ca_table/type, i.e ca_objects/video
 #
 quicksearch_default_results = [ca_objects, ca_entities, ca_places, ca_occurrences, ca_collections, ca_object_lots, ca_storage_locations, ca_loans, ca_movements, ca_tours, ca_tour_stops]
@@ -572,8 +572,8 @@ quicksearch_default_results = [ca_objects, ca_entities, ca_places, ca_occurrence
 #
 # What table types are broken out in the result list? Syntax is list within square brackets, i.e [ca_objects, ca_entities]
 #
-quicksearch_breakout_by_type = 
-    
+quicksearch_breakout_by_type =
+
 # -------------------
 # Restrict facets shown to specific facet groups?
 # 	<table_name>_browse_facet_group limits facets on the main browse landing page
@@ -584,16 +584,16 @@ quicksearch_breakout_by_type =
 # ca_objects_browse_facet_group = main
 # ca_objects_refine_facet_group = refine
 # ca_objects_search_refine_facet_group = refine
-          
+
 # -------------------
-# One table search 
+# One table search
 # -------------------
 # If set to a controller in the "find" module, will use that for quicksearch rather
 # than the regular "Quicksearch" controller. This is useful for having the Quicksearch
 # operate on a single table
 #
 # one_table_search =
-                       
+
 # -------------------
 # Out of process search indexing
 # -------------------
@@ -604,24 +604,24 @@ disable_out_of_process_search_indexing = 0
 # -------------------
 # Caption formatting for object search/browse "thumbnail" results
 # -------------------
-# Set a display template here to customize display of captions under thumbnails in the thumbnail result view. The 
+# Set a display template here to customize display of captions under thumbnails in the thumbnail result view. The
 # template will be evaluated relative to each object in the result set.
 #
 ca_objects_results_thumbnail_caption_template = ^ca_objects.preferred_labels.name%truncate=27&ellipsis=1<br/><l>^ca_objects.idno</l>
-                                 
-                                   
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   ______         _                       
-#  |  ____|       | |                      
-#  | |__ ___  __ _| |_ _   _ _ __ ___  ___ 
+#   ______         _
+#  |  ____|       | |
+#  | |__ ___  __ _| |_ _   _ _ __ ___  ___
 #  |  __/ _ \/ _` | __| | | | '__/ _ \/ __|
 #  | | |  __/ (_| | |_| |_| | | |  __/\__ \
 #  |_|  \___|\__,_|\__|\__,_|_|  \___||___/
-#                                         
-#  Settings related to various features such as: location tracking, deaccessioning, 
-#  WorldCat, check in/check out and more.                                       
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+#
+#  Settings related to various features such as: location tracking, deaccessioning,
+#  WorldCat, check in/check out and more.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -------------------------
 # Location tracking options
@@ -633,16 +633,16 @@ ca_objects_results_thumbnail_caption_template = ^ca_objects.preferred_labels.nam
 # (also set this for movement-based storage location tracking)
 # ---
 #
-object_storage_location_tracking_relationship_type =  
+object_storage_location_tracking_relationship_type =
 
 # ---
 # Movement-based storage location tracking
 # ---
 #
-movement_storage_location_tracking_relationship_type = 
-movement_object_tracking_relationship_type = 
+movement_storage_location_tracking_relationship_type =
+movement_object_tracking_relationship_type =
 record_movement_information_when_moving_storage_location = 0
-movement_storage_location_date_element =   
+movement_storage_location_date_element =
 
 
 # -------------------
@@ -684,7 +684,7 @@ worldcat_z39.50_password =
 # To enable set "worlcat_isbn_element_code" to the ca_objects metadata element code containing the ISBN code for the book.
 worlcat_isbn_element_code =
 
-# Display template used to format "ISBN present" message. Evaluated relative to the existing object. 
+# Display template used to format "ISBN present" message. Evaluated relative to the existing object.
 # You can use standard display template codes (eg. ^ca_objects.idno) to display details about the match.
 worlcat_isbn_exists_template = <span class="caWorldCatExistingObjectIcon"><l><i class="fa fa-external-link" aria-hidden="true"></i></span></l>
 
@@ -712,7 +712,7 @@ ubio_keycode = enter_your_keycode_here
 # "Rich text" (aka. wysiwyg) editor options
 # -------------------------
 # You can read more about available text editor options here: http://docs.cksource.com/CKEditor_3.x/Developers_Guide/Toolbar
-# 
+#
 # Defines options available in the toolbar
 wysiwyg_editor_toolbar = {
 	formatting = [Bold, Italic, Underline, Strike, -, Subscript, Superscript, Font, FontSize, TextColor],
@@ -734,11 +734,11 @@ enable_dependent_field_visibility = 0
 # Global template values
 # -----------------------
 # Globals are text values that may be set in the Pawtucket web UI and substituted
-# into any view template, including headers and footers. Values defined here 
+# into any view template, including headers and footers. Values defined here
 # will be editable in the "Global Values Editor" (available to users with the can_edit_theme_global_values priv)
 # and usable in templates under their name (Eg. {{{operating_hours}}} in the example below).
 #
-# Options controlling how the editor displays the value may be set for each global. Width and height control the size 
+# Options controlling how the editor displays the value may be set for each global. Width and height control the size
 # of the element; usewysiwygeditor enables a "wysiwyg" rich text editor for formatted text.
 #
 global_template_values = {
@@ -751,18 +751,18 @@ global_template_values = {
 	#}
 }
 
-                                                                  
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#                                    _____            _             _ 
+#                                    _____            _             _
 #      /\                           / ____|          | |           | |
 #     /  \   ___ ___ ___  ___ ___  | |     ___  _ __ | |_ _ __ ___ | |
 #    / /\ \ / __/ __/ _ \/ __/ __| | |    / _ \| '_ \| __| '__/ _ \| |
 #   / ____ \ (_| (_|  __/\__ \__ \ | |___| (_) | | | | |_| | | (_) | |
 #  /_/    \_\___\___\___||___/___/  \_____\___/|_| |_|\__|_|  \___/|_|
-#                                                                    
+#
 #  Structural mechanisms that control who can see what, and how (optional).
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
-                                                                    
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 # -------------------------
 # Bundle-level access control
 # -------------------------
@@ -847,16 +847,16 @@ ca_objects_access_inheritance_default = 1
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#    _____ _         _ _             
-#   / ____| |       | (_)            
-#  | (___ | |_ _   _| |_ _ __   __ _ 
+#    _____ _         _ _
+#   / ____| |       | (_)
+#  | (___ | |_ _   _| |_ _ __   __ _
 #   \___ \| __| | | | | | '_ \ / _` |
 #   ____) | |_| |_| | | | | | | (_| |
 #  |_____/ \__|\__, |_|_|_| |_|\__, |
 #               __/ |           __/ |
-#              |___/           |___/ 
-#   
-#  Controls for visual elements such as logos, colors, etc. within the application and exported reports and labels       
+#              |___/           |___/
+#
+#  Controls for visual elements such as logos, colors, etc. within the application and exported reports and labels
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -------------------------
@@ -953,15 +953,15 @@ views_directory = <themes_directory>/<theme>/views
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   __  __                   _             
-#  |  \/  |                 (_)            
-#  | \  / | __ _ _ __  _ __  _ _ __   __ _ 
+#   __  __                   _
+#  |  \/  |                 (_)
+#  | \  / | __ _ _ __  _ __  _ _ __   __ _
 #  | |\/| |/ _` | '_ \| '_ \| | '_ \ / _` |
 #  | |  | | (_| | |_) | |_) | | | | | (_| |
 #  |_|  |_|\__,_| .__/| .__/|_|_| |_|\__, |
 #               | |   | |             __/ |
-#               |_|   |_|            |___/ 
-# 
+#               |_|   |_|            |___/
+#
 #  Settings for GeoNames and Mapping plugins (Google Maps/Open Layers)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1035,14 +1035,14 @@ ca_objects_map_attribute = georeference
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   _____        __            _ _       
-#  |  __ \      / _|          | | |      
-#  | |  | | ___| |_ __ _ _   _| | |_ ___ 
+#   _____        __            _ _
+#  |  __ \      / _|          | | |
+#  | |  | | ___| |_ __ _ _   _| | |_ ___
 #  | |  | |/ _ \  _/ _` | | | | | __/ __|
 #  | |__| |  __/ || (_| | |_| | | |_\__ \
 #  |_____/ \___|_| \__,_|\__,_|_|\__|___/
-#                                       
-#                                  
+#
+#
 #  System defaults to control layouts, displays, templates and more.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1140,7 +1140,7 @@ ca_object_checkouts_lookup_delimiter = ➔
 # ----------------------------
 ca_objects_default_bundle_display_template = <unit relativeTo="ca_objects"><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</unit>
 ca_entities_default_bundle_display_template = <unit relativeTo="ca_entities"><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</unit>
-ca_places_default_bundle_display_template = <unit relativeTo="ca_places"><l>^ca_places.preferred_labels.name</l> (^relationship_typename)</unit> 
+ca_places_default_bundle_display_template = <unit relativeTo="ca_places"><l>^ca_places.preferred_labels.name</l> (^relationship_typename)</unit>
 ca_occurrences_default_bundle_display_template = <unit relativeTo="ca_occurrences"><l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)</unit>
 ca_object_lots_default_bundle_display_template = <unit relativeTo="ca_object_lots"><l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)</unit>
 ca_storage_locations_default_bundle_display_template = <unit relativeTo="ca_storage_locations"><l>^ca_storage_locations.preferred_labels.name</l> (^relationship_typename)</unit>
@@ -1183,7 +1183,7 @@ ca_object_representations_preferred_label_type_list = object_representation_labe
 ca_object_representations_nonpreferred_label_type_list = object_representation_label_types
 ca_representation_annotation_preferred_label_type_list = representation_annotation_label_types_preferred
 ca_representation_annotation_nonpreferred_label_type_list = representation_annotation_label_types
-                                     
+
 # ------------------------------------------------
 # Default to summary when opening item for editing?
 # ------------------------------------------------
@@ -1301,7 +1301,7 @@ ca_entities_set_item_display_template = ^ca_entities.preferred_labels.displaynam
 ca_places_set_item_display_template = ^ca_places.preferred_labels.name
 ca_occurrences_set_item_display_template = ^ca_occurrences.preferred_labels.name
 ca_collections_set_item_display_template = ^ca_collections.preferred_labels.name
-ca_loans_set_item_display_template = ^ca_loans.preferred_labels.name 
+ca_loans_set_item_display_template = ^ca_loans.preferred_labels.name
 ca_movements_set_item_display_template = ^ca_movements.preferred_labels.name
 ca_storage_locations_set_item_display_template = ^ca_storage_locations.preferred_labels.name
 ca_object_representations_set_item_display_template = ^ca_object_representations.preferred_labels.name
@@ -1364,13 +1364,13 @@ dont_mark_duplicated_records_in_preferred_label = 0
 dont_show_timestamp_in_change_log = 0
 
 
-# When deleting an item it is possible to move any references to or from that item to another. 
-# Alternatively references can be deleted with the item. The system-wide default behavior may be set here 
+# When deleting an item it is possible to move any references to or from that item to another.
+# Alternatively references can be deleted with the item. The system-wide default behavior may be set here
 # and will be used when the user has not set a preference.
 # Valid options are "remove" or "transfer"
-# Note that you can set per-table defaults by prefacing "delete_reference_handling_default" with a table name. 
+# Note that you can set per-table defaults by prefacing "delete_reference_handling_default" with a table name.
 # (For example, "ca_objects_delete_reference_handling_default")
-# 
+#
 delete_reference_handling_default = remove
 
 # ----------
@@ -1380,18 +1380,18 @@ ca_objects_container_types = []
 ca_objects_component_types = []
 ca_objects_component_display_settings = <l>^ca_objects.preferred_labels.name</l> (^ca_objects.idno)
 
-                                                                    
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   __  __          _ _       
-#  |  \/  |        | (_)      
-#  | \  / | ___  __| |_  __ _ 
+#   __  __          _ _
+#  |  \/  |        | (_)
+#  | \  / | ___  __| |_  __ _
 #  | |\/| |/ _ \/ _` | |/ _` |
 #  | |  | |  __/ (_| | | (_| |
 #  |_|  |_|\___|\__,_|_|\__,_|
-#                            
-# 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
+#
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -------------------
 # Media processing tweaks
@@ -1417,13 +1417,13 @@ dont_use_graphicsmagick_to_identify_pdfs = 0
 #
 dont_use_zendpdf_to_identify_pdfs = 1
 
-# CollectiveAccess supports three methods for generating PDF output for download and printing: dompdf (slower; built-in), 
-# wkhtmltopdf (faster; requires additional software installation) and phantomjs (faster; requires additional software installation). 
-# By default it will favor using wkhtmltopdf if available, falling back to phantomjs and then to dompdf which is always available. 
+# CollectiveAccess supports three methods for generating PDF output for download and printing: dompdf (slower; built-in),
+# wkhtmltopdf (faster; requires additional software installation) and phantomjs (faster; requires additional software installation).
+# By default it will favor using wkhtmltopdf if available, falling back to phantomjs and then to dompdf which is always available.
 #
-# You can override the build in preference and force the use of a specific PDF generator by uncommenting and setting this 
+# You can override the build in preference and force the use of a specific PDF generator by uncommenting and setting this
 # option to one of the following:
-#		wkhtmltopdf, phantomjs, dompdf 
+#		wkhtmltopdf, phantomjs, dompdf
 # use_pdf_renderer = wkhtmltopdf
 
 # Only media than can be identified by a plugin may be uploaded. If you want to be able to upload any file
@@ -1602,7 +1602,7 @@ ajax_media_upload_tmp_directory_timeout = 86400
 ca_object_representation_download_versions = [original, large, medium, small]
 
 # Set maximum number of files to allow to be downloaded in one go. Leave set to 0 or blank for no limit.
-maximum_download_file_count = 
+maximum_download_file_count =
 
 # -------------------
 # Task queue set up (deferred processing of uploaded media)
@@ -1614,14 +1614,14 @@ taskqueue_process_timeout = 3600
 taskqueue_max_items_processed_per_session = 100
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#              _           _       
-#     /\      | |         (_)      
-#    /  \   __| |_ __ ___  _ _ __  
-#   / /\ \ / _` | '_ ` _ \| | '_ \ 
+#              _           _
+#     /\      | |         (_)
+#    /  \   __| |_ __ ___  _ _ __
+#   / /\ \ / _` | '_ ` _ \| | '_ \
 #  / ____ \ (_| | | | | | | | | | |
 # /_/    \_\__,_|_| |_| |_|_|_| |_|
-#                                  
-#  Nit picky stuff related to system configuration and administration.                               
+#
+#  Nit picky stuff related to system configuration and administration.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -------------------
@@ -1644,11 +1644,15 @@ dont_do_expensive_configuration_checks_in_web_ui = 0
 configuration_export_only_system_displays = 1
 configuration_export_only_system_search_forms = 1
 
-# Exclude lists from configuration export with more than a specified number of items. If set to zero no limit is enforced. 
+# Exclude lists from configuration export with more than a specified number of items. If set to zero no limit is enforced.
 configuration_export_exclude_lists_larger_than = 0
+# Exclude lists items from configuration export with more than a specified number of items. If set to zero no limit is enforced.
+configuration_export_exclude_list_items_larger_than = 0
 
 # list of list codes to exclude from configuration export
 configuration_export_exclude_lists = []
+# list of list codes to exclude list items from configuration export
+configuration_export_exclude_list_items = []
 
 # -------------------------------------------------------
 # Object lot inheritance
@@ -1687,14 +1691,14 @@ session_domain =
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#  ______                       _   
-# |  ____|                     | |  
-# | |__  __  ___ __   ___  _ __| |_ 
+#  ______                       _
+# |  ____|                     | |
+# | |__  __  ___ __   ___  _ __| |_
 # |  __| \ \/ / '_ \ / _ \| '__| __|
-# | |____ >  <| |_) | (_) | |  | |_ 
+# | |____ >  <| |_) | (_) | |  | |_
 # |______/_/\_\ .__/ \___/|_|   \__|
-#             | |                   
-#             |_|                   
+#             | |
+#             |_|
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # -----------------------------------------
@@ -1761,13 +1765,13 @@ ca_tour_stops_batch_export_filename = tour_stops_batch_export
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#  \ \   / /        ( )              | |                 
-#   \ \_/ /__  _   _|/ _ __ ___    __| | ___  _ __   ___ 
+#  \ \   / /        ( )              | |
+#   \ \_/ /__  _   _|/ _ __ ___    __| | ___  _ __   ___
 #    \   / _ \| | | | | '__/ _ \  / _` |/ _ \| '_ \ / _ \
 #     | | (_) | |_| | | | |  __/ | (_| | (_) | | | |  __/
 #     |_|\___/ \__,_| |_|  \___|  \__,_|\___/|_| |_|\___|....
-#                                                       
-#  
+#
+#
 #  ....probably. Most users don't modify the configs below.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/app/lib/ca/ConfigurationExporter.php
+++ b/app/lib/ca/ConfigurationExporter.php
@@ -215,7 +215,9 @@ final class ConfigurationExporter {
 		}
 
 		$va_exclude_lists = $this->opo_config->get('configuration_export_exclude_lists');
+		$va_exclude_list_items = $this->opo_config->get('configuration_export_exclude_list_items');
 		$vn_exclude_lists_larger_than = $this->opo_config->get('configuration_export_exclude_lists_larger_than');
+		$vn_exclude_list_items_larger_than = $this->opo_config->get('configuration_export_exclude_list_items_larger_than');
 
 		while($qr_lists->nextRow()) {
 			// skip excluded lists (in diff exports only)
@@ -224,8 +226,8 @@ final class ConfigurationExporter {
 					continue;
 				}
 			}
-			
-			if (($vn_exclude_lists_larger_than > 0) && ($t_list->numItemsInList($qr_lists->get('list_id')) > $vn_exclude_lists_larger_than)) { continue; }
+			$vn_number_items = $t_list->numItemsInList($qr_lists->get('list_id'));
+			if (($vn_exclude_lists_larger_than > 0) && ($vn_number_items > $vn_exclude_lists_larger_than)) { continue; }
 
 			$vo_list = $this->opo_dom->createElement("list");
 			$vo_list->setAttribute("code", $this->makeIDNOFromInstance($qr_lists, 'list_code'));
@@ -253,8 +255,13 @@ final class ConfigurationExporter {
 			}
 
 			$vo_list->appendChild($vo_labels);
+			if($this->opn_modified_after && is_array($va_exclude_list_items) && (sizeof($va_exclude_list_items) > 0)) {
+				if(in_array($qr_lists->get('list_code'), $va_exclude_list_items)) {
+					continue;
+				}
+			}
 
-			$vo_items = $this->getListItemsAsDOM($t_list->getRootItemIDForList($qr_lists->get("list_code")), $qr_lists->get('list_id'));
+			$vo_items = $vn_exclude_list_items_larger_than && $vn_number_items > $vn_exclude_list_items_larger_than ? null : $this->getListItemsAsDOM($t_list->getRootItemIDForList($qr_lists->get("list_code")), $qr_lists->get('list_id'));
 
 
 			if($this->opn_modified_after) {


### PR DESCRIPTION
* add `configuration_export_exclude_list_items_larger_than` and `configuration_export_exclude_list_items` options.
* Whitespace trimmed from end of lines by PHPStorm/.editorconfig
NOJIRA
