### PR TITLE
Auto detect https connection status in setup.config

### DIFF
--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -115,7 +115,7 @@ packages = {
 	openlayers = {
 		maps = OpenLayers.js,
 		mobile = OpenLayers.mobile.js,
-		stamen = http://maps.stamen.com/js/tile.stamen.js?v1.1.3
+		stamen = https://stamen-maps.a.ssl.fastly.net/js/tile.stamen.js
 	},
 	# -----------------------
 	timelinejs = {

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -233,6 +233,17 @@ if (!defined("__CA_SITE_HOSTNAME__")) {
 	define("__CA_SITE_HOSTNAME__", isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
 }
 
+
+#
+# __CA_SITE_PROTOCOL__ = the protocol for your webserver
+#
+#               The default value attempts to determine the protocol automatically. You should only change                                  
+#               this if it's failing to derive the correct value or you need a different protocol than http or https.
+#
+if (!defined("__CA_SITE_PROTOCOL__")) {
+        define("__CA_SITE_PROTOCOL__", isset($_SERVER['HTTPS']) ? 'https' : 'http');
+}
+
 # --------------------------------------------------------------------------------------------
 # IT IS VERY UNLIKELY THAT YOU WILL NEED TO CHANGE ANYTHING UNDER THIS LINE
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
Instead of hard-coding ssl connection status, let PHP auto-detect the https-status and set protocol accordingly.
Change "stamen" URL to https-version.