### PR TITLE
Add __CA_SITE_PROTOCOL__ variable to global.conf

### DIFF
--- a/app/conf/global.conf
+++ b/app/conf/global.conf
@@ -58,6 +58,8 @@ ca_lib_dir =  __CA_LIB_DIR__
 ca_models_dir = __CA_MODELS_DIR__
 
 # You MUST change these next three entries to match your web setup.
+#Use the __CA_SITE_PROTOCOL__ variable only if your setup.php includes it.
+#site_protocol =__CA_SITE_PROTOCOL__
 site_protocol = http
 site_hostname =__CA_SITE_HOSTNAME__
 site_host = <site_protocol>://<site_hostname>


### PR DESCRIPTION
Otherwise the variable makes no sense… I forgot this addition in the initial pull request, sorry.
Only include the variable in a commented line together with a short hint, because replacing the current line would brake configurations, which are based on the old setup.php-dist.