### PR TITLE
NOJIRA Prevent rounding errors in spreadsheet results. ￼…

### DIFF
--- a/themes/default/views/administrate/setup/Results/xlsx_results.php
+++ b/themes/default/views/administrate/setup/Results/xlsx_results.php
@@ -39,11 +39,12 @@
 	$vs_supercol = '';
 	
 	$va_a_to_z = range('A', 'Z');
-	
+	$vn_precision = ini_get('precision');
 	$workbook = new PHPExcel();
 
 	// more accurate (but slower) automatic cell size calculation
 	PHPExcel_Shared_Font::setAutoSizeMethod(PHPExcel_Shared_Font::AUTOSIZE_METHOD_EXACT);
+	ini_set('precision', $vn_precision);
 
 	$o_sheet = $workbook->getActiveSheet();
 	// mise en forme

--- a/themes/default/views/find/Results/xlsx_results.php
+++ b/themes/default/views/find/Results/xlsx_results.php
@@ -39,12 +39,12 @@
 	$vs_supercol = '';
 	
 	$va_a_to_z = range('A', 'Z');
-	
+	$vn_precision = ini_get('precision');
 	$workbook = new PHPExcel();
 
 	// more accurate (but slower) automatic cell size calculation
 	PHPExcel_Shared_Font::setAutoSizeMethod(PHPExcel_Shared_Font::AUTOSIZE_METHOD_EXACT);
-
+	ini_set('precision', $vn_precision);
 	$o_sheet = $workbook->getActiveSheet();
 	// mise en forme
 	$columntitlestyle = array(


### PR DESCRIPTION
PHPExcel sets the precision to a value that's different from what the data is stored in. As a result measuements like `70.1 cm` get converted to `70.099999999999 cm` on download.

This resets the precision to what it was after the workbook has been created fixing the issue.