### PR TITLE
Fix single table indexing for ElasticSearch 5.x

### DIFF
--- a/app/lib/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch.php
@@ -267,16 +267,18 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 			if(!$vs_table_name = Datamodel::getTableName($pn_table_num)) { return false; }
 
 			$va_search_params = array(
-				'search_type' => 'scan',    // use search_type=scan
 				'scroll' => '1m',          // how long between scroll requests. should be small!
 				'index' => $this->getIndexName(),
 				'type' => $vs_table_name,
 				'body' => array(
 					'query' => array(
-						'match_all' => array()
+						'match_all' => $this->version >= 5 ? new \stdClass() : []
 					)
 				)
 			);
+			if ($this->version < 5){
+				$va_search_params['search_type'] = 'scan';
+			}
 
 			$va_tmp = $this->getClient()->search($va_search_params);   // Execute the search
 			$vs_scroll_id = $va_tmp['_scroll_id'];   // The response will contain no results, just a _scroll_id


### PR DESCRIPTION
* Slightly different parameters for performing the search for existing records.
* https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_search_operations.html#_scan_scroll vs https://www.elastic.co/guide/en/elasticsearch/client/php-api/5.0/_search_operations.html#_scan_scroll

Previously:
```
caUtils rebuild-search-index
```
resulted in:
```
PHP Fatal error:  Uncaught Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"parsing_exception","reason":"[match_all] query malformed, no start_object after query name","line":1,"col":23}],"type":"parsing_exception","reason":"[match_all] query malformed, no start_object after query name","line":1,"col":23},"status":400} in /path/to/ca/vendor/elasticsearch/elasticsearch/src/Elasticsearch/Connections/Connection.php:610
```

This is no longer the case ;)