### PR TITLE
NOJIRA Don't remove empty values from arrays in caSanitizeArray

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -2136,7 +2136,7 @@ function caFileIsIncludable($ps_file) {
 					continue;
 				}
 
-				if (((strlen($vm_v) < 8192) && (!preg_match("!^\X+$!", $vm_v))) || (!mb_detect_encoding($vm_v))) {
+				if (((!empty($vm_v) && strlen($vm_v) < 8192) && (!preg_match("!^\X+$!", $vm_v))) || (!mb_detect_encoding($vm_v))) {
 					unset($pa_array[$vn_k]);
 					continue;
 				}


### PR DESCRIPTION
* The method description says it's designed to strip weird noncharacter data.
* This change only removes values if they are actually set.
* Means that SimpleAPI can return blank values in a deterministic way.