### PR TITLE
Fix weird reserved word error on AWS.

### DIFF
--- a/app/controllers/administrate/setup/ElementsController.php
+++ b/app/controllers/administrate/setup/ElementsController.php
@@ -467,7 +467,7 @@ class ElementsController extends BaseEditorController {
 				(SELECT rank,count(*) as count
 					FROM ca_metadata_elements
 					WHERE parent_id=?
-					GROUP BY rank) as lambda
+					GROUP BY rank) as `lambda`
 			WHERE
 				count > 1;
 		",$pn_parent_id);


### PR DESCRIPTION
* ERROR --> DatabaseException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'lambda WHERE count > 1' at line 5

This is an AWS Aurora database.