### PR TITLE
PROV-2795 Dates are shown on the wrong locale

### DIFF
--- a/app/lib/Attributes/Values/DateRangeAttributeValue.php
+++ b/app/lib/Attributes/Values/DateRangeAttributeValue.php
@@ -223,10 +223,12 @@
  		static private $s_date_cache = array();
  		# ------------------------------------------------------------------
  		public function __construct($pa_value_array=null) {
+ 			global $g_ui_locale;
+
  			parent::__construct($pa_value_array);
  			if(!DateRangeAttributeValue::$o_tep) { 
  				DateRangeAttributeValue::$o_tep = new TimeExpressionParser(); 
- 				DateRangeAttributeValue::$o_tep->setLanguage(__CA_DEFAULT_LOCALE__);
+ 				DateRangeAttributeValue::$o_tep->setLanguage($g_ui_locale);
  			}
  		}
  		# ------------------------------------------------------------------


### PR DESCRIPTION
Use the current global locale to initialize `TimeExpressionParser`

See https://collectiveaccess.atlassian.net/browse/PROV-2795