### PR TITLE
Allow additional arguments for ImageMagick external applications

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1618,6 +1618,9 @@ always_show_counts_for_relationship_bundles_in_editor = 0
 #
 ca_sets_default_type = user
 
+# Allow multiple instances of the same item in a set?
+allow_duplicate_items_in_sets = 0
+
 # -----------------------------------
 # Timecode output
 # -----------------------------------

--- a/app/conf/external_applications.conf
+++ b/app/conf/external_applications.conf
@@ -13,6 +13,16 @@ dcraw_app = /usr/bin/dcraw
 # Path to directory containing ImageMagick binaries (http://www.imagemagick.org)
 imagemagick_path = /usr/bin
 
+# -----------------------------------
+# Defaults for ImageMagick commands
+# -----------------------------------
+#
+# Define a configuration item `imagemagick_<COMMAND_NAME>_args` per command.
+# For example, for `convert` command, use `imagemagick_convert_args`.
+#
+#imagemagick_convert_args =-limit thread 1
+
+
 # Path to GraphicsMagick binary (http://www.graphicsmagick.org)
 graphicsmagick_app = /usr/bin/gm
 

--- a/app/controllers/batch/MetadataImportController.php
+++ b/app/controllers/batch/MetadataImportController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2019 Whirl-i-Gig
+ * Copyright 2012-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -177,6 +177,8 @@
  			$va_last_settings['importer_id'] = $this->request->getParameter("importer_id", pInteger); 
  			$va_last_settings['inputFormat'] = $this->request->getParameter("inputFormat", pString); 
  			$va_last_settings['logLevel'] = $this->request->getParameter("logLevel", pInteger); 
+ 			$va_last_settings['limitLogTo'] = $this->request->getParameter("limitLogTo", pArray); 
+
  			$va_last_settings['dryRun'] = $this->request->getParameter("dryRun", pInteger); 
  			if ($vs_file_input = $this->request->getParameter("fileInput", pString)) {
  				$va_last_settings['fileInput'] = $vs_file_input; 

--- a/app/controllers/manage/sets/SetEditorController.php
+++ b/app/controllers/manage/sets/SetEditorController.php
@@ -78,6 +78,8 @@
 				return;
 			}
 			
+			Session::setVar('last_set_id', $t_subject->getPrimaryKey());
+			
       		$this->view->setVar('can_delete', $this->UserCanDeleteSet($t_subject->get('user_id')));
  			parent::Edit($pa_values, $pa_options);
  		}

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1281,8 +1281,11 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 			$t_set = new ca_sets();
 			if (is_array($va_sets = caExtractValuesByUserLocale($t_set->getSetsForItem($t_item->tableNum(), $t_item->getPrimaryKey(), array('user_id' => $po_view->request->getUserID(), 'access' => __CA_SET_READ_ACCESS__)))) && sizeof($va_sets)) {
 				$va_links = array();
+				
+				$last_set_id = Session::getVar('last_set_id');
 				foreach($va_sets as $vn_set_id => $va_set) {
-					$va_links[] = "<a href='".caEditorUrl($po_view->request, 'ca_sets', $vn_set_id)."'>".$va_set['name']."</a>";
+					$class = ($last_set_id == $vn_set_id) ? "class='currentSet'" : "";
+					$va_links[] = "<a {$class} href='".caEditorUrl($po_view->request, 'ca_sets', $vn_set_id)."'>".$va_set['name']."</a>";
 				}
 				$vs_more_info .= "<div><strong>".((sizeof($va_links) == 1) ? _t("In set") : _t("In sets"))."</strong> ".join(", ", $va_links)."</div>\n";
 			}

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -4800,3 +4800,27 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 		return $t->getDisplayLabel($bundle);
 	}
 	# ------------------------------------------------------------------
+	/**
+	 * Returns concatenated first name and surname, with a default in case
+	 * both values are null.
+	 *
+	 * In case any of the names is missing, no additional (left or right)
+	 * whitespace is included.
+	 *
+	 * @param      $fname
+	 * @param      $lname
+	 * @param null $default
+	 *
+	 * @return mixed|string
+	 */
+	function caFormatPersonName($fname, $lname, $default=null){
+		$names = [];
+		$fname ? ( $names[] = $fname ) : null ;
+		$lname ? ( $names[] = $lname ) : null ;
+
+		if ($fname || $lname){
+			return join( ' ', $names );
+		}
+		return _t($default);
+	}
+	# ------------------------------------------------------------------

--- a/app/helpers/htmlFormHelpers.php
+++ b/app/helpers/htmlFormHelpers.php
@@ -96,7 +96,7 @@
 			foreach($pa_content as $vs_val => $vs_opt) {
 				if ($vb_use_options_for_values) { $vs_val = preg_replace("!^[\s]+!", "", preg_replace("![\s]+$!", "", str_replace("&nbsp;", "", $vs_opt))); }
 				if ($COLOR = ($vs_color = $va_colors[$vs_val]) ? " data-color='#{$vs_color}'" : '') { $vb_uses_color = true; }
-				if (!($SELECTED = (((string)$vs_selected_val === (string)$vs_val) && strlen($vs_selected_val)) ? ' selected="1"' : '')) {
+				if (is_null($vs_selected_val) || !($SELECTED = (((string)$vs_selected_val === (string)$vs_val) && strlen($vs_selected_val)) ? ' selected="1"' : '')) {
 					$SELECTED = (is_array($va_selected_vals) && in_array($vs_val, $va_selected_vals)) ? ' selected="1"' : '';
 				}
 				$DISABLED = (isset($va_disabled_options[$vs_val]) && $va_disabled_options[$vs_val]) ? ' disabled="1"' : '';
@@ -107,7 +107,7 @@
 				foreach($pa_content as $vs_val) {
 					if ($COLOR = ($vs_color = $va_colors[$vs_val]) ? " data-color='#{$vs_color}'" : '') { $vb_uses_color = true; }
 					
-					if (!($SELECTED = ((string)$vs_selected_val === (string)$vs_val) ? ' selected="1"' : '')) {
+					if (is_null($vs_selected_val) || !($SELECTED = ((string)$vs_selected_val === (string)$vs_val) ? ' selected="1"' : '')) {
 						$SELECTED = (is_array($va_selected_vals) && in_array($vs_val, $va_selected_vals))  ? ' selected="1"' : '';
 					}
 					$DISABLED = (isset($va_disabled_options[$vs_val]) && $va_disabled_options[$vs_val]) ? ' disabled="1"' : '';
@@ -118,7 +118,7 @@
 					if ($vb_use_options_for_values) { $vs_val = preg_replace("!^[\s]+!", "", preg_replace("![\s]+$!", "", str_replace("&nbsp;", "", $vs_opt))); }
 					if ($COLOR = ($vs_color = $va_colors[$vs_val]) ? " data-color='#{$vs_color}'" : '') { $vb_uses_color = true; }
 				
-					if (!($SELECTED = ((string)$vs_selected_val === (string)$vs_val) ? ' selected="1"' : '')) {
+					if (is_null($vs_selected_val) || !($SELECTED = ((string)$vs_selected_val === (string)$vs_val) ? ' selected="1"' : '')) {
 						$SELECTED = (is_array($va_selected_vals) && in_array($vs_val, $va_selected_vals)) ? ' selected="1"' : '';
 					}
 					$DISABLED = (isset($va_disabled_options[$vs_val]) && $va_disabled_options[$vs_val]) ? ' disabled="1"' : '';

--- a/app/helpers/htmlFormHelpers.php
+++ b/app/helpers/htmlFormHelpers.php
@@ -410,9 +410,13 @@
 			$vn_width = 						(int)$pa_options["width"];
 			$vn_height = 						(int)$pa_options["height"];
 			
-			$vn_tile_width = 					(int)$pa_options["tile_width"];
-			$vn_tile_height = 					(int)$pa_options["tile_height"];
-			
+			$vn_tile_width = 					caGetOption('tile_width', $pa_options, 256, array('castTo'=>'int'));
+			$vn_tile_height = 					caGetOption('tile_height', $pa_options, 256, array('castTo'=>'int'));
+			// Tiles must be square.
+			if ($vn_tile_width != $vn_tile_height){
+				$vn_tile_height = $vn_tile_width;
+			}
+
 			$vn_layers = 						(int)$pa_options["layers"];
 			
 			if (!($vs_id_name = (string)$pa_options["idname"])) {
@@ -465,7 +469,8 @@
 			$va_opts['info'] = array(
 				'width' => $vn_width,
 				'height' => $vn_height,
-				'tilesize'=> 256,
+				// Set tile size using function options.
+				'tilesize'=> $vn_tile_width,
 				'levels' => $vn_layers
 			);
 			

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4274,3 +4274,19 @@ function caFileIsIncludable($ps_file) {
 			);
 	}
 	# ----------------------------------------
+
+	function caReturnValueInBytes($vs_val) {
+		$vs_val = trim($vs_val);
+		$vs_last = strtolower($vs_val[strlen($vs_val)-1]);
+		switch($vs_last) {
+			case 't':
+				$vs_val *= 1024;
+			case 'g':
+				$vs_val *= 1024;
+			case 'm':
+				$vs_val *= 1024;
+			case 'k':
+				$vs_val *= 1024;
+		}
+		return $vs_val;
+	}

--- a/app/lib/BaseLookupController.php
+++ b/app/lib/BaseLookupController.php
@@ -82,7 +82,12 @@
 				$pb_quickadd = (bool)$this->request->getParameter('quickadd', pInteger);
 				$pb_no_inline = (bool)$this->request->getParameter('noInline', pInteger);
 				$pb_quiet = (bool)$this->request->getParameter('quiet', pInteger);
-			
+				
+				if((!(bool)$o_config->get('allow_duplicate_items_in_sets')) && ($set_id = $this->request->getParameter('set_id', pInteger))) {
+					$t_set = new ca_sets($set_id);
+					$va_excludes = array_keys($t_set->getItemRowIDs());
+				}
+				
 				if (!($pn_limit = $this->request->getParameter('limit', pInteger))) { $pn_limit = 100; }
 				$va_items = array();
 				if (($vn_str_len = mb_strlen($ps_query)) > 0) {
@@ -209,7 +214,7 @@
 				
 					$va_items = caProcessRelationshipLookupLabel($qr_res, $this->opo_item_instance, $va_opts);
 				}
-				if (!is_array($va_items)) { $va_items = array(); }
+				if (!is_array($va_items)) { $va_items = []; }
 			
 				// Optional output simple list of labels instead of full data format
 				if ((bool)$this->request->getParameter('simple', pInteger)) { 

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -8730,8 +8730,7 @@ $pa_options["display_form_field_tips"] = true;
 					$post_max_size = caFormatFileSize(caReturnValueInBytes(ini_get( 'post_max_size' )));
 					$upload_max_filesize = caFormatFileSize(caReturnValueInBytes(ini_get( 'upload_max_filesize' )));
 
-					$vs_element = '<input type="file" name="'.$pa_options["name"].'" id="'.$pa_options["id"].'" '.$vs_js.'/>';
-					$vs_element .= '<div>' . _t("You can upload up to ${post_max_size} at one time. No individual file may be larger than ${upload_max_filesize}. If you want to upload more than that, you must upload the files separately, use a different upload format, or ask your system administrator to allow larger uploads.") . '</div>';
+					$vs_element = '<div class="formLabelUploadSizeNote"><input type="file" name="'.$pa_options["name"].'" id="'.$pa_options["id"].'" '.$vs_js.'/>'._t("Maxixum upload size is ${post_max_size}") . '</div>';
 
 					// show current media icon
 					if ($vs_version = (array_key_exists('displayMediaVersion', $pa_options)) ? $pa_options['displayMediaVersion'] : 'icon') {

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -8730,7 +8730,7 @@ $pa_options["display_form_field_tips"] = true;
 					$post_max_size = caFormatFileSize(caReturnValueInBytes(ini_get( 'post_max_size' )));
 					$upload_max_filesize = caFormatFileSize(caReturnValueInBytes(ini_get( 'upload_max_filesize' )));
 
-					$vs_element = '<div class="formLabelUploadSizeNote"><input type="file" name="'.$pa_options["name"].'" id="'.$pa_options["id"].'" '.$vs_js.'/>'._t("Maxixum upload size is ${post_max_size}") . '</div>';
+					$vs_element = '<div class="formLabelUploadSizeNote"><input type="file" name="'.$pa_options["name"].'" id="'.$pa_options["id"].'" '.$vs_js.'/>'._t("Maximum upload size is ${post_max_size}") . '</div>';
 
 					// show current media icon
 					if ($vs_version = (array_key_exists('displayMediaVersion', $pa_options)) ? $pa_options['displayMediaVersion'] : 'icon') {

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -8727,9 +8727,13 @@ $pa_options["display_form_field_tips"] = true;
 				# ----------------------------
 				case(FT_MEDIA):
 				case(FT_FILE):
+					$post_max_size = caFormatFileSize(caReturnValueInBytes(ini_get( 'post_max_size' )));
+					$upload_max_filesize = caFormatFileSize(caReturnValueInBytes(ini_get( 'upload_max_filesize' )));
+
 					$vs_element = '<input type="file" name="'.$pa_options["name"].'" id="'.$pa_options["id"].'" '.$vs_js.'/>';
-					
-					// show current media icon 
+					$vs_element .= '<div>' . _t("You can upload up to ${post_max_size} at one time. No individual file may be larger than ${upload_max_filesize}. If you want to upload more than that, you must upload the files separately, use a different upload format, or ask your system administrator to allow larger uploads.") . '</div>';
+
+					// show current media icon
 					if ($vs_version = (array_key_exists('displayMediaVersion', $pa_options)) ? $pa_options['displayMediaVersion'] : 'icon') {
 						$va_valid_versions = $this->getMediaVersions($ps_field);
 						if (!in_array($vs_version, $va_valid_versions)) { 

--- a/app/lib/BaseModelWithAttributes.php
+++ b/app/lib/BaseModelWithAttributes.php
@@ -1402,7 +1402,7 @@
 				}
 			}
 			
-			return $t_list->getListAsHTMLFormElement($this->getTypeListCode(), $ps_name, $pa_attributes, array_merge($pa_options, ['value' => $this->get($this->getTypeFieldName())]));
+			return $t_list->getListAsHTMLFormElement($this->getTypeListCode(), $ps_name, $pa_attributes, array_merge($pa_options, ['value' => caGetOption('value', $pa_options, $this->get($this->getTypeFieldName()))]));
 		}
 		# ------------------------------------------------------------------
 		// --- Forms

--- a/app/lib/BaseModelWithAttributes.php
+++ b/app/lib/BaseModelWithAttributes.php
@@ -204,6 +204,10 @@
 			
 			$va_attr_values = $t_attr->getAttributeValues();
 			$element = null;
+			
+			$num_values = sizeof($pa_values);
+			if(array_key_exists('locale_id', $pa_values)) { $num_values--; }
+			
 			if (
 			    // this may return a false positive if the attribute is a container with media or file attributes, 
 			    // as ca_attribute_values records for those will only be present if a file was uploaded
@@ -212,7 +216,7 @@
 			    // so if it looks like it may be a mismatch we do another, more costly, element calcuation to be sure
 			    is_array($elements = array_filter(ca_metadata_elements::getElementsForSet($vn_attr_element_id, ['omitContainers' => true]), function($v) { return (int)$v['datatype'] !== 0; }))
 			    &&    
-			    (sizeof($elements) !== sizeof($pa_values))
+			    (sizeof($elements) !== $num_values)
 			) {		// -1 to remove locale_id which is not in attribute values array
 				// Value arrays are different sizes - probably means the elements in the set have been reconfigured (sub-elements added or removed)
 				// so we need to force a save.
@@ -249,7 +253,14 @@
 						(
 							in_array($vn_element_datatype, [__CA_ATTRIBUTE_VALUE_MEDIA__, __CA_ATTRIBUTE_VALUE_FILE__])
 							&& 
-							isset($pa_values[$vs_element_code]) && sizeof($pa_values[$vs_element_code])
+							isset($pa_values[$vs_element_code]) && is_array($pa_values[$vs_element_code]) && sizeof($pa_values[$vs_element_code])
+							
+						)
+						||
+						(
+							in_array($vn_element_datatype, [__CA_ATTRIBUTE_VALUE_MEDIA__, __CA_ATTRIBUTE_VALUE_FILE__])
+							&& 
+							isset($pa_values[$vn_element_id]) && is_array($pa_values[$vn_element_id]) && sizeof($pa_values[$vn_element_id])
 							
 						)
 					) {

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -845,31 +845,30 @@
 										$vs_bool = 'OR';
 										$va_values = array();
 										
-										$vs_match_value = $va_matches[1];
-									    if (isset($idno_alts_list[strtolower($vs_match_value)])) { $vs_match_value = $idno_alts_list[strtolower($vs_match_value)];  }
+										$match_value = $va_matches[1];
+									    if (isset($idno_alts_list[strtolower($match_value)])) { $match_value = $idno_alts_list[strtolower($match_value)];  }
 										foreach($va_fields_to_match_on as $vs_fld) {
 											switch($vs_match_type) {
 												case 'STARTS':
-													$vs_match_value = "{$match_value}%";
+													$match_value = "{$match_value}%";
 													break;
 												case 'ENDS':
-													$vs_match_value = "%{$match_value}";
+													$match_value = "%{$match_value}";
 													break;
 												case 'CONTAINS':
-													$vs_match_value = "%{$match_value}%";
+													$match_value = "%{$match_value}%";
 													break;
 											}
 											if (in_array($vs_fld, array('preferred_labels', 'nonpreferred_labels'))) {
-												$va_values[$vs_fld] = ['name' => $vs_match_value];
+												$va_values[$vs_fld] = ['name' => $match_value];
 											} elseif(sizeof($va_flds = explode('.', $vs_fld)) > 1) {
-												$va_values[$va_flds[0]][$va_flds[1]] = $vs_match_value;
+												$va_values[$va_flds[0]][$va_flds[1]] = $match_value;
 											} else {
-												$va_values[$vs_fld] = $vs_match_value;
+												$va_values[$vs_fld] = $match_value;
 											}
 										}
 										
 										$o_log->logDebug("Trying to find records using boolean {$vs_bool} and values ".print_r($va_values,true));
-
 
 										if (class_exists($vs_import_target) && ($vn_id = $vs_import_target::find($va_values, array('returnAs' => 'firstId', 'allowWildcards' => true, 'boolean' => $vs_bool, 'restrictToTypes' => $va_limit_matching_to_type_ids)))) {
 											if ($t_instance->load($vn_id)) {

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -1326,6 +1326,10 @@
 			$vs_log_level = caGetOption('logLevel', $pa_options, "INFO"); 
 			$vb_import_all_datasets =  caGetOption('importAllDatasets', $pa_options, false); 
 			
+			if ($limit_log_to = caGetOption('limitLogTo', $pa_options, null)) {
+				$limit_log_to = array_map(function($v) { return strtoupper($v); }, preg_split("![;,]+!", $limit_log_to));
+			}
+			
 			$vb_dry_run = caGetOption('dryRun', $pa_options, false); 
 			
 			$vn_log_level = BatchProcessor::_logLevelStringToNumber($vs_log_level);
@@ -1339,7 +1343,7 @@
 			$vn_file_num = 0;
 			foreach($va_sources as $vs_source) {
 				$vn_file_num++;
-				if (!ca_data_importers::importDataFromSource($vs_source, $ps_importer, array('originalFilename' => caGetOption('originalFilename', $pa_options, null), 'fileNumber' => $vn_file_num, 'numberOfFiles' => sizeof($va_sources), 'logDirectory' => $o_config->get('batch_metadata_import_log_directory'), 'request' => $po_request,'format' => $ps_input_format, 'showCLIProgressBar' => false, 'useNcurses' => false, 'progressCallback' => isset($pa_options['progressCallback']) ? $pa_options['progressCallback'] : null, 'reportCallback' => isset($pa_options['reportCallback']) ? $pa_options['reportCallback'] : null,  'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level, 'dryRun' => $vb_dry_run, 'importAllDatasets' => $vb_import_all_datasets))) {
+				if (!ca_data_importers::importDataFromSource($vs_source, $ps_importer, array('originalFilename' => caGetOption('originalFilename', $pa_options, null), 'fileNumber' => $vn_file_num, 'numberOfFiles' => sizeof($va_sources), 'logDirectory' => $o_config->get('batch_metadata_import_log_directory'), 'request' => $po_request,'format' => $ps_input_format, 'showCLIProgressBar' => false, 'useNcurses' => false, 'progressCallback' => isset($pa_options['progressCallback']) ? $pa_options['progressCallback'] : null, 'reportCallback' => isset($pa_options['reportCallback']) ? $pa_options['reportCallback'] : null,  'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level, 'limitLogTo' => $limit_log_to, 'dryRun' => $vb_dry_run, 'importAllDatasets' => $vb_import_all_datasets))) {
 					$va_errors['general'][] = array(
 						'idno' => "*",
 						'label' => "*",

--- a/app/lib/ConfigurationCheck.php
+++ b/app/lib/ConfigurationCheck.php
@@ -489,7 +489,7 @@ final class ConfigurationCheck {
 		if($vs_memory_limit == "-1"){ // unlimited memory for php processes -> everything's fine
 			return true;
 		}
-		$vn_memory_limit = self::returnValueInBytes($vs_memory_limit);
+		$vn_memory_limit = caReturnValueInBytes($vs_memory_limit);
 		if($vn_memory_limit < 134217728){
 			self::addError(_t(
 				'The memory limit for your PHP installation may not be sufficient to run CollectiveAccess correctly. '.
@@ -502,8 +502,8 @@ final class ConfigurationCheck {
 	}
 	# -------------------------------------------------------
 	public static function uploadLimitExpensiveCheck() {
-		$vn_post_max_size = self::returnValueInBytes(ini_get("post_max_size"));
-		$vn_upload_max_filesize = self::returnValueInBytes(ini_get("upload_max_filesize"));
+		$vn_post_max_size = caReturnValueInBytes(ini_get("post_max_size"));
+		$vn_upload_max_filesize = caReturnValueInBytes(ini_get("upload_max_filesize"));
 
 		if($vn_post_max_size != $vn_upload_max_filesize){
 			self::addError(_t(
@@ -589,20 +589,6 @@ final class ConfigurationCheck {
 			return $qr_res->get('n');
 		}
 		return null;
-	}
-	# -------------------------------------------------------
-	private static function returnValueInBytes($vs_val) {
-		$vs_val = trim($vs_val);
-		$vs_last = strtolower($vs_val[strlen($vs_val)-1]);
-		switch($vs_last) {
-			case 'g':
-				$vs_val *= 1024;
-			case 'm':
-				$vs_val *= 1024;
-			case 'k':
-				$vs_val *= 1024;
-		}
-		return $vs_val;
 	}
 	# -------------------------------------------------------
 	public static function performDatabaseSchemaUpdate() {

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -291,8 +291,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		// get config for external apps
 		$this->opo_config = Configuration::load();
 		$this->opo_external_app_config = Configuration::load(__CA_CONF_DIR__."/external_applications.conf");
-		$this->ops_imagemagick_path = $this->opo_external_app_config->get('imagemagick_path');
-		$this->ops_graphicsmagick_path = $this->opo_external_app_config->get('graphicsmagick_app');
+		$this->ops_imagemagick_path = $this->ops_base_path;
 
 		if (caMediaPluginImagickInstalled()) {	
 			return null;	// don't use if Imagick is available
@@ -302,7 +301,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			return null;	// don't use if Gmagick is available
 		}
 		
-		if (caMediaPluginGraphicsMagickInstalled($this->ops_graphicsmagick_path)){
+		if (caMediaPluginGraphicsMagickInstalled()){
 			return null;	// don't use if GraphicsMagick is available
 		}
 		
@@ -319,7 +318,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		if ($this->register()) {
 			$va_status['available'] = true;
 		} else {
-			if (caMediaPluginGraphicsMagickInstalled($this->ops_graphicsmagick_path)) {
+			if (caMediaPluginGraphicsMagickInstalled()) {
 				$va_status['unused'] = true;
 				$va_status['warnings'][] = _t("Didn't load because GraphicsMagick is available and preferred");
 			}

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -45,18 +45,31 @@ include_once(__CA_LIB_DIR__."/Configuration.php");
 include_once(__CA_APP_DIR__."/helpers/mediaPluginHelpers.php");
 include_once(__CA_LIB_DIR__."/Parsers/MediaMetadata/XMPParser.php");
 
-trait DefaultArgsConfiguration {
+/**
+ * Trait CommandConfiguration
+ *
+ * Manage the command configuration, application and default args.
+ *
+ * TODO: Refactor to be included in BaseMediaPlugin so it is available in all media classes.
+ */
+trait CommandConfiguration {
 
 	static private $opo_external_app_config_static = null;
 	private $ops_base_path = null;
-	private $app_name = null;
+	private $ops_command_name = null;
 
-	public function initDefaultArgs( $ps_app_name, $ps_config ) {
-		$this->app_name = $ps_app_name;
+	/**
+	 * Initialize
+	 *
+	 * @param $ps_command_name Set application name. Used for getting settings from configuration file.
+	 * @param $ps_basepath_setting Name of the setting to the base path
+	 */
+	public function initCommandConfiguration( $ps_command_name, $ps_basepath_setting ) {
+		$this->ops_command_name = $ps_command_name;
 		if ( self::$opo_external_app_config_static == null ) {
 			self::$opo_external_app_config_static = Configuration::load( __CA_CONF_DIR__ . "/external_applications.conf" );
 		}
-		$this->ops_base_path = self::$opo_external_app_config_static->get( $ps_config );
+		$this->ops_base_path = self::$opo_external_app_config_static->get( $ps_basepath_setting );
 	}
 
 	/**
@@ -70,7 +83,7 @@ trait DefaultArgsConfiguration {
 	public function getCommandDefaultArgs( $command, $default ) {
 		$command = trim( $command );
 
-		return self::$opo_external_app_config_static->get( $this->app_name . "_${command}_args", $default );
+		return self::$opo_external_app_config_static->get( $this->ops_command_name . "_${command}_args", $default );
 	}
 
 	/**
@@ -102,7 +115,7 @@ trait DefaultArgsConfiguration {
 
 class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 
-	use DefaultArgsConfiguration;
+	use CommandConfiguration;
 
 	var $errors = array();
 	
@@ -282,7 +295,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	public function __construct() {
 		$this->description = _t('Provides image processing and conversion services using ImageMagick via exec() calls to ImageMagick binaries');
 		$this->init();
-		$this->initDefaultArgs('imagemagick', 'imagemagick_path');
+		$this->initCommandConfiguration('imagemagick', 'imagemagick_path');
 	}
 	# ------------------------------------------------
 	# Tell WebLib what kinds of media this plug-in supports

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -291,7 +291,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			$this->postError(1610, _t("Filenames with colons (:) are not allowed"), "WLPlugImageMagick->divineFileFormat()");
 			return false;
 		}
-			
+
 		# is it a tilepic?
 		$tp = new TilepicParser();
 		if ($tp->isTilepic($filepath)) {
@@ -882,7 +882,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		}
 
 		$va_output = array();
-		caExec($this->ops_imagemagick_path.'/identify -format "%m\n" '.caEscapeShellArg($this->filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+		caExec( $this->commandWithDefaultArgs('identify') . ' -format "%m\n" ' . caEscapeShellArg($this->filepath) . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 		
 		// don't extract previews from "normal" images (the output line count is always # of files + 1)
 		if(sizeof($va_output)<=2) { return false; } 
@@ -890,7 +890,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		$vs_output_file_prefix = tempnam($vs_tmp_dir, 'caMultipagePreview');
 		$vs_output_file = $vs_output_file_prefix.'_%05d.jpg';
 
-		caExec($this->ops_imagemagick_path.'/convert '.caEscapeShellArg($this->filepath)." ".$vs_output_file.(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+		caExec( $this->commandWithDefaultArgs('convert') . ' ' . caEscapeShellArg($this->filepath) . " " . $vs_output_file . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 
 		$vn_i = 0;
 		$va_files = array();
@@ -923,7 +923,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		}
 
 		if(sizeof($va_acceptable_files)){
-			caExec($this->ops_imagemagick_path."/convert ".join(" ",$va_acceptable_files)." ".$vs_archive_original.(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( $this->commandWithDefaultArgs('convert') . ' ' . join(" ",$va_acceptable_files) . " " . $vs_archive_original . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 			if($vn_return === 0){
 				return $vs_archive_original;
 			}
@@ -1013,7 +1013,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	# ------------------------------------------------
 	private function _imageMagickIdentify($ps_filepath) {
 		if (caMediaPluginImageMagickInstalled($this->ops_imagemagick_path)) {
-			caExec($this->ops_imagemagick_path.'/identify -format "%m" '.caEscapeShellArg($ps_filepath.'[0]').(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( $this->commandWithDefaultArgs('identify') . ' -format "%m" ' . caEscapeShellArg( $ps_filepath . '[0]') . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 			return $this->magickToMimeType($va_output[0]);
 		}
 		return null;
@@ -1041,14 +1041,14 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 				}
 			}
 			
-			caExec($this->ops_imagemagick_path."/identify -format '%[DPX:*]' ".caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( $this->commandWithDefaultArgs('identify') . " -format '%[DPX:*]' " . caEscapeShellArg($ps_filepath) . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 			if ($va_output[0]) { $va_metadata['DPX'] = $va_output; }
 			
 			/* IPTC metadata */
 			$vs_iptc_file = tempnam(caGetTempDirPath(), 'imiptc');
 			@rename($vs_iptc_file, $vs_iptc_file.'.iptc'); // IM uses the file extension to figure out what we want
 			$vs_iptc_file .= '.iptc';
-			caExec($this->ops_imagemagick_path."/convert ".caEscapeShellArg($ps_filepath)." ".caEscapeShellArg($vs_iptc_file).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( $this->commandWithDefaultArgs('convert') . ' ' . caEscapeShellArg($ps_filepath) . " " . caEscapeShellArg($vs_iptc_file) . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 
 			$vs_iptc_data = file_get_contents($vs_iptc_file);
 			@unlink($vs_iptc_file);
@@ -1104,7 +1104,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	private function _imageMagickRead($ps_filepath, $options=null) {
 		if (caMediaPluginImageMagickInstalled($this->ops_imagemagick_path)) {
 		
-			caExec($this->ops_imagemagick_path.'/identify -format "%m;%w;%h;%[colorspace];%[depth];%[xresolution];%[yresolution]\n" '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( $this->commandWithDefaultArgs('identify') . ' -format "%m;%w;%h;%[colorspace];%[depth];%[xresolution];%[yresolution]\n" ' . caEscapeShellArg($ps_filepath) . (caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 			
 			$va_tmp = explode(';', $va_output[0]);
 			
@@ -1264,11 +1264,11 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					array_unshift($va_ops['convert'], '-quality '.intval($pn_quality));
 				}
 				array_unshift($va_ops['convert'], '-colorspace RGB');
-				caExec($this->ops_imagemagick_path.'/convert '.caEscapeShellArg($vs_input_file.'[0]').' '.join(' ', $va_ops['convert']).' '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""));
+				caExec( $this->commandWithDefaultArgs('convert') . ' ' . caEscapeShellArg( $vs_input_file . '[0]') . ' ' . join(' ', $va_ops['convert']) . ' ' . caEscapeShellArg($ps_filepath) . (caIsPOSIX() ? " 2> /dev/null" : ""));
 				$vs_input_file = $ps_filepath;
 			}
 			if (is_array($va_ops['composite']) && sizeof($va_ops['composite'])) {
-				caExec($this->ops_imagemagick_path.'/composite '.join(' ', $va_ops['composite']).' '.caEscapeShellArg($vs_input_file.'[0]').' '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""));
+				caExec( $this->commandWithDefaultArgs('composite') . join(' ', $va_ops['composite']) . ' ' . caEscapeShellArg( $vs_input_file . '[0]') . ' ' . caEscapeShellArg($ps_filepath) . (caIsPOSIX() ? " 2> /dev/null" : ""));
 			}	
 			
 			return true;
@@ -1276,4 +1276,44 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		return null;
 	}
 	# ------------------------------------------------
+
+	/**
+	 * Load command default arguments from configuration
+	 *
+	 * @param $command
+	 * @param $default
+	 *
+	 * @return string
+	 */
+	public function getCommandDefaultArgs( $command, $default ) {
+		$command = trim( $command );
+
+		return $this->opo_external_app_config->get( "imagemagick_${command}_args", $default );
+	}
+
+	/**
+	 * Return absolute path to command and default arguments
+	 *
+	 * @param      $command
+	 * @param null $default_args
+	 *
+	 * @return string
+	 */
+	public function commandWithDefaultArgs( $command, $default_args = null ) {
+		return $this->command( $command ) . " " . $this->getCommandDefaultArgs( $command, $default_args );
+	}
+
+	/**
+	 * Return absolute path to command
+	 *
+	 * @param $command
+	 *
+	 * @return string
+	 */
+	public function command( $command ) {
+		$command = trim( $command );
+
+		return "{$this->ops_imagemagick_path}/$command";
+	}
+
 }

--- a/app/lib/Plugins/TaskQueueHandlers/mediaproc.php
+++ b/app/lib/Plugins/TaskQueueHandlers/mediaproc.php
@@ -89,7 +89,7 @@ include_once(__CA_LIB_DIR__."/Logging/Eventlog.php");
 			if (file_exists($va_parameters["FILENAME"])) {
 				$va_params['input_file_size'] = array(
 					'label' => _t('Input file size'),
-					'value' => sprintf("%4.2dM", filesize($va_parameters["FILENAME"])/(1024 * 1024))
+					'value' => sprintf("%s", caFormatFileSize(filesize($va_parameters["FILENAME"])))
 				);
 			}
 			$va_params['table'] = array(

--- a/app/lib/Service/ItemService.php
+++ b/app/lib/Service/ItemService.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2019 Whirl-i-Gig
+ * Copyright 2012-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -365,7 +365,7 @@ class ItemService extends BaseJSONService {
 		}
 
 		// preferred labels
-		$va_labels = $t_instance->get($this->ops_table.".preferred_labels", array("returnWithStructure" => true, "returnAllLocales" => true));
+		$va_labels = $t_instance->get($this->ops_table.".preferred_labels", array("returnWithStructure" => true, "returnAllLocales" => true, "assumeDisplayField" => false));
 		$va_labels = end($va_labels);
 		if(is_array($va_labels)) {
 			foreach($va_labels as $vn_locale_id => $va_labels_by_locale) {
@@ -384,7 +384,7 @@ class ItemService extends BaseJSONService {
 		}
 
 		// nonpreferred labels
-		$va_labels = $t_instance->get($this->ops_table.".nonpreferred_labels", array("returnWithStructure" => true, "returnAllLocales" => true));
+		$va_labels = $t_instance->get($this->ops_table.".nonpreferred_labels", array("returnWithStructure" => true, "returnAllLocales" => true, "assumeDisplayField" => false));
 		$va_labels = end($va_labels);
 		if(is_array($va_labels)) {
 			foreach($va_labels as $vn_locale_id => $va_labels_by_locale) {

--- a/app/lib/Sync/LogEntry/Base.php
+++ b/app/lib/Sync/LogEntry/Base.php
@@ -482,7 +482,7 @@ abstract class Base {
 						$this->getModelInstance()->set($vs_field, $t_rel_item->getPrimaryKey());
 						continue;
 					} else {
-						if (!in_array($vs_field, ['type_id', 'locale_id', 'item_id', 'lot_id'])) {	// let auto-resolved fields fall through
+						if (!in_array($vs_field, ['type_id', 'locale_id', 'item_id', 'lot_id', 'home_location_id'])) {	// let auto-resolved fields fall through
 							throw new IrrelevantLogEntry(_t("%1 guid value '%2' is not defined on this system for %3: %4", $vs_field, $va_snapshot[$vs_field.'_guid'], $t_rel_item->tableName(), print_R($va_snapshot, true)));
 						}
 					}

--- a/app/lib/Sync/Replicator.php
+++ b/app/lib/Sync/Replicator.php
@@ -227,6 +227,7 @@ class Replicator {
 						->addGetParameter('pushMediaTo', $vs_push_media_to)
 						->request()->getRawData();
 
+					if(!is_array($va_source_log_entries)) { break; }
                     $log_ids = array_keys($va_source_log_entries);
                     $start_log_id = array_shift($log_ids);
                     $end_log_id = array_pop($log_ids);

--- a/app/lib/TaskQueue.php
+++ b/app/lib/TaskQueue.php
@@ -337,11 +337,13 @@ class TaskQueue extends BaseObject {
 					
 					
 				} else {
-					$this->opo_eventlog->log(array(
-						"CODE" => "ERR", 
-						"SOURCE" => "TaskQueue->processQueue()", 
-						"MESSAGE" => "Queue processing failed using handler $proc_handler: ".($h->error ? $h->error->getErrorDescription() : '')." [".$h->error->getErrorNumber()."]; queue was <b>NOT</b> halted")
-					);
+					$errorDescription = $h->error ? $h->error->getErrorDescription() : '';
+					$errorNumber      = $h->error->getErrorNumber();
+					$this->opo_eventlog->log( array(
+						"CODE"    => "ERR",
+						"SOURCE"  => "TaskQueue->processQueue()",
+						"MESSAGE" => "Queue processing failed using handler $proc_handler: $errorDescription [$errorNumber]; queue was NOT halted"
+					) );
 					$this->errors[] = $h->error;
 					
 					// Got error, so mark task as failed (non-zero error_code value)
@@ -349,7 +351,7 @@ class TaskQueue extends BaseObject {
 						UPDATE ca_task_queue 
 						SET completed_on = ?, error_code = ? 
 						WHERE task_id = ?", 
-						time(), (int)$h->error->getErrorNumber(), (int)$qr_tasks->get("task_id"));
+						time(), (int) $errorNumber, (int)$qr_tasks->get("task_id"));
 				}
 				if ($o_db->numErrors()) {
 					$this->opo_eventlog->log(array(

--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -452,6 +452,7 @@
 				CLIUtils::addError(_t('Set %1 does take items imported by mapping', $vs_add_to_set));
 				return false;
 			}
+			
 
 			$vb_direct = (bool)$po_opts->getOption('direct');
 			$vb_no_search_indexing = (bool)$po_opts->getOption('no-search-indexing');
@@ -467,7 +468,7 @@
 				define("__CA_DONT_DO_SEARCH_INDEXING__", true);
 			}
 
-			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, array('dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 'format' => $vs_format, 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 'addToSet' => $vs_add_to_set, 'environment' => $env))) {
+			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, array('dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 'format' => $vs_format, 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 'limitLogTo' => $po_opts->getOption('limit-log-to'), 'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 'addToSet' => $vs_add_to_set, 'environment' => $env))) {
 				CLIUtils::addError(_t("Could not import source %1: %2", $vs_data_source, join("; ", ca_data_importers::getErrorList())));
 				return false;
 			} else {
@@ -485,7 +486,8 @@
 				"mapping|m=s" => _t('Mapping to import data with.'),
 				"format|f-s" => _t('The format of the data to import. (Ex. XLSX, tab, CSV, mysql, OAI, Filemaker XML, ExcelXML, MARC). If omitted an attempt will be made to automatically identify the data format.'),
 				"log|l-s" => _t('Path to directory in which to log import details. If not set no logs will be recorded.'),
-				"log-level|d-s" => _t('Logging threshold. Possible values are, in ascending order of important: DEBUG, INFO, NOTICE, WARN, ERR, CRIT, ALERT. Default is INFO.'),
+				"log-level|d-s" => _t('Logging threshold. Possible values are, in ascending order of importance: DEBUG, INFO, NOTICE, WARN, ERR, CRIT, ALERT. Default is INFO.'),
+				"limit-log-to|l-s" => _t('Limit logging to specific event types when log level is set to INFO. Limit logging to specific event types for log level INFO. Valid values are: GENERAL (general status messages), EXISTING_RECORD_POLCY (messages relating to merging of existing records, SKIP (messages relating to conditional skipping of mappings, groups or records), RELATIONSHIPS (messages relating to creating of relationships. Seprate multiple types with commas or semicolors.'),
 				"add-to-set|t-s" => _t('Optional identifier of set to add all imported items to.'),
 				"environment|e-s" => _t('JSON-encoded key value pairs to add to import environment values.'),
 				"dryrun" => _t('If set import is performed without data actually being saved to the database. This is useful for previewing an import for errors.'),

--- a/app/models/ca_objects.php
+++ b/app/models/ca_objects.php
@@ -184,34 +184,6 @@ BaseModel::$s_ca_models_definitions['ca_objects'] = array(
 				'LIST_CODE' => 'object_deaccession_types',
 				'LABEL' => _t('Deaccession type'), 'DESCRIPTION' => _t('Indicates type of deaccession.')
 		),
-		'current_loc_class' => array(
-				'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_OMIT, 
-				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
-				'IS_NULL' => true, 
-				'DONT_ALLOW_IN_UI' => true,
-				'BOUNDS_CHOICE_LIST' => array(
-					_t('occurrences') => 67,
-					_t('storage locations') => 119,	// we store the ca_objects_x_storage_locations relation_id for locations
-					_t('loans') => 133,
-					_t('movements') => 137,
-					_t('object lots') => 51
-				),
-				'LABEL' => _t('Current location class'), 'DESCRIPTION' => _t('Indicates classification of last location for objects (eg. storage location, occurrence, loan, movement)')
-		),
-		'current_loc_subclass' => array(
-				'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_OMIT, 
-				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
-				'IS_NULL' => true, 
-				'DONT_ALLOW_IN_UI' => true,
-				'LABEL' => _t('Current location sub-class'), 'DESCRIPTION' => _t('Indicates sub-classification of last location for objects (eg. storage location relationship type, occurrence type, loan type, movement)')
-		),
-		'current_loc_id' => array(
-				'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_OMIT, 
-				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
-				'IS_NULL' => true, 
-				'DONT_ALLOW_IN_UI' => true,
-				'LABEL' => _t('Current location'), 'DESCRIPTION' => _t('Reference to record recording details of current object location.')
-		),
 		'item_status_id' => array(
 				'FIELD_TYPE' => FT_NUMBER, 'DISPLAY_TYPE' => DT_SELECT, 
 				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,

--- a/app/widgets/trackProcessing/trackProcessingWidget.php
+++ b/app/widgets/trackProcessing/trackProcessingWidget.php
@@ -84,7 +84,7 @@
 				$va_params = caUnserializeForDatabase($va_row["parameters"]);
 				$va_completed[$va_row["task_id"]]["handler_name"] = $vo_tq->getHandlerName($va_row['handler']);
 				$va_completed[$va_row["task_id"]]["created"] = $va_row["created_on"];
-				$va_completed[$va_row["task_id"]]["by"] = $va_row["fname"].' '.$va_row['lname'];
+				$va_completed[$va_row["task_id"]]["by"] = caFormatPersonName( $va_row["fname"], $va_row['lname'], _t('Command line or job'));
 				$va_completed[$va_row["task_id"]]["completed_on"] = $va_row["completed_on"];
 				$va_completed[$va_row["task_id"]]["error_code"] = $va_row["error_code"];
 				
@@ -122,12 +122,12 @@
 				if(!$vo_tq->rowKeyIsBeingProcessed($va_row["row_key"])){
 					$va_qd_jobs[$va_row["task_id"]]["handler_name"] = $vo_tq->getHandlerName($va_row['handler']);
 					$va_qd_jobs[$va_row["task_id"]]["created"] = $va_row["created_on"];
-					$va_qd_jobs[$va_row["task_id"]]["by"] = $va_row["fname"].' '.$va_row['lname'];
+					$va_qd_jobs[$va_row["task_id"]]["by"] = caFormatPersonName( $va_row["fname"], $va_row['lname'], _t('Command line or job'));
 					$va_qd_jobs[$va_row["task_id"]]["status"] = $vo_tq->getParametersForDisplay($va_row);
 				} else {
 					$va_pr_jobs[$va_row["task_id"]]["handler_name"] = $vo_tq->getHandlerName($va_row['handler']);
 					$va_pr_jobs[$va_row["task_id"]]["created"] = $va_row["created_on"];
-					$va_pr_jobs[$va_row["task_id"]]["by"] = $va_row["fname"].' '.$va_row['lname'];
+					$va_pr_jobs[$va_row["task_id"]]["by"] = caFormatPersonName( $va_row["fname"], $va_row['lname'], _t('Command line or job'));
 					$va_pr_jobs[$va_row["task_id"]]["status"] = $vo_tq->getParametersForDisplay($va_row);
 				}
 			}

--- a/app/widgets/trackProcessing/views/main_html.php
+++ b/app/widgets/trackProcessing/views/main_html.php
@@ -15,7 +15,7 @@
  * the terms of the provided license as published by Whirl-i-Gig
  *
  * CollectiveAccess is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
  *
  * This source code is free and modifiable under the terms of 
@@ -32,13 +32,40 @@
 	$vn_jobs_queued_processing = $this->getVar('jobs_queued_processing');
 	$va_jobs_queued = $this->getVar('qd_job_data');
 	$va_jobs_processing = $this->getVar('pr_job_data');
-	
+
+	/**
+	 * Returns a string to render status information in html.
+	 *
+	 * @param $va_status
+	 * @param $view
+	 */
+	function getStatusForDisplay($va_status, $view){
+		$result = "";
+		foreach($va_status as $vs_code => $va_info) {
+			switch($vs_code) {
+				case 'table':
+					$va_tmp = explode(':', $va_status['table']['value']);
+					if ($vs_link = caEditorLink($view->request, $va_info['value'], 'link', $va_tmp[0], $va_tmp[2], array(), array(), array('verifyLink' => true))) {
+						$result .= "<strong>".$va_info['label']."</strong>: ".$vs_link."<br/>\n";
+					} else {
+						$result .=  "<strong>".$va_info['label']."</strong>: ".$va_info['value']." [<em>"._t('DELETED')."</em>]<br/>\n";
+					}
+					break;
+				default:
+					$result .= "<strong>".$va_info['label']."</strong>: ".$va_info['value']."<br/>\n";
+					break;
+			}
+		}
+
+		return $result;
+	}
 ?>
 
 <div class="dashboardWidgetContentContainer" id="widget_<?php print $vs_widget_id; ?>">
-	<div style="float:right; margin-right: 10px;" id="widget_last_update_display_<?php print $vs_widget_id; ?>">
+	<div class="control-box-right-content" id="widget_last_update_display_<?php print $vs_widget_id; ?>">
 		<?php print _t('Updated at %1', date('H:i')); ?>
 	</div>
+	<div class="clear"></div>
 
 <?php
 	if((sizeof($va_jobs_processing) > 0) || (sizeof($va_jobs_queued) > 0) || (sizeof($va_jobs_done) > 0)){
@@ -79,12 +106,7 @@
 						
 						<?php print "<strong>"._t("Created on")."</strong>: ".date("n/d/Y @ g:i:sa T", $va_job["created"])."<br />"; ?>
 						<?php print "<strong>"._t("Created by")."</strong>: ".$va_job['by']."<br />"; ?>
-<?php 
-						foreach($va_job['status'] as $vs_code => $va_info) {
-							print "<strong>".$va_info['label']."</strong>: ".$va_info['value']."<br/>\n"; 
-						}
-		
-?>
+						<?php print getStatusForDisplay( $va_job['status'], $this ); ?>
 					</td>
 				</tr>
 <?php
@@ -109,10 +131,7 @@
 						
 						<?php print "<strong>"._t("Created on")."</strong>: ".date("n/d/Y @ g:i:sa T", $va_job["created"])."<br />"; ?>
 						<?php print "<strong>"._t("Created by")."</strong>: ".$va_job['by']."<br />"; ?>
-<?php 
-						foreach($va_job['status'] as $vs_code => $va_info) {
-							print "<strong>".$va_info['label']."</strong>: ".$va_info['value']."<br/>\n"; 
-						}
+						<?php print getStatusForDisplay($va_job['status'], $this);
 ?>
 					</td>
 				</tr>
@@ -142,27 +161,17 @@
 							print "<strong>"._t('Completed on')."</strong>: ".date("n/d/Y @ g:i:sa T", $va_job["completed_on"])."<br/>\n"; 
 							
 							if ((int)$va_job["error_code"] > 0) {
-								print "<span style='color: #cc0000;'><strong>"._t('Error')."</strong>: ".$va_job["error_message"]." [".$va_job["error_code"]."] <em>"._t('TASK DID NOT COMPLETE')."</em></span><br/>\n"; 
+								print "<span style='color: #cc0000;'><strong>" . _t( 'Error' ) . "</strong>: "
+								      . $va_job["error_message"] . " [" . $va_job["error_code"] . "] <em>"
+								      . _t( 'TASK DID NOT COMPLETE' ) . "</em>"
+								      ." Review " . caNavLink( $this->request,
+										'Event Log', '', '', 'logs/Events', 'Index' ) . "</span><br/>\n";
 							}
 						}
-						
-						foreach($va_job['status'] as $vs_code => $va_info) {
-							switch($vs_code) {
-								case 'table':
-									$va_tmp = explode(':', $va_job['status']['table']['value']);
-									if ($vs_link = caEditorLink($this->request, $va_info['value'], '', $va_tmp[0], $va_tmp[2], array(), array(), array('verifyLink' => true))) {
-										print "<strong>".$va_info['label']."</strong>: ".$vs_link."<br/>\n";
-									} else {
-										print "<strong>".$va_info['label']."</strong>: ".$va_info['value']." [<em>"._t('DELETED')."</em>]<br/>\n";
-									}
-									break;
-								default:
-									print "<strong>".$va_info['label']."</strong>: ".$va_info['value']."<br/>\n"; 
-									break;
-							}
-						}
-		
-		?>
+
+						print getStatusForDisplay( $va_job['status'], $this );
+
+						?>
 						<?php print "<strong>"._t("Total processing time")."</strong>: ".$va_job['processing_time']."s<br />"; ?>
 					</td>
 				</tr>
@@ -176,7 +185,11 @@
 	</div><!-- end tabContainer -->
 <?php
 	}else{
-		print _t("There are no running jobs, queued jobs or jobs completed in the last %1 hours.", $this->getVar('hours'));
+		?>
+	<div class="block">
+		<?php print _t("There are no running jobs, queued jobs or jobs completed in the last %1 hours.", $this->getVar('hours'));
+		?>
+	</div><?php
 	}
 ?>
 </div>

--- a/assets/ca/ca.seteditor.js
+++ b/assets/ca/ca.seteditor.js
@@ -6,7 +6,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2018 Whirl-i-Gig
+ * Copyright 2010-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -63,7 +63,7 @@ var caUI = caUI || {};
 			// setup autocompleter
 			jQuery('#' + that.setItemAutocompleteID).autocomplete(
 				{
-					source: that.lookupURL + "?quickadd=0&noInline=1",
+					source: that.lookupURL + "?quickadd=0&noInline=1&set_id=" + that.setID,
 					minLength: 3, max: 50, html: true,
 					select: function(event, ui) {
 						jQuery.getJSON(that.itemInfoURL, {'set_id': that.setID, 'table_num': that.table_num, 'row_id': ui.item.id, 'displayTemplate': that.displayTemplate} , 

--- a/tests/conf/external_applications.conf
+++ b/tests/conf/external_applications.conf
@@ -1,0 +1,12 @@
+# Path to directory containing ImageMagick binaries (http://www.imagemagick.org)
+imagemagick_path = /usr/bin
+
+# -----------------------------------
+# Defaults for ImageMagick commands
+# -----------------------------------
+#
+# Define a configuration item `imagemagick_<COMMAND_NAME>_args` per command.
+# For example, for `convert` command, use `imagemagick_convert_args`.
+#
+imagemagick_convert_args =-limit thread 1
+imagemagick_whatever_args =

--- a/tests/helpers/DisplayHelpersTest.php
+++ b/tests/helpers/DisplayHelpersTest.php
@@ -36,53 +36,81 @@ require_once(__CA_APP_DIR__."/helpers/displayHelpers.php");
 class DisplayHelpersTest extends TestCase {
 	# -------------------------------------------------------
 	public function testTags() {
-		$va_tags = caGetTemplateTags('Here is a simple CA field spec: ^ca_objects.idno');
-		$this->assertEquals('ca_objects.idno', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
+		$va_tags = caGetTemplateTags( 'Here is a simple CA field spec: ^ca_objects.idno' );
+		$this->assertEquals( 'ca_objects.idno', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
 		$va_tags = caGetTemplateTags('Here is a simple CA field spec with options: ^ca_objects.user_tags%delimiter=_➜_');
-		$this->assertEquals('ca_objects.user_tags%delimiter=_➜_', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
+		$this->assertEquals( 'ca_objects.user_tags%delimiter=_➜_', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
 		$va_tags = caGetTemplateTags('Here is a simple CA field spec with options: ^ca_objects.user_tags%delimiter=_➜_&maxLength=100');
-		$this->assertEquals('ca_objects.user_tags%delimiter=_➜_&maxLength=100', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
-		$va_tags = caGetTemplateTags('Here is a tag: ^description');
-		$this->assertEquals('description', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
-		$va_tags = caGetTemplateTags('Here is a tag with options: ^description%delimiter=_➜_');
-		$this->assertEquals('description%delimiter=_➜_', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
-		$va_tags = caGetTemplateTags('Here is a tag with options: ^description%delimiter=_➜_&maxLength=100');
-		$this->assertEquals('description%delimiter=_➜_&maxLength=100', $va_tags[0]);
-		$this->assertEquals(1, sizeof($va_tags));
-		
-		$va_tags = caGetTemplateTags('Here are tags as used for an Excel mapping: ^8 ^9, ^10 blah blah blah');
-		$this->assertEquals('8', $va_tags[0]);
-		$this->assertEquals('9', $va_tags[1]);
-		$this->assertEquals('10', $va_tags[2]);
-		$this->assertEquals(3, sizeof($va_tags));
-		
+		$this->assertEquals( 'ca_objects.user_tags%delimiter=_➜_&maxLength=100', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
+		$va_tags = caGetTemplateTags( 'Here is a tag: ^description' );
+		$this->assertEquals( 'description', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
+		$va_tags = caGetTemplateTags( 'Here is a tag with options: ^description%delimiter=_➜_' );
+		$this->assertEquals( 'description%delimiter=_➜_', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
+		$va_tags = caGetTemplateTags( 'Here is a tag with options: ^description%delimiter=_➜_&maxLength=100' );
+		$this->assertEquals( 'description%delimiter=_➜_&maxLength=100', $va_tags[0] );
+		$this->assertEquals( 1, sizeof( $va_tags ) );
+
+		$va_tags = caGetTemplateTags( 'Here are tags as used for an Excel mapping: ^8 ^9, ^10 blah blah blah' );
+		$this->assertEquals( '8', $va_tags[0] );
+		$this->assertEquals( '9', $va_tags[1] );
+		$this->assertEquals( '10', $va_tags[2] );
+		$this->assertEquals( 3, sizeof( $va_tags ) );
+
 		$va_tags = caGetTemplateTags("Here are XPath tags: ^/datafield[@tag='040']/subfield[@code='a'] ^/datafield[@tag='040']/title,meow ^/datafield[@tag='040']/subfield[@code='c']");
-		$this->assertEquals("/datafield[@tag='040']/subfield[@code='a']", $va_tags[0]);
-		$this->assertEquals("/datafield[@tag='040']/title", $va_tags[1]);
-		$this->assertEquals("/datafield[@tag='040']/subfield[@code='c']", $va_tags[2]);
-		
-		$this->assertEquals(3, sizeof($va_tags));
-		
+		$this->assertEquals( "/datafield[@tag='040']/subfield[@code='a']", $va_tags[0] );
+		$this->assertEquals( "/datafield[@tag='040']/title", $va_tags[1] );
+		$this->assertEquals( "/datafield[@tag='040']/subfield[@code='c']", $va_tags[2] );
+
+		$this->assertEquals( 3, sizeof( $va_tags ) );
+
 		$va_tags = caGetTemplateTags("Here are namespaced XPath tags: ^/tei:title[@tag='040']/subfield[@code='a'],foo ^/tei:title[@tag='040']/subfield[@code='b'] ^/tei:title[@tag='040']/title");
-		$this->assertEquals("/tei:title[@tag='040']/subfield[@code='a']", $va_tags[0]);
-		$this->assertEquals("/tei:title[@tag='040']/subfield[@code='b']", $va_tags[1]);
-		$this->assertEquals("/tei:title[@tag='040']/title", $va_tags[2]);
-		$this->assertEquals(3, sizeof($va_tags));
-		
-		$va_tags = caGetTemplateTags('Here are tags with modifiers: ^1~LP:0/10 and ^4~UPPER');
-		$this->assertEquals('1~LP:0/10', $va_tags[0]);
-		$this->assertEquals('4~UPPER', $va_tags[1]);
-		$this->assertEquals(2, sizeof($va_tags));
+		$this->assertEquals( "/tei:title[@tag='040']/subfield[@code='a']", $va_tags[0] );
+		$this->assertEquals( "/tei:title[@tag='040']/subfield[@code='b']", $va_tags[1] );
+		$this->assertEquals( "/tei:title[@tag='040']/title", $va_tags[2] );
+		$this->assertEquals( 3, sizeof( $va_tags ) );
+
+		$va_tags = caGetTemplateTags( 'Here are tags with modifiers: ^1~LP:0/10 and ^4~UPPER' );
+		$this->assertEquals( '1~LP:0/10', $va_tags[0] );
+		$this->assertEquals( '4~UPPER', $va_tags[1] );
+		$this->assertEquals( 2, sizeof( $va_tags ) );
+	}
+	# -------------------------------------------------------
+	public function testDisplayNameWithBothNames() {
+		$fname = 'Peter';
+		$lname = 'Perkins';
+
+		$this->assertEquals('Peter Perkins', caFormatPersonName($fname, $lname));
+	}
+	# -------------------------------------------------------
+	public function testDisplayNameOnlyFirstName() {
+		$fname = 'Peter';
+		$lname = null;
+
+		$this->assertEquals('Peter', caFormatPersonName($fname, $lname));
+	}
+	# -------------------------------------------------------
+	public function testDisplayNameOnlySurname() {
+		$fname = null;
+		$lname = 'Perkins';
+
+		$this->assertEquals('Perkins', caFormatPersonName($fname, $lname));
+	}
+	# -------------------------------------------------------
+	public function testDisplayNameDefault() {
+		$fname = null;
+		$lname = null;
+
+		$this->assertEquals('Faulty Default', caFormatPersonName($fname, $lname, 'Faulty Default'));
 	}
 	# -------------------------------------------------------
 }

--- a/tests/helpers/HtmlFormHelpersTest.php
+++ b/tests/helpers/HtmlFormHelpersTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) Orestes Sanchez Benavente <orestes@estotienearreglo.es> 2020
+ */
+use PHPUnit\Framework\TestCase;
+ 
+require_once(__CA_APP_DIR__."/helpers/displayHelpers.php");
+
+class HtmlFormHelpersTest extends TestCase {
+	# -------------------------------------------------------
+	public function testImageUsesDefaultTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+		));
+		$this->assertStringContainsString('"tilesize":256', $result);
+	}
+	# -------------------------------------------------------
+	public function testImageUsesCustomTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_width' => 512
+		));
+		$this->assertStringContainsString('"tilesize":512', $result);
+	}
+	# -------------------------------------------------------
+	public function testImageDoesNotUseHeightTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_height' => 1024
+		));
+		// Uses default tilesize
+		$this->assertStringContainsString('"tilesize":256', $result);
+	}
+	# -------------------------------------------------------
+	public function testImagePrefersWidthTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_width' => 1024,
+			'tile_height' => 512
+		));
+		// Uses default tilesize
+		$this->assertStringContainsString('"tilesize":1024', $result);
+	}
+	# -------------------------------------------------------
+	public function testJpegImageDoesNotUseTiles() {
+		$result = caHTMLImage('http://example.com/image.jpg', array());
+		$this->assertStringNotContainsString('"tilesize"', $result);
+	}
+	# -------------------------------------------------------
+	# -------------------------------------------------------
+}

--- a/tests/lib/Plugins/Media/ImageMagickTest.php
+++ b/tests/lib/Plugins/Media/ImageMagickTest.php
@@ -79,4 +79,16 @@ class ImageMagickTest extends TestCase {
 		$this->assertEquals( '/usr/bin/convert -limit thread 1', $command );
 	}
 
+	/**
+	 * First attempt for unit testing and mocks.
+	 */
+	public function testCheckStatus() {
+		$imagemagick_plugin = $this->getMockBuilder( WLPlugMediaImageMagick::class )->onlyMethods( [ 'register' ] )
+		                           ->getMock();
+		$imagemagick_plugin->method( 'register' )->willReturn( array( 'info' => 1 ) );
+		$status = $imagemagick_plugin->checkStatus();
+
+		$this->assertIsArray( $status );
+		$this->assertTrue( $status['available'] );
+	}
 }

--- a/tests/lib/Plugins/Media/ImageMagickTest.php
+++ b/tests/lib/Plugins/Media/ImageMagickTest.php
@@ -23,53 +23,60 @@
  * the "license.txt" file for details, or visit the CollectiveAccess web site at
  * http://www.CollectiveAccess.org
  *
- * @package CollectiveAccess
+ * @package    CollectiveAccess
  * @subpackage tests
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
- * @author Orestes Sanchez <orestes@estotienearreglo.es>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ * @author     Orestes Sanchez <orestes@estotienearreglo.es>
  *
  * ----------------------------------------------------------------------
  */
+
 use PHPUnit\Framework\TestCase;
 
-require_once(__CA_APP_DIR__."/helpers/systemHelpers.php");
-require_once(__CA_APP_DIR__."/lib/Plugins/Media/ImageMagick.php");
+require_once( __CA_APP_DIR__ . "/helpers/systemHelpers.php" );
+require_once( __CA_APP_DIR__ . "/lib/Plugins/Media/ImageMagick.php" );
 
+/**
+ * Class ImageMagickTest
+ *
+ * Allow testing imagemagick media plugin.
+ * See configuration on tests/conf.
+ *
+ */
 class ImageMagickTest extends TestCase {
+
+	protected $im_plugin = null;
+	protected $prophet = null;
+
+	protected function setUp(): void {
+		$this->im_plugin = new WLPlugMediaImageMagick();
+		$this->im_plugin->register();
+	}
+
 	# -------------------------------------------------------
 	public function testConvertCmd() {
-		$im_plugin = new WLPlugMediaImageMagick();
-		$im_plugin->register();
-		$command = $im_plugin->command('convert');
-		$this->assertEquals('/usr/bin/convert', $command);
+		$command = $this->im_plugin->command( 'convert' );
+		$this->assertEquals( '/usr/bin/convert', $command );
 	}
 
 	public function testIdentifyCmd() {
-		$im_plugin = new WLPlugMediaImageMagick();
-		$im_plugin->register();
-		$command = $im_plugin->command('identify');
-		$this->assertEquals('/usr/bin/identify', $command);
+		$command = $this->im_plugin->command( 'identify' );
+		$this->assertEquals( '/usr/bin/identify', $command );
 	}
 
 	public function testWhateverCmd() {
-		$im_plugin = new WLPlugMediaImageMagick();
-		$im_plugin->register();
-		$command = $im_plugin->command('whatever');
-		$this->assertEquals('/usr/bin/whatever', $command);
+		$command = $this->im_plugin->command( 'whatever' );
+		$this->assertEquals( '/usr/bin/whatever', $command );
 	}
 
 	public function testMissingCmdWithEmptyArgs() {
-		$im_plugin = new WLPlugMediaImageMagick();
-		$im_plugin->register();
-		$command = $im_plugin->commandWithDefaultArgs('whatever');
-		$this->assertEquals('/usr/bin/whatever ', $command);
+		$command = $this->im_plugin->commandWithDefaultArgs( 'whatever' );
+		$this->assertEquals( '/usr/bin/whatever ', $command );
 	}
 
 	public function testConvertCmdWithDefaultArgs() {
-		$im_plugin = new WLPlugMediaImageMagick();
-		$im_plugin->register();
-		$command = $im_plugin->commandWithDefaultArgs('convert');
-		$this->assertEquals('/usr/bin/convert -limit thread 1', $command);
+		$command = $this->im_plugin->commandWithDefaultArgs( 'convert' );
+		$this->assertEquals( '/usr/bin/convert -limit thread 1', $command );
 	}
 
 }

--- a/tests/lib/Plugins/Media/ImageMagickTest.php
+++ b/tests/lib/Plugins/Media/ImageMagickTest.php
@@ -1,0 +1,75 @@
+<?php
+/** ---------------------------------------------------------------------
+ * tests/helpers/ImageMagickTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2016 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage tests
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ * @author Orestes Sanchez <orestes@estotienearreglo.es>
+ *
+ * ----------------------------------------------------------------------
+ */
+use PHPUnit\Framework\TestCase;
+
+require_once(__CA_APP_DIR__."/helpers/systemHelpers.php");
+require_once(__CA_APP_DIR__."/lib/Plugins/Media/ImageMagick.php");
+
+class ImageMagickTest extends TestCase {
+	# -------------------------------------------------------
+	public function testConvertCmd() {
+		$im_plugin = new WLPlugMediaImageMagick();
+		$im_plugin->register();
+		$command = $im_plugin->command('convert');
+		$this->assertEquals('/usr/bin/convert', $command);
+	}
+
+	public function testIdentifyCmd() {
+		$im_plugin = new WLPlugMediaImageMagick();
+		$im_plugin->register();
+		$command = $im_plugin->command('identify');
+		$this->assertEquals('/usr/bin/identify', $command);
+	}
+
+	public function testWhateverCmd() {
+		$im_plugin = new WLPlugMediaImageMagick();
+		$im_plugin->register();
+		$command = $im_plugin->command('whatever');
+		$this->assertEquals('/usr/bin/whatever', $command);
+	}
+
+	public function testMissingCmdWithEmptyArgs() {
+		$im_plugin = new WLPlugMediaImageMagick();
+		$im_plugin->register();
+		$command = $im_plugin->commandWithDefaultArgs('whatever');
+		$this->assertEquals('/usr/bin/whatever ', $command);
+	}
+
+	public function testConvertCmdWithDefaultArgs() {
+		$im_plugin = new WLPlugMediaImageMagick();
+		$im_plugin->register();
+		$command = $im_plugin->commandWithDefaultArgs('convert');
+		$this->assertEquals('/usr/bin/convert -limit thread 1', $command);
+	}
+
+}

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -5240,12 +5240,12 @@ a.dashboardRemoveWidget {
 
 .dashboardWidgetScrollMedium {
     height: 300px;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: auto;
 }
 .dashboardWidgetScrollLarge {
     height: 400px;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: auto;
 }
 .dashboardWidgetTable{
@@ -7583,7 +7583,16 @@ span.statisticsDashboardSelectedsite {
     font-weight: bold;
 }
 
+.dashboardWidgetContentContainer a.link {
+    text-decoration: underline;
+    color: #1ab3c8;
+
 a.currentSet {
-	font-weight: bold;
-	color: #333;
+    font-weight: bold;
+    color: #333;
+}
+
+.dashboardWidgetContentContainer a.link {
+    text-decoration: underline;
+    color: #1ab3c8;
 }

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -1208,6 +1208,12 @@ div.hint {
     font-size: 9px;
 }
 
+div.formLabelUploadSizeNote {
+	font-weight: normal;
+	font-size: 10px;
+	font-style: italic;
+}
+
 .bundleLabel {
 	position: relative;
 	

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -7576,3 +7576,8 @@ span.statisticsDashboardSelectedGroup {
 span.statisticsDashboardSelectedsite {
     font-weight: bold;
 }
+
+a.currentSet {
+	font-weight: bold;
+	color: #333;
+}

--- a/themes/default/css/wide.css
+++ b/themes/default/css/wide.css
@@ -1906,7 +1906,7 @@ div.browseCriterion {
 	border: 1px solid #999999; 
 	padding: 5px; 
 	height: 90px; 
-	overflow: hide;
+	overflow: hidden;
 }
 
 .browseCriterionLabel {
@@ -1981,7 +1981,7 @@ div.searchFormElementEditorAddGroupButton {
 	border-top: 1px dotted #aaaaaa;
 }
 
-/ * SEARCH FORMS */
+/* SEARCH FORMS */
 
 div.searchFormSelector {
 	float: right;

--- a/themes/default/views/batch/mediaimport/import_options_html.php
+++ b/themes/default/views/batch/mediaimport/import_options_html.php
@@ -459,13 +459,17 @@
 									<tr>
 										<td class='formLabel'>
 	<?php
-				print caHTMLCheckboxInput('create_relationship_for[]', array('value' => $vs_rel_table,  'id' => "caCreateRelationshipForMedia{$vs_rel_table}", 'onclick' => "jQuery('#caRelationshipTypeIdFor{$vs_rel_table}').prop('disabled', !jQuery('#caCreateRelationshipForMedia{$vs_rel_table}').prop('checked'))"), array('dontConvertAttributeQuotesToEntities' => true));
+				$checked = (is_array($va_last_settings['create_relationship_for']) && in_array($vs_rel_table, $va_last_settings['create_relationship_for'])) ? true : false;
+				$default_rel_type_id = isset($va_last_settings['relationship_type_id_for_'.$vs_rel_table]) ? $va_last_settings['relationship_type_id_for_'.$vs_rel_table] : null;
+				print caHTMLCheckboxInput('create_relationship_for[]', array('value' => $vs_rel_table,  'id' => "caCreateRelationshipForMedia{$vs_rel_table}", 'checked' => $checked, 'onclick' => "jQuery('#caRelationshipTypeIdFor{$vs_rel_table}').prop('disabled', !jQuery('#caCreateRelationshipForMedia{$vs_rel_table}').prop('checked'))"), ['dontConvertAttributeQuotesToEntities' => true]);
 				print ' '._t("to %1 with relationship type", $t_rel_table->getProperty('NAME_SINGULAR'));
 	?>
 										</td>
 										<td class='formLabel'>
 	<?php
-				print $t_rel->getRelationshipTypesAsHTMLSelect('ltor', null, null, array('name' => "relationship_type_id_for_{$vs_rel_table}", 'id' => "caRelationshipTypeIdFor{$vs_rel_table}", 'disabled' => 1));
+				$opts = ['name' => "relationship_type_id_for_{$vs_rel_table}", 'id' => "caRelationshipTypeIdFor{$vs_rel_table}"];
+				if(!$checked) { $opts['disabled'] = true; }
+				print $t_rel->getRelationshipTypesAsHTMLSelect('ltor', null, null, $opts, ['value' => $default_rel_type_id]);
 	?>
 										</td>
 									</tr>

--- a/themes/default/views/batch/metadataimport/importer_run_html.php
+++ b/themes/default/views/batch/metadataimport/importer_run_html.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2019 Whirl-i-Gig
+ * Copyright 2013-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -138,6 +138,30 @@ print $vs_control_box = caFormControlBox(
 		print caHTMLSelect('logLevel', caGetLogLevels(), array('id' => 'caLogLevel'), array('value' => $va_last_settings['logLevel']));
 ?>
 					</p>
+				</div>
+			</div>
+		</div>
+		<div class='bundleLabel'>
+			<span class="formLabelText"><?php print _t('Limit log to'); ?></span> 
+			<div class="bundleContainer">
+				<div class="caLabelList">
+					<table style="width: 600px; margin-left: 10px;">
+<?php
+		$c = 0;
+		$acc = [];
+		$limit_log_to_selected = caGetOption('limitLogTo', $va_last_settings, [], ['castTo' => 'array']);
+		foreach(['GENERAL' => _t('General information'), 'EXISTING_RECORD_POLICY' => _t('Existing record policy messages'), 'SKIP' => _t('Skip message'), 'RELATIONSHIPS' => _t('Relationship creation messages')] as $level => $name) {
+			$attr = ['value' => $level];
+			if(in_array($level, $limit_log_to_selected)) { $attr['checked'] = true; }
+			$acc[] = "<td class='formLabelPlain' style='padding: 5px'>".caHTMLCheckboxInput('limitLogTo[]', $attr, [])." {$name}</td>";
+			$c++;
+			if (($c % 2) == 0) {
+				print "<tr>".join("", $acc)."</tr>\n";
+				$acc = [];
+			}
+		}
+?>
+					</table>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Define a configuration item in `external_applications.conf`, like this: `imagemagick_<COMMAND_NAME>_args` per command.

For example, for `convert` command, use 

```
imagemagick_convert_args = -limit thread 1
```

As of now it only allows arguments on the ImageMagick media class. It is pending a refactor of TilePicParser class to use this feature.

With a bit of refactor, new class `CommandConfiguration` can be promoted to `BaseMediaPlugin` class, and the feature will be available to subclasses.