### PR TITLE
FIX Remove duplicate for `lifespan` intrinsci attribute.

### DIFF
--- a/install/profiles/xml/default.xml
+++ b/install/profiles/xml/default.xml
@@ -2524,29 +2524,6 @@
         </restriction>
       </typeRestrictions>
     </metadataElement>
-    <metadataElement code="lifespan" datatype="DateRange">
-      <labels>
-        <label locale="en_US">
-          <name>Life dates</name>
-        </label>
-        <label locale="fr_FR">
-          <name>Dates</name>
-        </label>
-      </labels>
-      <settings>
-        <setting name="fieldWidth">40</setting>
-        <setting name="fieldHeight">1</setting>
-      </settings>
-      <typeRestrictions>
-        <restriction code="r1">
-          <table>ca_entities</table>
-          <settings>
-            <setting name="minAttributesPerRow">1</setting>
-            <setting name="maxAttributesPerRow">1</setting>
-          </settings>
-        </restriction>
-      </typeRestrictions>
-    </metadataElement>
     <metadataElement code="address" datatype="Container">
       <labels>
         <label locale="en_US">


### PR DESCRIPTION
There is an intrinsic attribute `ca_entities.lifespan` as per https://github.com/collectiveaccess/providence/blob/9f4a96639f80da0e31e9acc9b76bb8935f8c36b6/app/models/ca_entities.php#L109-L117

And there is an additional `lifespan` metadata attribute on `default.xml` profile. 

This PR removes the second one.