### PR TITLE
Force loading a clean setup from the dist file.

### DIFF
--- a/tests/setup-tests.php
+++ b/tests/setup-tests.php
@@ -38,4 +38,4 @@ if (!defined('__CA_CACHE_BACKEND__')) {
 }
 
 // Use remaining settings from main config.
-require_once(__CA_BASE_DIR__ . '/setup.php');
+require_once(__CA_BASE_DIR__ . '/setup.php-dist');


### PR DESCRIPTION
Bootstraping file for tests at `setup-tests.php` loads `setup.php` file.

In case you are developing locally, it will use your local configuration too, so tests might break, for instance, if you setup a timezone in Europe, or any other local configuration.

A workaround is already in place in `.travis.setup.php` file: it loads vanilla setup from `setup.php-dist`.

Related to #400.