### PR TITLE
Mark tests as incomplete when web service lookup fails.

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -42,6 +42,8 @@ require_once(__CA_LIB_DIR__.'/Utils/Encoding.php');
 require_once(__CA_LIB_DIR__.'/Zend/Measure/Length.php');
 require_once(__CA_LIB_DIR__.'/Parsers/ganon.php');
 use GuzzleHttp\Client;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\SelfDescribing;
 
 # ----------------------------------------------------------------------
 # String localization functions (getText)
@@ -2925,6 +2927,16 @@ function caFileIsIncludable($ps_file) {
 	 * @return string
 	 * @throws \Exception
  	 */
+	class WebServiceError extends Exception
+	{
+		/**
+		 * Wrapper for getMessage() which is declared as final.
+		 */
+		public function toString(): string
+		{
+			return $this->getMessage();
+		}
+	}
 	function caQueryExternalWebservice($ps_url) {
 		if(!isURL($ps_url)) { return false; }
 		$o_conf = Configuration::load();
@@ -2949,9 +2961,8 @@ function caFileIsIncludable($ps_file) {
 		$vs_content = curl_exec($vo_curl);
 
 		if(curl_getinfo($vo_curl, CURLINFO_HTTP_CODE) !== 200) {
-			throw new \Exception(_t('An error occurred while querying an external webservice'));
+			throw new WebServiceError(_t('An error occurred while querying an external webservice'). _t(" at %1", $ps_url). " ". print_r(curl_getinfo($vo_curl), true));
 		}
-
 		curl_close($vo_curl);
 		return $vs_content;
 	}

--- a/tests/lib/AttributeValues/LCSHQueryTest.php
+++ b/tests/lib/AttributeValues/LCSHQueryTest.php
@@ -39,7 +39,11 @@ class LCSHQueryTest extends TestCase {
 		$vs_voc_query = '&q='.rawurlencode('cs:http://id.loc.gov/authorities/subjects');
 		$vs_url = 'http://id.loc.gov/search/?q='.urlencode('"bowl"').$vs_voc_query.'&format=atom&count=150';
 
-		$vs_data = caQueryExternalWebservice($vs_url);
+		try {
+			$vs_data = caQueryExternalWebservice($vs_url);
+		} catch ( WebServiceError $e ) {
+			$this->markTestIncomplete($e->getMessage());
+		}
 		$this->assertIsString($vs_data);
 		$this->assertGreaterThan(0, strlen($vs_data));
 

--- a/tests/lib/AttributeValues/WikipediaInformationServiceAttributeValueTest.php
+++ b/tests/lib/AttributeValues/WikipediaInformationServiceAttributeValueTest.php
@@ -29,7 +29,9 @@
  * 
  * ----------------------------------------------------------------------
  */
- use PHPUnit\Framework\TestCase;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 
 require_once(__CA_LIB_DIR__."/Plugins/InformationService/Wikipedia.php");
 require_once(__CA_MODELS_DIR__."/ca_objects.php");
@@ -38,7 +40,11 @@ class WikipediaInformationServiceAttributeValueTest extends TestCase {
 
 	public function testLookup() {
 		$o_service = new WLPlugInformationServiceWikipedia();
-		$va_return = $o_service->lookup(array(), 'Aaron Burr');
+		try {
+			$va_return = $o_service->lookup( array(), 'Aaron Burr' );
+		} catch ( WebServiceError $e ) {
+			$this->markTestIncomplete($e->getMessage());
+		}
 
 		$this->assertIsArray($va_return);
 		$this->assertArrayHasKey('results', $va_return);
@@ -48,13 +54,21 @@ class WikipediaInformationServiceAttributeValueTest extends TestCase {
 
 	public function testNonExistentLookup() {
 		$o_service = new WLPlugInformationServiceWikipedia();
-		$va_return = $o_service->lookup(array(), 'sdkfljsdlkfjsdlkjhfljksdfhjsljkd');
+		try{
+			$va_return = $o_service->lookup(array(), 'sdkfljsdlkfjsdlkjhfljksdfhjsljkd');
+		} catch ( WebServiceError $e ) {
+			$this->markTestIncomplete($e->getMessage());
+		}
 		$this->assertEmpty($va_return);
 	}
 
 	public function testGermanLookup() {
 		$o_service = new WLPlugInformationServiceWikipedia();
-		$va_return = $o_service->lookup(array('lang' => 'de'), 'John von Neumann');
+		try {
+			$va_return = $o_service->lookup(array('lang' => 'de'), 'John von Neumann');
+		} catch ( WebServiceError $e ) {
+			$this->markTestIncomplete($e->getMessage());
+		}
 
 		$this->assertIsArray($va_return);
 		$this->assertArrayHasKey('results', $va_return);
@@ -64,7 +78,11 @@ class WikipediaInformationServiceAttributeValueTest extends TestCase {
 
 	public function testGetExtraInfo() {
 		$o_service = new WLPlugInformationServiceWikipedia();
-		$vm_ret = $o_service->getExtraInfo(array(), 'http://en.wikipedia.org/wiki/Aaron_Burr');
+		try {
+			$vm_ret = $o_service->getExtraInfo(array(), 'http://en.wikipedia.org/wiki/Aaron_Burr');
+		} catch ( WebServiceError $e ) {
+			$this->markTestIncomplete($e->getMessage());
+		}
 
 		$this->assertIsArray($vm_ret);
 		$this->assertArrayHasKey('fullurl', $vm_ret);


### PR DESCRIPTION
Related to #400.

A Web service is an external dependency. In case it fails I suggest marking the test as incomplete.