### PR TITLE
Allow additional arguments for ImageMagick external applications

### DIFF
--- a/app/conf/external_applications.conf
+++ b/app/conf/external_applications.conf
@@ -13,6 +13,16 @@ dcraw_app = /usr/bin/dcraw
 # Path to directory containing ImageMagick binaries (http://www.imagemagick.org)
 imagemagick_path = /usr/bin
 
+# -----------------------------------
+# Defaults for ImageMagick commands
+# -----------------------------------
+#
+# Define a configuration item `imagemagick_<COMMAND_NAME>_args` per command.
+# For example, for `convert` command, use `imagemagick_convert_args`.
+#
+#imagemagick_convert_args =-limit thread 1
+
+
 # Path to GraphicsMagick binary (http://www.graphicsmagick.org)
 graphicsmagick_app = /usr/bin/gm
 

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -45,7 +45,78 @@ include_once(__CA_LIB_DIR__."/Configuration.php");
 include_once(__CA_APP_DIR__."/helpers/mediaPluginHelpers.php");
 include_once(__CA_LIB_DIR__."/Parsers/MediaMetadata/XMPParser.php");
 
+/**
+ * Trait CommandConfiguration
+ *
+ * Manage the command configuration, application and default args.
+ *
+ * TODO: Refactor to be included in BaseMediaPlugin so it is available in all media classes.
+ */
+trait CommandConfiguration {
+
+	static private $opo_external_app_config_static = null;
+	private $ops_base_path = null;
+	private $ops_command_name = null;
+
+	/**
+	 * Initialize
+	 *
+	 * @param $ps_command_name Set application name. Used for getting settings from configuration file.
+	 * @param $ps_basepath_setting Name of the setting to the base path
+	 */
+	public function initCommandConfiguration( $ps_command_name, $ps_basepath_setting ) {
+		$this->ops_command_name = $ps_command_name;
+		if ( self::$opo_external_app_config_static == null ) {
+			self::$opo_external_app_config_static = Configuration::load( __CA_CONF_DIR__ . "/external_applications.conf" );
+		}
+		$this->ops_base_path = self::$opo_external_app_config_static->get( $ps_basepath_setting );
+	}
+
+	/**
+	 * Load command default arguments from configuration
+	 *
+	 * @param $command
+	 * @param $default
+	 *
+	 * @return string
+	 */
+	public function getCommandDefaultArgs( $command, $default ) {
+		$command = trim( $command );
+
+		return self::$opo_external_app_config_static->get( $this->ops_command_name . "_${command}_args", $default );
+	}
+
+	/**
+	 * Return absolute path to command and default arguments
+	 *
+	 * @param      $command
+	 * @param null $default_args
+	 *
+	 * @return string
+	 */
+	public function commandWithDefaultArgs( $command, $default_args = null ) {
+		return $this->command( $command ) . " " . $this->getCommandDefaultArgs( $command, $default_args );
+	}
+
+	/**
+	 * Return absolute path to command
+	 *
+	 * @param $command
+	 *
+	 * @return string
+	 */
+	public function command( $command ) {
+		$command = trim( $command );
+
+		return "{$this->ops_base_path}/$command";
+	}
+
+}
+
 class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
+
+	use CommandConfiguration;
+
 	var $errors = array();
 	
 	var $filepath;
@@ -55,10 +126,8 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	var $metadata = array();
 	
 	var $opo_config;
-	var $opo_external_app_config;
 	var $ops_imagemagick_path;
-	var $ops_graphicsmagick_path;
-	
+
 	var $info = array(
 		"IMPORT" => array(
 			"image/jpeg" 		=> "jpg",
@@ -225,6 +294,8 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	# ------------------------------------------------
 	public function __construct() {
 		$this->description = _t('Provides image processing and conversion services using ImageMagick via exec() calls to ImageMagick binaries');
+		$this->init();
+		$this->initCommandConfiguration('imagemagick', 'imagemagick_path');
 	}
 	# ------------------------------------------------
 	# Tell WebLib what kinds of media this plug-in supports
@@ -233,9 +304,8 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		// get config for external apps
 		$this->opo_config = Configuration::load();
 		$this->opo_external_app_config = Configuration::load(__CA_CONF_DIR__."/external_applications.conf");
-		$this->ops_imagemagick_path = $this->opo_external_app_config->get('imagemagick_path');
-		$this->ops_graphicsmagick_path = $this->opo_external_app_config->get('graphicsmagick_app');
-		
+		$this->ops_imagemagick_path = $this->ops_base_path;
+
 		if (caMediaPluginImagickInstalled()) {	
 			return null;	// don't use if Imagick is available
 		} 
@@ -244,7 +314,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			return null;	// don't use if Gmagick is available
 		}
 		
-		if (caMediaPluginGraphicsMagickInstalled($this->ops_graphicsmagick_path)){
+		if (caMediaPluginGraphicsMagickInstalled()){
 			return null;	// don't use if GraphicsMagick is available
 		}
 		
@@ -261,7 +331,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		if ($this->register()) {
 			$va_status['available'] = true;
 		} else {
-			if (caMediaPluginGraphicsMagickInstalled($this->ops_graphicsmagick_path)) {
+			if (caMediaPluginGraphicsMagickInstalled()) {
 				$va_status['unused'] = true;
 				$va_status['warnings'][] = _t("Didn't load because GraphicsMagick is available and preferred");
 			}
@@ -291,7 +361,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			$this->postError(1610, _t("Filenames with colons (:) are not allowed"), "WLPlugImageMagick->divineFileFormat()");
 			return false;
 		}
-			
+
 		# is it a tilepic?
 		$tp = new TilepicParser();
 		if ($tp->isTilepic($filepath)) {
@@ -882,15 +952,23 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		}
 
 		$va_output = array();
-		caExec($this->ops_imagemagick_path.'/identify -format "%m\n" '.caEscapeShellArg($this->filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
-		
+		caExec( join( ' ', array(
+			$this->commandWithDefaultArgs( 'identify' ),
+			'-format "%m\n"',
+			caEscapeShellArg( $this->filepath ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+		) ), $va_output, $vn_return );
+
 		// don't extract previews from "normal" images (the output line count is always # of files + 1)
 		if(sizeof($va_output)<=2) { return false; } 
 
 		$vs_output_file_prefix = tempnam($vs_tmp_dir, 'caMultipagePreview');
 		$vs_output_file = $vs_output_file_prefix.'_%05d.jpg';
 
-		caExec($this->ops_imagemagick_path.'/convert '.caEscapeShellArg($this->filepath)." ".$vs_output_file.(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+		caExec( join( ' ', array(
+			$this->commandWithDefaultArgs( 'convert' ),
+			caEscapeShellArg( $this->filepath ),
+			$vs_output_file . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+		) ), $va_output, $vn_return );
 
 		$vn_i = 0;
 		$va_files = array();
@@ -922,9 +1000,13 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			}
 		}
 
-		if(sizeof($va_acceptable_files)){
-			caExec($this->ops_imagemagick_path."/convert ".join(" ",$va_acceptable_files)." ".$vs_archive_original.(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
-			if($vn_return === 0){
+		if ( sizeof( $va_acceptable_files ) ) {
+			caExec( join( ' ', array(
+				$this->commandWithDefaultArgs( 'convert' ),
+				join( ' ', $va_acceptable_files ),
+				$vs_archive_original . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+			) ), $va_output, $vn_return );
+			if ( $vn_return === 0 ) {
 				return $vs_archive_original;
 			}
 		}
@@ -1011,11 +1093,17 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	# ------------------------------------------------
 	# Command line wrappers
 	# ------------------------------------------------
-	private function _imageMagickIdentify($ps_filepath) {
-		if (caMediaPluginImageMagickInstalled($this->ops_imagemagick_path)) {
-			caExec($this->ops_imagemagick_path.'/identify -format "%m" '.caEscapeShellArg($ps_filepath.'[0]').(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
-			return $this->magickToMimeType($va_output[0]);
+	private function _imageMagickIdentify( $ps_filepath ) {
+		if ( caMediaPluginImageMagickInstalled( $this->ops_imagemagick_path ) ) {
+			caExec( join( ' ', array(
+				$this->commandWithDefaultArgs( 'identify' ),
+				'-format "%m"',
+				caEscapeShellArg( $ps_filepath . '[0]' ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+			) ), $va_output, $vn_return );
+
+			return $this->magickToMimeType( $va_output[0] );
 		}
+
 		return null;
 	}
 	# ------------------------------------------------
@@ -1040,15 +1128,23 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					$va_metadata['XMP'] = $va_xmp_metadata;
 				}
 			}
-			
-			caExec($this->ops_imagemagick_path."/identify -format '%[DPX:*]' ".caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+
+			caExec( join( ' ', array(
+				$this->commandWithDefaultArgs( 'identify' ),
+				"-format '%[DPX:*]'",
+				caEscapeShellArg( $ps_filepath ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+			) ), $va_output, $vn_return );
 			if ($va_output[0]) { $va_metadata['DPX'] = $va_output; }
 			
 			/* IPTC metadata */
 			$vs_iptc_file = tempnam(caGetTempDirPath(), 'imiptc');
 			@rename($vs_iptc_file, $vs_iptc_file.'.iptc'); // IM uses the file extension to figure out what we want
 			$vs_iptc_file .= '.iptc';
-			caExec($this->ops_imagemagick_path."/convert ".caEscapeShellArg($ps_filepath)." ".caEscapeShellArg($vs_iptc_file).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+			caExec( join( ' ', array(
+				$this->commandWithDefaultArgs( 'convert' ),
+				caEscapeShellArg( $ps_filepath ),
+				caEscapeShellArg( $vs_iptc_file ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+			) ), $va_output, $vn_return );
 
 			$vs_iptc_data = file_get_contents($vs_iptc_file);
 			@unlink($vs_iptc_file);
@@ -1103,9 +1199,13 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	# ------------------------------------------------
 	private function _imageMagickRead($ps_filepath, $options=null) {
 		if (caMediaPluginImageMagickInstalled($this->ops_imagemagick_path)) {
-		
-			caExec($this->ops_imagemagick_path.'/identify -format "%m;%w;%h;%[colorspace];%[depth];%[xresolution];%[yresolution]\n" '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
-			
+
+			caExec( join( ' ', array(
+				$this->commandWithDefaultArgs( 'identify' ),
+				'-format "%m;%w;%h;%[colorspace];%[depth];%[xresolution];%[yresolution]\n" ',
+				caEscapeShellArg( $ps_filepath ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+			) ), $va_output, $vn_return );
+
 			$va_tmp = explode(';', $va_output[0]);
 			
 			if (sizeof($va_tmp) != 7) {
@@ -1264,11 +1364,21 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					array_unshift($va_ops['convert'], '-quality '.intval($pn_quality));
 				}
 				array_unshift($va_ops['convert'], '-colorspace RGB');
-				caExec($this->ops_imagemagick_path.'/convert '.caEscapeShellArg($vs_input_file.'[0]').' '.join(' ', $va_ops['convert']).' '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""));
+				caExec( join( ' ', array(
+					$this->commandWithDefaultArgs( 'convert' ),
+					caEscapeShellArg( $vs_input_file . '[0]' ),
+					join( ' ', $va_ops['convert'] ),
+					caEscapeShellArg( $ps_filepath ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+				) ) );
 				$vs_input_file = $ps_filepath;
 			}
 			if (is_array($va_ops['composite']) && sizeof($va_ops['composite'])) {
-				caExec($this->ops_imagemagick_path.'/composite '.join(' ', $va_ops['composite']).' '.caEscapeShellArg($vs_input_file.'[0]').' '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""));
+				caExec( join( ' ', array(
+					$this->commandWithDefaultArgs( 'composite' ),
+					join( ' ', $va_ops['composite'] ),
+					caEscapeShellArg( $vs_input_file . '[0]' ),
+					caEscapeShellArg( $ps_filepath ) . ( caIsPOSIX() ? ' 2> /dev/null' : '' )
+				) ) );
 			}	
 			
 			return true;

--- a/tests/conf/external_applications.conf
+++ b/tests/conf/external_applications.conf
@@ -1,0 +1,12 @@
+# Path to directory containing ImageMagick binaries (http://www.imagemagick.org)
+imagemagick_path = /usr/bin
+
+# -----------------------------------
+# Defaults for ImageMagick commands
+# -----------------------------------
+#
+# Define a configuration item `imagemagick_<COMMAND_NAME>_args` per command.
+# For example, for `convert` command, use `imagemagick_convert_args`.
+#
+imagemagick_convert_args =-limit thread 1
+imagemagick_whatever_args =

--- a/tests/lib/Plugins/Media/ImageMagickTest.php
+++ b/tests/lib/Plugins/Media/ImageMagickTest.php
@@ -1,0 +1,94 @@
+<?php
+/** ---------------------------------------------------------------------
+ * tests/helpers/ImageMagickTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2016 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package    CollectiveAccess
+ * @subpackage tests
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ * @author     Orestes Sanchez <orestes@estotienearreglo.es>
+ *
+ * ----------------------------------------------------------------------
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once( __CA_APP_DIR__ . "/helpers/systemHelpers.php" );
+require_once( __CA_APP_DIR__ . "/lib/Plugins/Media/ImageMagick.php" );
+
+/**
+ * Class ImageMagickTest
+ *
+ * Allow testing imagemagick media plugin.
+ * See configuration on tests/conf.
+ *
+ */
+class ImageMagickTest extends TestCase {
+
+	protected $im_plugin = null;
+	protected $prophet = null;
+
+	protected function setUp(): void {
+		$this->im_plugin = new WLPlugMediaImageMagick();
+		$this->im_plugin->register();
+	}
+
+	# -------------------------------------------------------
+	public function testConvertCmd() {
+		$command = $this->im_plugin->command( 'convert' );
+		$this->assertEquals( '/usr/bin/convert', $command );
+	}
+
+	public function testIdentifyCmd() {
+		$command = $this->im_plugin->command( 'identify' );
+		$this->assertEquals( '/usr/bin/identify', $command );
+	}
+
+	public function testWhateverCmd() {
+		$command = $this->im_plugin->command( 'whatever' );
+		$this->assertEquals( '/usr/bin/whatever', $command );
+	}
+
+	public function testMissingCmdWithEmptyArgs() {
+		$command = $this->im_plugin->commandWithDefaultArgs( 'whatever' );
+		$this->assertEquals( '/usr/bin/whatever ', $command );
+	}
+
+	public function testConvertCmdWithDefaultArgs() {
+		$command = $this->im_plugin->commandWithDefaultArgs( 'convert' );
+		$this->assertEquals( '/usr/bin/convert -limit thread 1', $command );
+	}
+
+	/**
+	 * First attempt for unit testing and mocks.
+	 */
+	public function testCheckStatus() {
+		$imagemagick_plugin = $this->getMockBuilder( WLPlugMediaImageMagick::class )->onlyMethods( [ 'register' ] )
+		                           ->getMock();
+		$imagemagick_plugin->method( 'register' )->willReturn( array( 'info' => 1 ) );
+		$status = $imagemagick_plugin->checkStatus();
+
+		$this->assertIsArray( $status );
+		$this->assertTrue( $status['available'] );
+	}
+}


### PR DESCRIPTION
Second attempt for this PR, previous one included a mix of commits not related to it.

Define a configuration item in `external_applications.conf`, like this: `imagemagick_<COMMAND_NAME>_args` per command.

For example, for `convert` command, use 

```
imagemagick_convert_args = -limit thread 1
```

As of now it only allows arguments on the ImageMagick media class. It is pending a refactor of TilePicParser class to use this feature.

With a bit of refactor, new class `CommandConfiguration` can be promoted to `BaseMediaPlugin` class, and the feature will be available to subclasses.