### PR TITLE
Improve coverage of tests for import helpers.

### DIFF
--- a/app/helpers/mediaPluginHelpers.php
+++ b/app/helpers/mediaPluginHelpers.php
@@ -45,9 +45,9 @@
 	 * @return string Path to application as defined in external_applications.conf
 	 */
 	function caGetExternalApplicationPath($ps_application_name) {
-		$o_config = Configuration::load();
-		if (!($o_ext_app_config = Configuration::load(__CA_CONF_DIR__.'/external_applications.conf'))) { return null; }
-
+        if (!($o_ext_app_config = Configuration::load(__CA_CONF_DIR__ . '/external_applications.conf'))) {
+            return null;
+        }
 		return $o_ext_app_config->get($ps_application_name.'_app');
 	}
 	# ------------------------------------------------------------------------------------------------

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -643,6 +643,32 @@ function caFileIsIncludable($ps_file) {
 	}
 	# ----------------------------------------
 	/**
+	 * Return text suitable for a regexp with escaped delimiter
+	 *
+	 * @param string $ps_text
+	 * @return string
+	 */
+	function caEscapeForDelimitedRegexp($ps_text, $ps_delimiter='!') {
+	    $vs_regex_delimiter = $ps_delimiter != '#' ? '#': '/';
+		return preg_replace($vs_regex_delimiter.'(?<!\\\\)'.$ps_delimiter.$vs_regex_delimiter, '\\'.$ps_delimiter, $ps_text);
+	}
+	# ----------------------------------------
+	/**
+	 * Return regexp delimited making sure delimiter is escaped on the regexp.
+	 *
+	 * @param string $ps_text
+	 * @return string
+	 */
+	function caMakeDelimitedRegexp($ps_text, $ps_delimiter='!') {
+        if ($ps_delimiter=='#') {
+            $vs_regex_delimiter = '/';
+        } else {
+            $vs_regex_delimiter = '#';
+        }
+		return $ps_delimiter.preg_replace($vs_regex_delimiter.'(?<!\\\\)'.$ps_delimiter.$vs_regex_delimiter, '\\'.$ps_delimiter, $ps_text).$ps_delimiter;
+	}
+	# ----------------------------------------
+	/**
 	 * 
 	 *
 	 * @param array $options Options include:

--- a/app/refineries/EADCollectionHierarchyBuilder/EADCollectionHierarchyBuilderRefinery.php
+++ b/app/refineries/EADCollectionHierarchyBuilder/EADCollectionHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2018 Whirl-i-Gig
+ * Copyright 2018-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -247,7 +247,7 @@
 						    
 						    $items[] = $item;
 						}
-						$rel_data = caProcessRefineryRelated($rel['relatedTable'], $items, $refinery_data['source_data'], $refinery_data['item'], 0, array_merge($refinery_data['options'], ['reader' => $reader]));
+						$rel_data = caProcessRefineryRelated($this, $rel['relatedTable'], $items, $refinery_data['source_data'], $refinery_data['item'], 0, array_merge($refinery_data['options'], ['reader' => $reader]));
 
 				        foreach($rel_data as $k1 => $v1) {
 				            foreach($v1 as $k2 => $v2) {

--- a/app/refineries/collectionIndentedHierarchyBuilder/collectionIndentedHierarchyBuilderRefinery.php
+++ b/app/refineries/collectionIndentedHierarchyBuilder/collectionIndentedHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2019 Whirl-i-Gig
+ * Copyright 2019-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -141,7 +141,6 @@
 						}
 						
 						if(is_array($va_relationships)) {
-							//$rel_data = caProcessRefineryRelated('ca_collections', $va_relationships, $pa_source_data, $pa_item, 0, []);
 							$rels = [];
 							caProcessRefineryRelatedMultiple($this, $pa_item, $pa_source_data, null, $o_log, $o_reader, $rels, $attr_values, []);
 				

--- a/tests/conf/external_applications.conf
+++ b/tests/conf/external_applications.conf
@@ -1,6 +1,8 @@
 # Path to directory containing ImageMagick binaries (http://www.imagemagick.org)
 imagemagick_path = /usr/bin
 
+ghostscript_app=/usr/bin/gs
+
 # -----------------------------------
 # Defaults for ImageMagick commands
 # -----------------------------------

--- a/tests/helpers/ImportHelpersTest.php
+++ b/tests/helpers/ImportHelpersTest.php
@@ -15,73 +15,507 @@
  * the terms of the provided license as published by Whirl-i-Gig
  *
  * CollectiveAccess is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * This source code is free and modifiable under the terms of 
+ * This source code is free and modifiable under the terms of
  * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
  * the "license.txt" file for details, or visit the CollectiveAccess web site at
  * http://www.CollectiveAccess.org
- * 
- * @package CollectiveAccess
+ *
+ * @package    CollectiveAccess
  * @subpackage tests
- * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
- * 
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
  * ----------------------------------------------------------------------
  */
+
 use PHPUnit\Framework\TestCase;
 
-require_once(__CA_APP_DIR__."/helpers/importHelpers.php");
+require_once(__CA_APP_DIR__ . "/helpers/importHelpers.php");
 
 class ImportHelpersTest extends TestCase {
-	# -------------------------------------------------------
-	public function testAATMatch() {
-		// some real-world examples
-		$vm_ret = caMatchAAT(
-			explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression: visual arts:abstraction')
-		);
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300056508', $vm_ret);
+    protected $data;
+    protected $item;
+    protected $attributes;
+    protected $parents;
+    protected $groups;
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings')
-		);
+    static $opa_valid_tables = array('ca_objects', 'ca_entities', 'ca_occurrences', 'ca_movements', 'ca_loans', 'ca_object_lots', 'ca_storage_locations', 'ca_places', 'ca_item_comments');
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300041365', $vm_ret);
+    protected function setUp(): void {
+        $this->data = [
+                1 => "Verdun",
+                2 => ['Cambrai', 'Arras'],
+                3 => 'Chateau Thierry',
+                4 => 'Somme',
+                5 => 'Popperinge',
+                6 => 'Ypres;Somme;Cambrai;Ypres;Popperinge',
+                7 => ['Antwerp', 'Dieppe|Charleois|Paschendale', 'Bruges']
+        ];
+        $this->item = [
+                'settings' => [
+                        'original_values' => [
+                                'sector_ypres', 'sector_somme', 'sector_cambrai'
+                        ],
+                        'replacement_values' => [
+                                'Value_Ypres', 'Value_Somme', 'Value_Cambrai'
+                        ]
+                ]
+        ];
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper')
-		);
+        $this->attributes = array(
+                'movement_reason' => "^1",
+                'preferred_label' => ["^3"],
+                'nonpreferred_label' => array("name" => "^5")
+        );
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300189621', $vm_ret);
+        $this->parents = array(
+                array('idno' => '^1',
+                        'name' => '^3',
+                        'attributes' => array(
+                                'description' => '^5'
+                        )
+                )
+        );
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract'),
-			180, array('removeParensFromLabels' => true)
-		);
+        $this->groups = array();
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300108127', $vm_ret);
+    }
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art'),
-			180, array('removeParensFromLabels' => true)
-		);
+    /**
+     * Delete all records we created for this test to avoid side effects with other tests
+     */
+    protected function tearDown() : void {
+        if($this->opb_care_about_side_effects) {
+            foreach($this->opa_record_map as $vs_table => &$va_records) {
+                $t_instance = Datamodel::getInstance($vs_table);
+                // delete in reverse order so that we can properly
+                // catch potential hierarchical relationships
+                rsort($va_records);
+                foreach($va_records as $vn_id) {
+                    if($t_instance->load($vn_id)) {
+                        $t_instance->setMode(ACCESS_WRITE);
+                        $t_instance->delete(true, array('hard' => true));
+                    }
+                }
+            }
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300069478', $vm_ret);
+            // check record counts again (make sure there are no lingering records)
+            $this->checkRecordCounts();
+        }
+    }
+    # -------------------------------------------------------
+    private function checkRecordCounts() {
+        // ensure there are no lingering records
+        $o_db = new Db();
+        foreach(self::$opa_valid_tables as $vs_table) {
+            $qr_rows = $o_db->query("SELECT count(*) AS c FROM {$vs_table}");
+            $qr_rows->nextRow();
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)'),
-			180, array('removeParensFromLabels' => true)
-		);
+            // these two are allowed to have hierarchy roots
+            if(in_array($vs_table, array('ca_storage_locations', 'ca_places'))) {
+                $vn_allowed_records = 1;
+            } else {
+                $vn_allowed_records = 0;
+            }
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300182574', $vm_ret);
+            $this->assertEquals($vn_allowed_records, $qr_rows->get('c'), "Table {$vs_table} should be empty to avoid side effects between tests");
+        }
+    }
 
-		$vm_ret = caMatchAAT(
-			explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)'),
-			180, array('removeParensFromLabels' => true)
-		);
+    protected function _runGenericImportSplitter($ps_refinery_name, $ps_table, $ps_type) {
 
-		$this->assertEquals('http://vocab.getty.edu/aat/300054216', $vm_ret);
-	}
-	# -------------------------------------------------------
+        global $g_ui_locale_id;
+        $g_ui_locale_id = 1;
+        $ps_item_prefix = "";
+        $ps_refinery_class = $this->_loadRefinery($ps_refinery_name);
+        $po_refinery_instance = $this->_createRefineryMock($ps_refinery_class);
+        $pa_destination_data = array();
+        $pa_group = $this->groups;
+        $pa_item = $this->item;
+        $pa_source_data = $this->data;
+        $pa_options = array();
+        $result = caGenericImportSplitter($ps_refinery_name, $ps_item_prefix, $ps_table,
+                $po_refinery_instance, $pa_destination_data, $pa_group, $pa_item, $pa_source_data, $pa_options);
+
+        return $result;
+    }
+
+    /**
+     * @param $refinery_name
+     *
+     * @return string
+     */
+    protected function _loadRefinery($refinery_name): string {
+        $refinery_class = $refinery_name . 'Refinery';
+        require_once(join(DIRECTORY_SEPARATOR, [__CA_APP_DIR__, 'refineries', $refinery_name, $refinery_class . '.php']));
+        return $refinery_class;
+    }
+
+    protected function _createRefineryMock($ps_name) {
+        $stubRefinery = $this->createMock($ps_name);
+        $stubRefinery->method('getName')->willReturn($ps_name);
+        $stubRefinery->method('setReturnsMultipleValues');
+        return $stubRefinery;
+    }
+
+    protected function _runProcessRefineryParents($refinery_name, $ps_table_name, $ps_type) {
+        global $g_ui_locale_id;
+        $g_ui_locale_id = 1;
+        $refinery_class = $this->_loadRefinery($refinery_name);
+
+        $stubRefinery = $this->_createRefineryMock($refinery_class);
+        $ps_refinery_name = $refinery_name;
+        $ps_table = $ps_table_name;
+        $pa_parents = $this->parents;
+        $pa_parents[0]['type'] = $ps_type;
+        $pa_source_data = $this->data;
+        $pa_item = $this->item;
+        $pn_c = 0;
+        $pa_options = array(
+                'refinery' => $stubRefinery,
+        );
+        $result = caProcessRefineryParents($ps_refinery_name, $ps_table, $pa_parents, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        return $result;
+    }
+
+
+    # -------------------------------------------------------
+    public function testAATMatchPeople() {
+        // some real-world examples
+        $vm_ret = caMatchAAT(
+                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression: visual arts:abstraction')
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300056508', $vm_ret);
+    }
+
+    public function testAATMatchPrints() {
+        // some real-world examples
+        $vm_ret = caMatchAAT(
+                explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings')
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300041365', $vm_ret);
+    }
+
+    public function testAATMatchPaper() {
+        // some real-world examples
+        $vm_ret = caMatchAAT(
+                explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper')
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300189621', $vm_ret);
+    }
+
+    public function testAATMatchAbstractArt() {
+        // some real-world examples
+
+        $vm_ret = caMatchAAT(
+                explode(':', 'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract'),
+                180, array('removeParensFromLabels' => true)
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300108127', $vm_ret);
+    }
+
+    public function testAATMatchComputerArt() {
+        // some real-world examples
+
+        $vm_ret = caMatchAAT(
+                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art'),
+                180, array('removeParensFromLabels' => true)
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300069478', $vm_ret);
+    }
+
+    public function testAATMatchAcrylicPainting() {
+        // some real-world examples
+
+        $vm_ret = caMatchAAT(
+                explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)'),
+                180, array('removeParensFromLabels' => true)
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300182574', $vm_ret);
+    }
+
+    public function testAATMatchPainting() {
+        // some real-world examples
+
+        $vm_ret = caMatchAAT(
+                explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)'),
+                180, array('removeParensFromLabels' => true)
+        );
+
+        $this->assertEquals('http://vocab.getty.edu/aat/300054216', $vm_ret);
+    }
+    # -------------------------------------------------------
+
+
+    /**
+     *
+     *
+     */
+    public function testCaProcessImportItemSettingsForValue() {
+        $ps_value = '7.30.pepe';
+        $pa_item_settings = array(
+                'applyRegularExpressions' => array(
+                        array("match" => '([0-9]+)\\.([0-9]+)',
+                                "replaceWith" => "\\1:\\2"),
+                        array(
+                                "match" => "[^0-9:]+",
+                                "replaceWith" => ""
+                        )
+                )
+        );
+
+        $result = caProcessImportItemSettingsForValue($ps_value, $pa_item_settings);
+        $this->assertSame('7:30', $result);
+    }
+
+    public function testCaProcessImportItemSettingsForArrayValue() {
+        $va_value = ['7.30.pepe', '8.30.smith'];
+        $va_item_settings = array(
+                'applyRegularExpressions' => array(
+                        array("match" => '([0-9]+)\\.([0-9]+)',
+                                "replaceWith" => "\\1:\\2"),
+                        array(
+                                "match" => "[^0-9:]+",
+                                "replaceWith" => ""
+                        )
+                )
+        );
+
+        $result = caProcessImportItemSettingsForValue($va_value, $va_item_settings);
+        $this->assertIsArray($result);
+        $this->assertEquals(2, sizeof($result));
+        $this->assertSame(['7:30', '8:30'], $result);
+    }
+
+    public function testCaProcessImportItemSettingsForArrayValueWithEmptyMatch() {
+        $va_value = ['7.30.pepe', '8.30.smith'];
+        $va_item_settings = array(
+                'applyRegularExpressions' => array(
+                        array("match" => '',
+                                "replaceWith" => "\\1:\\2"),
+                        array(
+                                "match" => "",
+                                "replaceWith" => ""
+                        )
+                )
+        );
+
+        $result = caProcessImportItemSettingsForValue($va_value, $va_item_settings);
+        $this->assertIsArray($result);
+        $this->assertEquals(2, sizeof($result));
+        $this->assertSame($va_value, $result);
+    }
+
+    public function testCaProcessImportItemSettingsForValueWithExclamation() {
+        $ps_value = '7!30!pepe';
+        $pa_item_settings = array(
+                'applyRegularExpressions' => array(
+                        array("match" => '([0-9]+)!([0-9]+)',
+                                "replaceWith" => "\\1:\\2"),
+                        array(
+                                "match" => "[^0-9:]+",
+                                "replaceWith" => ""
+                        )
+                )
+        );
+
+        $result = caProcessImportItemSettingsForValue($ps_value, $pa_item_settings);
+        $this->assertSame('7:30', $result);
+    }
+
+    public function testCaValidateGoogleSheetsUrlReturnsNullForBadUrl() {
+        $url = "http://collectiveaccess.org";
+        $result = caValidateGoogleSheetsUrl($url);
+        $this->assertNull($result);
+    }
+
+    public function testCaValidateGoogleSheetsUrlReturnsValidatedUrl() {
+        $url = "https://docs.google.com/file/d/";
+        $result = caValidateGoogleSheetsUrl($url);
+        $this->assertSame('https://docs.google.com/file/d/export?format=xlsx', $result);
+    }
+
+    public function testCaProcessRefineryAttributesEmptyIsNotNull() {
+        $pa_attributes = $this->attributes;
+        $pa_source_data = $this->data;
+        $pa_item = $this->item;
+        $pn_c = 0;
+        $pa_options = array();
+        $result = caProcessRefineryAttributes($pa_attributes, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryAttributesEmptyProducesEmptyResults() {
+        $pa_attributes = array();
+        $pa_source_data = array();
+        $pa_item = array();
+        $pn_c = 0;
+        $pa_options = array();
+        $result = caProcessRefineryAttributes($pa_attributes, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        $this->assertNotNull($result);
+        $this->assertEquals(0, sizeof($result));
+    }
+
+    public function testCaProcessRefineryAttributesWithFileType() {
+        $this->markTestIncomplete('testCaProcessRefineryAttributesWithFileType pending test');
+    }
+
+    public function testCaProcessRefineryAttributesWithIndexedArray() {
+        $pa_attributes = $this->attributes;
+        $pa_source_data = $this->data;
+        $pa_item = $this->item;
+        $pn_c = 0;
+        $pa_options = array();
+        $result = caProcessRefineryAttributes($pa_attributes, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        $this->assertNotNull($result);
+        $this->assertEquals($this->data[3], $result["preferred_label"][0]);
+    }
+
+    public function testCaProcessRefineryAttributesWithAssociativeArray() {
+        $pa_attributes = $this->attributes;
+        $pa_source_data = $this->data;
+        $pa_item = $this->item;
+        $pn_c = 0;
+        $pa_options = array();
+        $result = caProcessRefineryAttributes($pa_attributes, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        $this->assertNotNull($result);
+        $this->assertEquals($this->data[5], $result["nonpreferred_label"]["name"]);
+    }
+
+    /****************************
+     *
+     * Refinery Parents tests
+     *
+     ****************************
+     */
+
+    public function testCaProcessRefineryParentsPlacesHierarchy() {
+        $vs_table = 'ca_places';
+        $result = $this->_runProcessRefineryParents('placeHierarchyBuilder', $vs_table, 'country');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryParentsCollectionHierarchy() {
+        $vs_table = 'ca_collections';
+        $result = $this->_runProcessRefineryParents('collectionHierarchyBuilder', $vs_table, 'internal');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryParentsEntityHierarchy() {
+        $vs_table = 'ca_entities';
+        $result = $this->_runProcessRefineryParents('entityHierarchyBuilder', $vs_table, 'org');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryParentsOccurrenceHierarchy() {
+        $vs_table = 'ca_occurrences';
+        $result = $this->_runProcessRefineryParents('occurrenceHierarchyBuilder', $vs_table, 'event');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryParentsObjectHierarchy() {
+        $vs_table = 'ca_objects';
+        $result = $this->_runProcessRefineryParents('objectHierarchyBuilder', $vs_table, 'software');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    public function testCaProcessRefineryParentsStorageLocationHierarchy() {
+        $vs_table = 'ca_storage_locations';
+        $result = $this->_runProcessRefineryParents('storageLocationHierarchyBuilder', $vs_table, 'drawer');
+        $this->_deleteInstance($vs_table, $result);
+        $this->assertNotNull($result);
+    }
+
+    /****************************
+     *
+     * Generic Splitter tests
+     *
+     ****************************
+     */
+
+    /**
+     *
+     */
+    public function testCaGenericImportSplitterEntity() {
+        $vs_refinery_name = 'entitySplitter';
+        $vs_type = 'org';
+        $this->groups['destination'] = 'ca_objects.unitdate.date_value';
+        $this->item['settings'][$vs_refinery_name . '_parents'] =
+                array(
+                        array(
+                                'name' => '^1',
+                                'type' => $vs_type
+                        ));
+        $vs_table = 'ca_entities';
+        $result = $this->_runGenericImportSplitter($vs_refinery_name, $vs_table, $vs_type);
+
+        // Delete entity
+        $this->_deleteInstance($vs_table, $result[0]['date_value']);
+
+        $this->assertNotNull($result);
+    }
+
+    public function testCaGenericImportSplitterEntitySkifIfValueMatches() {
+        $vs_refinery_name = 'entitySplitter';
+        $vs_type = 'org';
+        $this->groups['destination'] = 'ca_objects.unitdate.date_value';
+        $this->item['settings'][$vs_refinery_name . '_parents'] =
+                array(
+                        array(
+                                'name' => '^1',
+                                'type' => $vs_type
+                        ));
+        $this->item['settings'][$vs_refinery_name . '_skipIfValue'] = ['Verdun'];
+        $result = $this->_runGenericImportSplitter($vs_refinery_name, 'ca_entities', $vs_type);
+
+        $this->assertNotNull($result);
+        $this->assertSame(0, sizeof($result));
+    }
+
+    public function testCaGenericImportSplitterEntityUseHierarchy() {
+        $vs_refinery_name = 'entitySplitter';
+        $vs_type = 'org';
+        $this->groups['destination'] = 'ca_objects.unitdate.date_value';
+        $this->item['settings'][$vs_refinery_name . '_parents'] =
+                array(
+                        array(
+                                'name' => '^1',
+                                'type' => $vs_type
+                        ));
+        $this->item['settings'][$vs_refinery_name . '_hierarchy'] = $this->parents;
+        $vs_table = 'ca_entities';
+        $result = $this->_runGenericImportSplitter($vs_refinery_name, $vs_table, $vs_type);
+
+        // Delete entity
+        $this->_deleteInstance($vs_table, $result[0]['date_value']);
+
+        $this->assertNotNull($result);
+    }
+
+    /**
+     * @param string $ps_table
+     * @param        $pn_id
+     */
+    protected function _deleteInstance(string $ps_table, $pn_id): void {
+        $t_instance = Datamodel::getInstance($ps_table);
+        if ($t_instance->load($pn_id)) {
+            $t_instance->setMode(ACCESS_WRITE);
+            $t_instance->delete(true, array('hard' => true));
+        }
+    }
+
 }

--- a/tests/helpers/MediaPluginHelpersTest.php
+++ b/tests/helpers/MediaPluginHelpersTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ----------------------------------------------------------------------
+ * MediaPluginHelpersTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2015-2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package    CollectiveAccess
+ * @subpackage tests
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ *
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class MediaPluginHelpersTest extends TestCase {
+    public function setUp(): void {
+    }
+
+    public function testCaGetExternalApplicationPath() {
+        $this->assertSame("/usr/bin/gs", caGetExternalApplicationPath("ghostscript"));
+    }
+
+    public function testCaGetExternalApplicationPathReturnsNullsForMissingApplication() {
+        $this->assertNull(caGetExternalApplicationPath("test"));
+    }
+
+    public function testCaMediaPluginImageMagickInstalledFails() {
+        $this->assertFalse(caMediaPluginImageMagickInstalled());
+    }
+}
+

--- a/tests/helpers/UtilityHelpersTest.php
+++ b/tests/helpers/UtilityHelpersTest.php
@@ -124,4 +124,50 @@ JSON;
 		$this->assertEquals("5.0 in", $vm_ret[1]);
 	}
 	# -------------------------------------------------------
+
+    public function testCaEscapeForDelimitedRegexpWithEmptyExpression(){
+        $regexp = '';
+        $result = caEscapeForDelimitedRegexp($regexp, '!');
+        $this->assertEquals('', $result);
+    }
+
+    public function testCaEscapeForDelimitedRegexpWithSharp(){
+        $regexp = '#';
+        $result = caEscapeForDelimitedRegexp($regexp, '#');
+        $this->assertEquals('\#', $result);
+    }
+
+    public function testCaEscapeForDelimitedRegexpWithSlash(){
+        $regexp = '/';
+        $result = caEscapeForDelimitedRegexp($regexp, '/');
+        $this->assertEquals('\/', $result);
+    }
+
+    public function testCaEscapeForDelimitedRegexpWithExclamation(){
+        $regexp = '!';
+        $result = caEscapeForDelimitedRegexp($regexp, '!');
+        $this->assertEquals('\\!', $result);
+    }
+
+    public function testCaEscapeForDelimitedRegexpEscapedDelimiter(){
+        $regexp = '\!';
+        $result = caEscapeForDelimitedRegexp($regexp, '!');
+        $this->assertEquals('\!', $result);
+    }
+
+    public function testCaMakeDelimitedRegexp(){
+        $regexp = '([0-9]+)!([0-9]+)';
+        $result = caMakeDelimitedRegexp($regexp, '!');
+        $this->assertEquals('!([0-9]+)\\!([0-9]+)!', $result);
+    }
+    public function testCaMakeDelimitedRegexpWithSharp(){
+        $regexp = '([0-9]+)!([0-9]+)';
+        $result = caMakeDelimitedRegexp($regexp, '#');
+        $this->assertEquals('#([0-9]+)!([0-9]+)#', $result);
+    }
+    public function testCaMakeDelimitedRegexpWithSlash(){
+        $regexp = '([0-9]+)!([0-9]+)';
+        $result = caMakeDelimitedRegexp($regexp, '/');
+        $this->assertEquals('/([0-9]+)!([0-9]+)/', $result);
+    }
 }

--- a/tests/phpunit-coverage.xml
+++ b/tests/phpunit-coverage.xml
@@ -1,0 +1,72 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         cacheTokens="false"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         bootstrap="./setup-tests.php"
+         verbose="true">
+
+    <!--
+    IMPORTANT: All paths are relative to this file.
+    -->
+
+    <testsuites>
+        <testsuite name="Helpers Test Suite">
+            <directory>helpers/</directory>
+        </testsuite>
+        <testsuite name="Lib Test Suite">
+            <directory>lib/</directory>
+            <exclude>lib/Search/ElasticSearch</exclude>
+        </testsuite>
+        <testsuite name="Models Test Suite">
+            <directory>models/</directory>
+        </testsuite>
+        <testsuite name="Plugins Test Suite">
+            <directory>plugins/</directory>
+        </testsuite>
+        <testsuite name="Tests With Data Suite">
+            <directory>testsWithData/</directory>
+        </testsuite>
+        <testsuite name="Install Test Suite">
+            <directory>install/</directory>
+        </testsuite>
+        <testsuite name="Refineries Test Suite">
+            <directory>refineries/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false" addUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">../app</directory>
+            <directory suffix=".php">../install</directory>
+            <directory suffix=".php">../viewers</directory>
+            <directory suffix=".php">../hc</directory>
+            <exclude>
+                <directory>../install/profiles</directory>
+                <directory>../install/css</directory>
+                <directory>../install/graphics</directory>
+                <directory>../app/conf</directory>
+                <directory>../app/fonts</directory>
+                <directory>../app/lib/Zend</directory>
+                <directory>../app/lib/Print/phpqrcode/cache</directory>
+                <directory>../app/locale</directory>
+                <directory>../app/log</directory>
+                <directory>../app/queue</directory>
+                <directory>../app/tmp</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="../build/coverage.xml"/>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true" showUncoveredFiles="false"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
This PR includes a fix for #409 (broken regexp match).

While adding the test for it, I realized I may improve testing coverage, and I extended the PR to also include a refactor of `ImportHelpersTest`.

It also includes a cherry-pick at dc0ef584a1172dae7d6f25bc5d4b52a88eda3cdd by @collectiveaccess for pending TODOs on importHelpers, I included it to make sure tests are more robust.