### PR TITLE
Remove short alias on global options to avoid conflicts on subcommands.

### DIFF
--- a/app/helpers/CLIHelpers.php
+++ b/app/helpers/CLIHelpers.php
@@ -142,3 +142,24 @@ function caSetupCLIScript($pa_additional_parameters) {
 	return $o_opts;
 }
 # ---------------------------------------------------------------------
+
+/**
+ * Format a command line option for display
+ *
+ * @param $vs_opt_format
+ * @param $vs_opt_desc
+ */
+function caFormatCmdOptionsForDisplay($vs_opt_format, $vs_opt_desc): string {
+    if (in_array(substr($vs_opt_format, -2, 1), ['-', '='])) {
+        $flagList  = substr($vs_opt_format, 0, -2);
+    } else {
+        $flagList = $vs_opt_format;
+    }
+
+    $va_tmp = explode("|", $flagList);
+    $vs_alias = sizeof($va_tmp)>1 ? $va_tmp[1]: "";
+
+    $vn_padding = 25;
+    return "\t" . CLIUtils::textWithColor(str_pad("--" . $va_tmp[0] . " " . ($vs_alias ? "(-{$vs_alias})":""), $vn_padding), "red") . \
+                    wordwrap($vs_opt_desc, 75, "\n\t" . str_repeat(" ", $vn_padding)) . "\n\n";
+}

--- a/support/bin/caUtils
+++ b/support/bin/caUtils
@@ -31,20 +31,6 @@
  * ----------------------------------------------------------------------
  */
 
-    /**
-     * Format a command line option.
-     *
-     * @param $vs_opt_format
-     * @param $vs_opt_desc
-     */
-    function _formatCmdOptions($vs_opt_format, $vs_opt_desc): string {
-        $va_tmp = explode("|", $vs_opt_format);
-        $va_abbr = preg_split("![=\-]+!", $va_tmp[1]);
-
-        return "\t" . CLIUtils::textWithColor(str_pad("--" . $va_tmp[0] . " " . ($va_abbr[0] ? "(-{$va_abbr[0]})":""), 20), "red") . \
-                        wordwrap($vs_opt_desc, 75, "\n\t" . str_repeat(" ", 20)) . "\n\n";
-    }
-
 	if (!_caUtilsLoadSetupPHP()) {
 		die("Could not find your CollectiveAccess setup.php file! Please set the COLLECTIVEACCESS_HOME environment variable to the location of your CollectiveAccess installation, or run this command from a sub-directory of your CollectiveAccess installation.\n");
 	}
@@ -96,8 +82,8 @@
 	}
 
 	$va_available_cli_opts = array_merge(array(
-			"hostname|h-s" => 'Hostname of installation. If omitted default installation is used.',
-			"setup|s" => 'Specify the path to an alternate setup.php.',
+			"hostname-s" => 'Hostname of installation. If omitted default installation is used.',
+			"setup-s" => 'Specify the path to an alternate setup.php.',
 		), $va_command_opts);
 
 	try {
@@ -147,14 +133,14 @@
 				if (is_array($va_opts) && sizeof($va_opts)) {
 					print CLIUtils::textWithColor("Options for {$vs_cmd} are:", "bold_green")."\n\n";
 					foreach($va_opts as $vs_opt_format => $vs_opt_desc) {
-                        $output = _formatCmdOptions($vs_opt_format, $vs_opt_desc);
+                        $output = caFormatCmdOptionsForDisplay($vs_opt_format, $vs_opt_desc);
                         print $output;
                     }
 				}
 			} else {
 				print CLIUtils::textWithColor("No help is available for \"{$vs_cmd_proc}\"\n\n", "bold_red");
                 foreach($va_available_cli_opts as $vs_opt_format => $vs_opt_desc) {
-                    $output = _formatCmdOptions($vs_opt_format, $vs_opt_desc);
+                    $output = caFormatCmdOptionsForDisplay($vs_opt_format, $vs_opt_desc);
                     print $output;
                 }
 			}
@@ -201,7 +187,7 @@
         print CLIUtils::textWithColor("Global options\n\n", "bold_green");
 
         foreach($va_available_cli_opts as $vs_opt_format => $vs_opt_desc) {
-            $output = _formatCmdOptions($vs_opt_format, $vs_opt_desc);
+            $output = caFormatCmdOptionsForDisplay($vs_opt_format, $vs_opt_desc);
             print $output;
         }
 		$va_methods = get_class_methods("CLIUtils");

--- a/tests/helpers/CliHelpersTest.php
+++ b/tests/helpers/CliHelpersTest.php
@@ -1,0 +1,98 @@
+<?php
+/** ---------------------------------------------------------------------
+ * tests/helpers/CliHelpersTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2015 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package    CollectiveAccess
+ * @subpackage tests
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__CA_APP_DIR__ . "/helpers/CLIHelpers.php");
+
+class CliHelpersTest extends TestCase {
+
+    private $opa_options;
+
+    protected function setUp(): void {
+        $this->opa_options = array(
+                "hostname-s" => 'Hostname of installation. If omitted default installation is used.',
+                "hostname=s" => 'Hostname of installation. If omitted default installation is used.',
+                "hostname|h-s" => 'Hostname of installation. If omitted default installation is used.',
+                "hostname|h=s" => 'Hostname of installation. If omitted default installation is used.',
+                "hostname" => 'Hostname of installation. If omitted default installation is used.',
+        );
+    }
+
+    /**
+     * Delete all records we created for this test to avoid side effects with other tests
+     */
+    protected function tearDown() : void {
+    }
+
+    # -------------------------------------------------------
+    public function testDisplayFormatWithNoAliasOptional() {
+        // some real-world examples
+        $vs_key = "hostname-s";
+
+        $result = caFormatCmdOptionsForDisplay($vs_key, $this->opa_options[$vs_key]);
+        $this->assertStringContainsString("--hostname     ", $result);
+    }
+
+    public function testDisplayFormatWithNoAliasMandatory() {
+        // some real-world examples
+        $vs_key = "hostname=s";
+
+        $result = caFormatCmdOptionsForDisplay($vs_key, $this->opa_options[$vs_key]);
+        $this->assertStringContainsString("--hostname     ", $result);
+    }
+
+    public function testDisplayFormatWithAliasOptional() {
+        // some real-world examples
+        $vs_key = "hostname|h-s";
+
+        $result = caFormatCmdOptionsForDisplay($vs_key, $this->opa_options[$vs_key]);
+        $this->assertStringContainsString("--hostname (-h)     ", $result);
+    }
+
+    public function testDisplayFormatWithAliasMandatory() {
+        // some real-world examples
+        $vs_key = "hostname|h=s";
+
+        $result = caFormatCmdOptionsForDisplay($vs_key, $this->opa_options[$vs_key]);
+        $this->assertStringContainsString("--hostname (-h)     ", $result);
+    }
+
+    public function testDisplayFormatNoArgs() {
+        // some real-world examples
+        $vs_key = "hostname";
+
+        $result = caFormatCmdOptionsForDisplay($vs_key, $this->opa_options[$vs_key]);
+        $this->assertStringContainsString("--hostname     ", $result);
+    }
+
+}


### PR DESCRIPTION
I realized that short alias for global options may conflict with sub-commands options, for example, `import-media` source option also uses `-s` as a short alias (a PR will follow also on `import-media` params later).

In order to avoid the conflict, I removed sort aliases on global options.

In the process I realized:

* the right syntax for a long-only option is `longoption[-=]s`, so I also updated the code accordingly.
* former `_formatCmdOptions` function will best fit into a helper file. I refactored it a bit, using code borrowed from Zend GetOpt implementation.
* there were no tests on the former `_formatCmdOptions`, so I add them in this PR.
