### PR TITLE
FIX Fuzzy search caused infinity recursion

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1715,7 +1715,8 @@
 	function caSearchIsForSets($ps_search, $pa_options=null) {
 		$o_config = Configuration::load();
 		$o_query_parser = new LuceneSyntaxParser();
-		$o_query_parser->setEncoding($o_config->get('character_set'));
+        $vs_char_set = $o_config->get('character_set');
+        $o_query_parser->setEncoding($vs_char_set);
 		$o_query_parser->setDefaultOperator(LuceneSyntaxParser::B_AND);
 		
 		$ps_search = preg_replace('![\']+!', '', $ps_search);
@@ -1781,6 +1782,7 @@
 					break;	
 				case 'Zend_Search_Lucene_Search_Query_Range':
 				case 'Zend_Search_Lucene_Search_Query_Wildcard':
+				case 'Zend_Search_Lucene_Search_Query_Fuzzy':
 					// noop
 					break;
 				case 'Zend_Search_Lucene_Search_Query_Boolean':

--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1792,7 +1792,11 @@
 						}
 					}
 					break;
-				default:
+                default:
+				    /*
+				        TODO: probably remove, all cases are covered on previous cases. In
+                        addition, keeping it is a door to infinite recursion.
+				    */
 					if (is_array($va_sub_sets = caSearchIsForSets($subquery))) {
 						$va_sets = array_merge($va_sets, $va_sub_sets);
 					}

--- a/tests/helpers/SetSearchHelpersTest.php
+++ b/tests/helpers/SetSearchHelpersTest.php
@@ -34,23 +34,35 @@ use PHPUnit\Framework\TestCase;
 require_once(__CA_APP_DIR__."/helpers/searchHelpers.php");
 require_once(__CA_BASE_DIR__.'/tests/testsWithData/BaseTestWithData.php');
 
-class SearchHelpersTest extends TestCase {
-	# -------------------------------------------------------
-	public function testESDateRewrite() {
-		// day-less
-		$this->assertEquals('2014-04-01T00:00:00Z', caRewriteDateForElasticSearch('2014-04-00T00:00:00Z', true));
-		$this->assertEquals('2014-04-30T00:00:00Z', caRewriteDateForElasticSearch('2014-04-00T00:00:00Z', false));
 
-		// month- and day-less
-		$this->assertEquals('2014-01-01T00:00:00Z', caRewriteDateForElasticSearch('2014-00-00T00:00:00Z', true));
-		$this->assertEquals('2014-12-31T00:00:00Z', caRewriteDateForElasticSearch('2014-00-00T00:00:00Z', false));
+class SetSearchHelpersTest extends BaseTestWithData {
 
+    protected $opt_set;
+    protected $ops_set_code = 'TEST';
+
+    protected function setUp(): void {
+        parent::setUp();
+        $vn_set_id = $this->addTestRecord('ca_sets', array(
+                'intrinsic_fields' => array(
+                        'type_id' => 'user',
+                        'set_code' => $this->ops_set_code
+                ),
+                'preferred_labels' => array(
+                        array(
+                                "locale" => "en_US",
+                                "name" => "Test set",
+                        )
+                )
+        ));
+        $this->assertGreaterThan(0, $vn_set_id);
+        $this->opt_set = new ca_sets($vn_set_id);
+    }
+
+    public function testCaSearchIsForSetsFuzzySearchWithSet() {
+        $result = caSearchIsForSets("centro~ +set:{$this->ops_set_code}");
+        $key = array_key_first($result);
+        $this->assertEquals('Test set', $result[$key]);
 	}
 	# -------------------------------------------------------
 
-	public function testCaSearchIsForSetsFuzzySearchNoSet() {
-        $result = caSearchIsForSets('centro~');
-        $this->assertEmpty($result);
-	}
-	# -------------------------------------------------------
 }

--- a/tests/testsWithData/BaseTestWithData.php
+++ b/tests/testsWithData/BaseTestWithData.php
@@ -54,7 +54,7 @@ abstract class BaseTestWithData extends TestCase {
 	 */
 	private $opb_care_about_side_effects = true;
 
-	static $opa_valid_tables = array('ca_objects', 'ca_entities', 'ca_occurrences', 'ca_movements', 'ca_loans', 'ca_object_lots', 'ca_storage_locations', 'ca_places', 'ca_item_comments');
+	static $opa_valid_tables = array('ca_objects', 'ca_entities', 'ca_occurrences', 'ca_movements', 'ca_loans', 'ca_object_lots', 'ca_storage_locations', 'ca_places', 'ca_item_comments', 'ca_sets');
 	# -------------------------------------------------------
 	/**
 	 * Inserts test data set by implementation


### PR DESCRIPTION
While running a query like "centro~" the server crashed with an HTTP 500 Error.

Tracing the cause, it was due to an infinity recursion on `caSearchIsForSets`, because there was no stopping condition when subqueries were fuzzy.

Added some tests too.