### PR TITLE
#427 Allow configuring which controllers will not use compression.

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2116,6 +2116,37 @@ notification_email_subject = (<app_display_name>) Metadata Notification from Col
 display_template_debugger = 0
 
 
+# -----------------------------------
+# Disable gzip on progress bar
+# -----------------------------------
+#  Gzip adds a buffer so progress bar that incrementally issue javascript to update
+#  the bar will not take effect til the buffer is full.
+#  The value is a list of controllers with the corresponding action on the left.
+#
+disable_gzip_on_controllers = {
+	SearchReindexController => {
+		action = Reindex
+	},
+	HierarchicalReindexController => {
+		action = Reindex
+	},
+	SortValuesReloadController => {
+		action = Reload
+	},
+	MediaImportController => {
+		action = Save
+	},
+	MetadataImportController => {
+		action = ImportData
+	},
+	EditorController => {
+		action = Save
+	},
+	MetadataExportController => {
+		action = ExportData
+	}
+}
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 #  ______                       _   

--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2119,30 +2119,39 @@ display_template_debugger = 0
 # -----------------------------------
 # Disable gzip on progress bar
 # -----------------------------------
-#  Gzip adds a buffer so progress bar that incrementally issue javascript to update
-#  the bar will not take effect til the buffer is full.
-#  The value is a list of controllers with the corresponding action on the left.
+# Gzip adds a buffer so progress bar that incrementally sends javascript to update
+# the bar will not take effect til the buffer is full. In order to render the
+# progress bar immediately, content negotiation should be disabled for
+# those Controllers.
+#
+# Each entry has the controller name as a key.
+# Do not use the name of the class but the controller name.
+# Use Editor and not EditorController.
+# A controller with no actions will disable gzip for all of its actions.
+#
+# The entry value contains an "action" key to apply it to just
+# one action or a list of actions.
 #
 disable_gzip_on_controllers = {
-	SearchReindexController => {
+	SearchReindex = {
 		action = Reindex
 	},
-	HierarchicalReindexController => {
+	HierarchicalReindex = {
 		action = Reindex
 	},
-	SortValuesReloadController => {
+	SortValuesReload = {
 		action = Reload
 	},
-	MediaImportController => {
+	MediaImport = {
 		action = Save
 	},
-	MetadataImportController => {
-		action = ImportData
+	MetadataImport = {
+		action = [ImportData]
 	},
-	EditorController => {
+	Editor = {
 		action = Save
 	},
-	MetadataExportController => {
+	MetadataExport = {
 		action = ExportData
 	}
 }

--- a/app/helpers/navigationHelpers.php
+++ b/app/helpers/navigationHelpers.php
@@ -235,8 +235,7 @@
 	 *
 	 *
 	 * @param array $pa_options Options are:
-	 *		icon_position =
-	 *		no_background = 
+	 *		no_background =
 	 *		dont_show_content = 
 	 *		graphicsPath =
 	 *		size =
@@ -250,7 +249,6 @@
 			$vs_url = '';
 		}
 		
-		$ps_icon_pos = isset($pa_options['icon_position']) ? $pa_options['icon_position'] : __CA_NAV_ICON_ICON_POS_LEFT__;
 		$pb_no_background = (isset($pa_options['no_background']) && $pa_options['no_background']) ? true : false;
 		$pb_dont_show_content = (isset($pa_options['dont_show_content']) && $pa_options['dont_show_content']) ? true : false;
 		
@@ -282,19 +280,16 @@
 			$vn_padding = ($ps_content) ? 10 : 0;
 			$va_img_attr['class'] = 'form-button-left';
 			$va_img_attr['style'] = "padding-right: {$vn_padding}px;";
-		} else {
-			$vn_padding = 0;
-			$vs_img_tag_stuff = '';
 		}
 		
 		if (preg_match("/^[A-Za-z\.\-0-9 ]+$/", $ps_content)) {
-			$vs_alt = $vs_title = htmlspecialchars($ps_content, ENT_QUOTES, 'UTF-8');
+			$vs_title = htmlspecialchars($ps_content, ENT_QUOTES, 'UTF-8');
 		} else {
-			$vs_alt = $vs_title = '';
+			$vs_title = '';
 		}
+        $va_img_attr['title'] = $vs_title;
 		
-		
-		$vs_tag .= caNavIcon($pn_type, caGetOption('size', $pa_options, 2), $va_icon_attributes);
+		$vs_tag .= caNavIcon($pn_type, caGetOption('size', $pa_options, 2), $va_img_attr);
 		if (!$pb_dont_show_content) {
 			$vs_tag .= $ps_content;
 		}
@@ -351,7 +346,7 @@
 		$vs_img_tag_stuff = " padding= '{$vn_padding}px'";
 			
 		
-		if ($vs_icon_tag = caNavIcon($pn_type, caGetOption('size', $pa_options, '30px'), $va_icon_attributes)) {
+		if ($vs_icon_tag = caNavIcon($pn_type, caGetOption('size', $pa_options, '30px'), $va_img_attr)) {
 			$vs_content = (!$pb_dont_show_content) ? $ps_content : '';
 			
 			switch($ps_icon_pos) {
@@ -475,7 +470,6 @@
 	 *		size = 
 	 */
 	function caFormSubmitButton($po_request, $pn_type, $ps_content, $ps_id, $pa_options=null) {
-		$ps_icon_pos = isset($pa_options['icon_position']) ? $pa_options['icon_position'] : __CA_NAV_ICON_ICON_POS_LEFT__;
 		$ps_use_classname = isset($pa_options['class']) ? $pa_options['class'] : '';
 		$pb_no_background = (isset($pa_options['no_background']) && $pa_options['no_background']) ? true : false;
 		$pb_dont_show_content = (isset($pa_options['dont_show_content']) && $pa_options['dont_show_content']) ? true : false;
@@ -512,7 +506,7 @@
 		);
 		
 		
-		$vs_button .= caNavIcon($pn_type, caGetOption('size', $pa_options, '30px'), $va_icon_attributes);
+		$vs_button .= caNavIcon($pn_type, caGetOption('size', $pa_options, '30px'), $va_img_attr);
 		if (!$pb_dont_show_content) {
 			$vs_button .= $ps_content;
 		}
@@ -584,7 +578,7 @@
 		);
 		
 		
-		$vs_button .= caNavIcon($pn_type, caGetOption('size', $pa_options, 2), $va_icon_attributes);
+		$vs_button .= caNavIcon($pn_type, caGetOption('size', $pa_options, 2), $va_img_attr);
 		if (!$pb_dont_show_content) {
 			$vs_button .= $ps_content;
 		}
@@ -1376,3 +1370,24 @@
 		return $g_use_clean_urls = (defined('__CA_USE_CLEAN_URLS__') && (__CA_USE_CLEAN_URLS__) && caModRewriteIsAvailable());
 	}
 	# ------------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------------
+    /**
+     * @param $vs_controller
+     * @param $vs_action
+     *
+     * @return bool
+     */
+    function caIsGzipDisabled($vs_controller, $vs_action){
+        $conf = Configuration::load();
+        $va_disable_gzip = $conf->getAssoc('disable_gzip_on_controllers');
+        if (($va_acl = caGetOption($vs_controller, $va_disable_gzip, null)) !== null){
+            if (caGetOption('action', $va_acl, null) === $vs_action){
+                return true;
+            } else {
+                return sizeof(array_keys($va_acl))==0;
+            }
+        }
+        return false;
+    }
+
+

--- a/app/helpers/navigationHelpers.php
+++ b/app/helpers/navigationHelpers.php
@@ -1381,7 +1381,11 @@
         $conf = Configuration::load();
         $va_disable_gzip = $conf->getAssoc('disable_gzip_on_controllers');
         if (($va_acl = caGetOption($vs_controller, $va_disable_gzip, null)) !== null){
-            if (caGetOption('action', $va_acl, null) === $vs_action){
+            $va_actions = caGetOption('action', $va_acl, array());
+            if (!is_array($va_actions)){
+                $va_actions = array($va_actions);
+            }
+            if (in_array($vs_action, $va_actions)){
                 return true;
             } else {
                 return sizeof(array_keys($va_acl))==0;

--- a/app/lib/Controller/RequestDispatcher.php
+++ b/app/lib/Controller/RequestDispatcher.php
@@ -270,6 +270,9 @@ class RequestDispatcher extends BaseObject {
 							$this->postError(2310, _t("Not dispatchable"), "RequestDispatcher->dispatch()");
 							return false;
 						}
+						if (caIsGzipDisabled($this->ops_controller, $this->ops_action)){
+                            $this->opo_response->addHeader("Content-Encoding", "none");
+                        }
 						$o_action_controller->{$this->ops_action}($va_params);
 						if ($o_action_controller->numErrors()) {
 							$this->errors = $o_action_controller->errors();

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,9 @@
     "scholarslab/bagit": "~0.2",
     "srmklive/flysystem-dropbox-v2": ">=1.0.0",
     "tedivm/stash": "0.14.*"
+  },
+  "require": {
+    "ext-iconv": "*",
+    "ext-simplexml": "*"
   }
 }

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -1790,7 +1790,7 @@ class Installer {
 					$t_display->addTypeRestriction(array_pop(caMakeTypeIDList($vn_table_num, [$vs_type], ['dontIncludeSubtypesInTypeRestriction' => true])), ['includeSubtypes' => (bool)$vo_restriction->includeSubtypes ? 1 : 0]);
 					
 					if ($t_display->numErrors()) {
-						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in display {$vs_display_code}: ".join("; ",$t_restriction->getErrors()));
+						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in display {$vs_display_code}: ".join("; ",$t_display->getErrors()));
 					}
 
 					$this->logStatus(_t('Added type restriction with code %1 and type %2 for display with code %3', $vs_restriction_code, $vs_type, $vs_display_code));
@@ -1997,9 +1997,9 @@ class Installer {
 					$vs_type = trim((string)self::getAttribute($vo_restriction, "type"));
 					
 					$t_form->addTypeRestriction(array_pop(caMakeTypeIDList($vn_table_num, [$vs_type], ['dontIncludeSubtypesInTypeRestriction' => true])), ['includeSubtypes' => (bool)$vo_restriction->includeSubtypes ? 1 : 0]);
-					
-					if ($t_restriction->numErrors()) {
-						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in form {$vs_form_code}: ".join("; ",$t_restriction->getErrors()));
+
+					if ($t_form->numErrors()) {
+						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in form {$vs_form_code}: ".join("; ",$t_form->getErrors()));
 					}
 
 					$this->logStatus(_t('Added type restriction with code %1 and type %2 for form with code %3', $vs_restriction_code, $vs_type, $vs_form_code));
@@ -2365,7 +2365,7 @@ class Installer {
 					$t_md_alert->addTypeRestriction(array_pop(caMakeTypeIDList($vn_table_num, [$vs_type], ['dontIncludeSubtypesInTypeRestriction' => true])), ['includeSubtypes' => (bool)$vo_restriction->includeSubtypes ? 1 : 0]);
 					
 					if ($t_md_alert->numErrors()) {
-						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in metadata alert {$vs_alert_code}: ".join("; ",$t_restriction->getErrors()));
+						$this->addError("There was an error while inserting type restriction {$vs_restriction_code} in metadata alert {$vs_alert_code}: ".join("; ",$t_md_alert->getErrors()));
 					}
 
 					$this->logStatus(_t('Added type restriction with code %1 and type %2 for metadata alert with code %3', $vs_restriction_code, $vs_type, $vs_alert_code));

--- a/install/index.php
+++ b/install/index.php
@@ -27,8 +27,14 @@
  *
  * ----------------------------------------------------------------------
  */
+    //
+    // Send headers before any other content.
+    // Disable gzip or any compression to allow showing progressbar.
+    //
+    header('Content-Encoding: none');
 	define('__CollectiveAccess_Installer__', 1);
-	error_reporting(E_ALL ^ E_NOTICE);
+
+    error_reporting(E_ALL ^ E_NOTICE);
 	set_time_limit(7200);
 	ini_set("memory_limit", "512M");	
 	

--- a/tests/conf/app.conf
+++ b/tests/conf/app.conf
@@ -2,9 +2,8 @@ allow_fetching_of_media_from_remote_urls = 1
 disable_out_of_process_search_indexing = 1
 
 disable_gzip_on_controllers = {
-	TestController => { action = TestAction },
-	TestControllerAllActions => {},
-	SearchReindexController => {
-		action = Reindex
-	}
+	TestDisableGzip = { action = TestAction },
+	TestDisableGzipListActions = { action = [TestAction] },
+	TestDisableGzipAllActions = {},
+	TestOthers = {}
 }

--- a/tests/conf/app.conf
+++ b/tests/conf/app.conf
@@ -1,2 +1,10 @@
 allow_fetching_of_media_from_remote_urls = 1
 disable_out_of_process_search_indexing = 1
+
+disable_gzip_on_controllers = {
+	TestController => { action = TestAction },
+	TestControllerAllActions => {},
+	SearchReindexController => {
+		action = Reindex
+	}
+}

--- a/tests/lib/Controller/DisableGzipTest.php
+++ b/tests/lib/Controller/DisableGzipTest.php
@@ -43,7 +43,7 @@ class DisableGzipTest extends TestCase {
     /**
      * @var string
      */
-    private $vs_controller_enabled;
+    private $vs_controller_with_gzip;
     /**
      * @var string
      */
@@ -55,40 +55,50 @@ class DisableGzipTest extends TestCase {
     /**
      * @var string
      */
-    private $vs_controller_allactions;
+    private $vs_controller_all_actions;
 
 
     protected function setUp(): void {
         parent::setUp();
-        $this->vs_controller = 'TestController';
-        $this->vs_controller_allactions = 'TestControllerAllActions';
-        $this->vs_controller_enabled = 'TestControllerEnabled';
+        $this->vs_controller = 'TestDisableGzip';
+        $this->vs_controller_list_actions = 'TestDisableGzipListActions';
+        $this->vs_controller_all_actions = 'TestDisableGzipAllActions';
+        $this->vs_controller_with_gzip = 'TestEditorWithGzip';
         $this->vs_action = 'TestAction';
         $this->vs_action_enabled = 'TestActionEnabled';
     }
 
     public function testDisableGzipForControllerAllActions(){
-        $result = caIsGzipDisabled($this->vs_controller_allactions, null);
+        // A controller with no actions will disable gzip all actions
+        $result = caIsGzipDisabled($this->vs_controller_all_actions, null);
         $this->assertTrue($result);
     }
     public function testDisableGzipForControllerAllActionsWithAction(){
-        $result = caIsGzipDisabled($this->vs_controller_allactions, $this->vs_action);
+        $result = caIsGzipDisabled($this->vs_controller_all_actions, $this->vs_action);
+        $this->assertTrue($result);
+    }
+    public function testDisableGzipForListOfActions(){
+        $result = caIsGzipDisabled($this->vs_controller_list_actions, $this->vs_action);
         $this->assertTrue($result);
     }
     public function testDoNotDisableGzipNoAction(){
-        $result = caIsGzipDisabled($this->vs_controller_enabled, null);
+        $result = caIsGzipDisabled($this->vs_controller_with_gzip, null);
         $this->assertFalse($result);
     }
     public function testDoNotDisableGzipWithAction(){
-        $result = caIsGzipDisabled($this->vs_controller_enabled, $this->vs_action_enabled);
+        $result = caIsGzipDisabled($this->vs_controller_with_gzip, $this->vs_action_enabled);
         $this->assertFalse($result);
     }
     public function testDoNotDisableGzipControllerEmptyAction(){
         $result = caIsGzipDisabled($this->vs_controller, null);
         $this->assertFalse($result);
     }
-    public function testDoNotDisableGzipControllerMatchingAction(){
+    public function testDisableGzipControllerMatchingAction(){
         $result = caIsGzipDisabled($this->vs_controller, $this->vs_action);
         $this->assertTrue($result);
+    }
+    public function testDontDisabledGzipControllerActionNotFound(){
+        $result = caIsGzipDisabled($this->vs_controller, 'NotFoundAction');
+        $this->assertFalse($result);
     }
 }

--- a/tests/lib/Controller/DisableGzipTest.php
+++ b/tests/lib/Controller/DisableGzipTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ----------------------------------------------------------------------
+ * DisableGzipTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2015-2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage tests
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ *
+ */
+
+class DisableGzipTest extends TestCase {
+    /**
+     * @var string
+     */
+    private $vs_controller;
+    /**
+     * @var string
+     */
+    private $vs_controller_enabled;
+    /**
+     * @var string
+     */
+    private $vs_action;
+    /**
+     * @var string
+     */
+    private $vs_action_enabled;
+    /**
+     * @var string
+     */
+    private $vs_controller_allactions;
+
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->vs_controller = 'TestController';
+        $this->vs_controller_allactions = 'TestControllerAllActions';
+        $this->vs_controller_enabled = 'TestControllerEnabled';
+        $this->vs_action = 'TestAction';
+        $this->vs_action_enabled = 'TestActionEnabled';
+    }
+
+    public function testDisableGzipForControllerAllActions(){
+        $result = caIsGzipDisabled($this->vs_controller_allactions, null);
+        $this->assertTrue($result);
+    }
+    public function testDisableGzipForControllerAllActionsWithAction(){
+        $result = caIsGzipDisabled($this->vs_controller_allactions, $this->vs_action);
+        $this->assertTrue($result);
+    }
+    public function testDoNotDisableGzipNoAction(){
+        $result = caIsGzipDisabled($this->vs_controller_enabled, null);
+        $this->assertFalse($result);
+    }
+    public function testDoNotDisableGzipWithAction(){
+        $result = caIsGzipDisabled($this->vs_controller_enabled, $this->vs_action_enabled);
+        $this->assertFalse($result);
+    }
+    public function testDoNotDisableGzipControllerEmptyAction(){
+        $result = caIsGzipDisabled($this->vs_controller, null);
+        $this->assertFalse($result);
+    }
+    public function testDoNotDisableGzipControllerMatchingAction(){
+        $result = caIsGzipDisabled($this->vs_controller, $this->vs_action);
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
It also includes 
* code cleaning on `app/helpers/navigationHelpers.php` and the installer.
* disable gzip compression on web install script.

Closes #427 