### PR TITLE
NOJIRA Restore parameterized length limit

### DIFF
--- a/app/controllers/lookup/ListItemController.php
+++ b/app/controllers/lookup/ListItemController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2018 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -80,8 +80,8 @@
 				$va_lists = explode(";", $ps_lists);
 			}
 			
-			$vn_max_items_per_page = null;
-			if ($vn_max_items_per_page > 1000) {
+			$vn_max_items_per_page = $this->request->getParameter('max', pInteger);
+			if (($vn_max_items_per_page > 1000) || ($vn_max_items_per_page <= 0)) {
 				$vn_max_items_per_page = 100;
 			}
 			
@@ -132,11 +132,11 @@
 							unset($va_item['description']);
 							unset($va_item['icon']);
 						
-							if (!$va_item[$vs_label_display_field_name]) { $va_item[$vs_label_display_field_name] = $va_item['idno']; }
-							if (!$va_item[$vs_label_display_field_name]) { $va_item[$vs_label_display_field_name] = '???'; }
+							if (!trim($va_item[$vs_label_display_field_name])) { $va_item[$vs_label_display_field_name] = $va_item['idno']; }
+							if (!trim($va_item[$vs_label_display_field_name])) { $va_item[$vs_label_display_field_name] = '???'; }
 						
 							$va_item['name'] = $va_display_values[$vn_c];
-							if (!$va_item['name']) { $va_item['name'] = '??? '.$vn_item_id; }
+							if (!trim($va_item['name'])) { $va_item['name'] = '??? '.$vn_item_id; }
 							$va_item['table'] = 'ca_list_items';
 						
 							// Child count is only valid if has_children is not null


### PR DESCRIPTION
Code to read "max" parameter controlling maximum page lengths in hierarchy browser level loads had been removed. This commit restores it, greatly improving performance and display of very long hierarchy levels.