### PR TITLE
PROV-2902 Implement representation reuse

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -11647,7 +11647,7 @@ $pa_options["display_form_field_tips"] = true;
 						if (is_null($vm_value) && !$t_instance->getFieldInfo($vs_field, 'IS_NULL')) { $vs_op = '='; }
 					}
 					
-					if (is_null($vm_value)) {
+					if (is_null($vm_value) || ($vs_op === 'IS')) {
 						if ($vs_op !== '=') { $vs_op = 'IS'; }
 						$va_sql_wheres[] = "({$vs_field} {$vs_op} NULL)";
 					} elseif (is_array($vm_value) && sizeof($vm_value)) {

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -2836,7 +2836,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 				'includeSelf' => !(bool)$vb_strict_type_hierarchy, 
 				'directChildrenOnly' => $vb_strict_type_hierarchy && ($vb_strict_type_hierarchy !== '~'),
 				'restrictToTypes' => $t_rel ? [$t_rel->get('ca_relationship_types.sub_type_left_id')] : null,
-				'dontIncludeSubtypesInTypeRestriction' => !$t_rel->get('ca_relationship_types.include_subtypes_left')
+				'dontIncludeSubtypesInTypeRestriction' => $t_rel ? !$t_rel->get('ca_relationship_types.include_subtypes_left') : null
 			])));
 					
 		


### PR DESCRIPTION
Minor improvement that will link existing representations to a target record if no other relationships exist. This is useful in cases where you want to reimport object records (for example), but want to avoid reimporting the representations.