### PR TITLE
PROV-2910, PROV-2911 Improvements to expression parser

### DIFF
--- a/app/helpers/expressionHelpers.php
+++ b/app/helpers/expressionHelpers.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015 Whirl-i-Gig
+ * Copyright 2015-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -118,7 +118,6 @@ function caCalculateDateRangeAvgInDays() {
 
 	foreach($va_date_ranges as $vs_date_range) {
 		if(!$o_tep->parse($vs_date_range)) {
-			print "no parse $vs_date_range";
 			return false;
 		}
 
@@ -140,5 +139,19 @@ function caCalculateDateRangeAvgInDays() {
 	} else {
 		return false;
 	}
+}
+# ---------------------------------------
+/**
+ * Return true if date expression is a range rather than a single date
+ * @return bool
+ */
+function caDateIsRange($date_expression) {
+	$o_tep = new TimeExpressionParser();
+	if($o_tep->parse($date_expression)) {
+		$va_arg_historic_stamps = $o_tep->getHistoricTimestamps();
+		$v = $o_tep->getText(['dateFormat' => 'iso8601']);
+		return (strpos($v, '/') !== false);
+	}
+	return false;
 }
 # ---------------------------------------

--- a/app/lib/Parsers/ExpressionParser/ExpressionGrammar.pp
+++ b/app/lib/Parsers/ExpressionParser/ExpressionGrammar.pp
@@ -84,6 +84,9 @@
 %token  in_op     IN|in
 %token  notin_op  NOT\ IN|not\ in
 
+%token true true|TRUE
+%token false false|FALSE
+
 // Variables
 %token  variable  \^(ca_[A-Za-z]+[A-Za-z0-9_\-\.]+[A-Za-z0-9]{1}[\&\%]{1}[^ <]+|[0-9]+(?=[.,;])|[A-Za-z0-9_\.:\/]+[%]{1}[^\w\^\t\r\n\"\'<>\(\)\{\}\/]*|[A-Za-z0-9_\.\/]+[:]{1}[A-Za-z0-9_\.\/\[\]\@\'\"=:]+\]|[A-Za-z0-9_\.\/]+[:]{1}[A-Za-z0-9_\.\/\[\]\@\'\"=:]+|[A-Za-z0-9_\.\/]+[~]{1}[A-Za-z0-9]+[:]{1}[A-Za-z0-9_\.\/]+|[A-Za-z0-9_\.\/]+)
 
@@ -152,6 +155,8 @@ scalar:
   | (<string> ( ::plus:: #stradd scalar())?)
   | (<string_single_quote> ( ::plus:: #stradd scalar())?)
   | <variable>
+  | <true>
+  | <false>
 
 primary:
     secondary() ( ::minus:: #substraction scalar() )?

--- a/app/lib/Parsers/ExpressionParser/ExpressionVisitor.php
+++ b/app/lib/Parsers/ExpressionParser/ExpressionVisitor.php
@@ -443,6 +443,7 @@ class ExpressionVisitor implements Visitor\Visit {
 				$token = $po_element->getValueToken();
 				$out = null;
 
+				
 				switch($token) {
 					case 'id':
 						return $value;

--- a/app/lib/Parsers/ExpressionParser/ExpressionVisitor.php
+++ b/app/lib/Parsers/ExpressionParser/ExpressionVisitor.php
@@ -103,7 +103,8 @@ class ExpressionVisitor implements Visitor\Visit {
 			'join'			=> xcallable($implode),
 			'implode'		=> xcallable($implode),
 			'trim'			=> xcallable('trim'),
-			'idnoUseCount'	=> xcallable('caIdnoUseCount')
+			'idnoUseCount'	=> xcallable('caIdnoUseCount'),
+			'dateIsRange'	=> xcallable('caDateIsRange')
 		);
 		return;
 	}
@@ -274,7 +275,6 @@ class ExpressionVisitor implements Visitor\Visit {
 
 			case '#comp_eq':
 				$va_children[0]->accept($this, $a, $f_eldnah);
-
 				$f_acc = function ($b) use ($a, $f_acc) {
 					return $f_acc($a() == $b);
 				};
@@ -442,7 +442,6 @@ class ExpressionVisitor implements Visitor\Visit {
 				$value = $po_element->getValueValue();
 				$token = $po_element->getValueToken();
 				$out = null;
-
 				
 				switch($token) {
 					case 'id':
@@ -461,6 +460,12 @@ class ExpressionVisitor implements Visitor\Visit {
 						$vs_var = mb_substr((string) $value, 1); // get rid of caret ^
 						$out = $this->getVariable($vs_var);
 						if(is_array($out)) { $out = join("", $out); }	// we need to join multiple values
+						break;
+					case 'true':
+						$out = true;
+						break;
+					case 'false':
+						$out = false;
 						break;
 					default:
 						$out = (float) $value;


### PR DESCRIPTION
• Add boolean literals to simplify testing of function return values
• Add isDateRange() function to test whether a date is single or a range (useful for EAD, where single dates are handled differently than ranges)