### PR TITLE
PROV-2914 Add new importer options for "parents"

### DIFF
--- a/app/lib/IDNumbering/MultipartIDNumber.php
+++ b/app/lib/IDNumbering/MultipartIDNumber.php
@@ -321,7 +321,7 @@ class MultipartIDNumber extends IDNumber {
 	 *
 	 * @return array An array of element information arrays, of the same format as returned by getElementInfo(), or null if the format and type are not set
 	 */
-	private function getElements() {
+	public function getElements() {
 		if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 			if (is_array($this->opa_formats[$vs_format][$vs_type]['elements'])) {
 				$vb_is_child = $this->isChild();
@@ -342,7 +342,7 @@ class MultipartIDNumber extends IDNumber {
 	 * @param string $ps_element_name The element to return information for
 	 * @return array An array of information with the same keys as in multipart_id_numbering.conf, or null if the element does not exist
 	 */
-	private function getElementInfo($ps_element_name) {
+	public function getElementInfo($ps_element_name) {
 		if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 			return $this->opa_formats[$vs_format][$vs_type]['elements'][$ps_element_name];
 		}

--- a/app/lib/IDNumbering/SMFMultipartIDNumber.php
+++ b/app/lib/IDNumbering/SMFMultipartIDNumber.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2007-2018 Whirl-i-Gig
+ * Copyright 2007-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -205,7 +205,7 @@
 		# -------------------------------------------------------
 		# Elements
 		# -------------------------------------------------------
-		private function getElements() {
+		public function getElements() {
 			if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 				if (is_array($this->opa_formats[$vs_format][$vs_type]['elements'])) {
 					$vb_is_child = $this->isChild();
@@ -220,7 +220,7 @@
 			return null;
 		}
 		# -------------------------------------------------------
-		private function getElementInfo($ps_element_name) {
+		public function getElementInfo($ps_element_name) {
 			if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 				return $this->opa_formats[$vs_format][$vs_type]['elements'][$ps_element_name];
 			}

--- a/app/lib/IDNumbering/UUIDNumber.php
+++ b/app/lib/IDNumbering/UUIDNumber.php
@@ -95,7 +95,7 @@
 		# -------------------------------------------------------
 		# Elements
 		# -------------------------------------------------------
-		private function getElements() {
+		public function getElements() {
 			if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 				if (is_array($this->opa_formats[$vs_format][$vs_type]['elements'])) {
 					$vb_is_child = $this->isChild();
@@ -110,7 +110,7 @@
 			return null;
 		}
 		# -------------------------------------------------------
-		private function getElementInfo($ps_element_name) {
+		public function getElementInfo($ps_element_name) {
 			if (($vs_format = $this->getFormat()) && ($vs_type = $this->getType())) {
 				return $this->opa_formats[$vs_format][$vs_type]['elements'][$ps_element_name];
 			}


### PR DESCRIPTION
To improve import of hierarchies where the numbering scheme reflects the hierarchical structure (common when dealing with collection-level records), this PR adds the following options:

1. "normalize": provides normalization of numbers such that an abbreviated number in the data source is intelligently padded out to full length. Eg. If the numbering scheme for a folder-level collection record is 6 numbers (Ex. 2020.5.3.3.8.1), the last of which is auto-generated, but the data fewer numbers (Ex. 2020.5.3.3), this option will pad out the "missing" numbers with 1's. Thus 2020.5.3.3.% in the mapping becomes 2020.5.3.3.1.% for import. (This sort of mismatched data is occurring in Riverside, for example). This option should require explicit activation in the mapping – by default is should be disabled.

2. A way to include the idno generated for an entry in the "parents" mapping in the mapping for its direct child. This will simplify import of cascading hierarchical identifiers where some of the identifier is inferred from context rather than directly mapped from source data. The value is be accessible via a placeholder tag (Eg. ^PARENT_IDNO)

3. A way to access the idno generated at any level of the "parents" mapping above the level of the mapping currently being evaluated (Eg. the identifiers generated for any parent of the currently processed parent entry). These are be numbered from one (where one is the highest level of the hierarchy) and exposed as placeholder tags (EG. ^LEVEL_1, ^LEVEL_2)

4. "prefix": an option to prefix the imported idno values for a parent entry with a value only when the idno value is non-empty. This allows us to prefix all entries of the parent hierarchy with a value will still skipping any empty levels.
