### PR TITLE
PROV-2914 Add PARENT_IDNO tag support to generic splitter

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -706,6 +706,7 @@
 	 */
 	function caGenericImportSplitter($ps_refinery_name, $ps_item_prefix, $ps_table, $po_refinery_instance, &$pa_destination_data, $pa_group, $pa_item, $pa_source_data, $pa_options) {
 		global $g_ui_locale_id;
+		$pa_source_data['PARENT_IDNO'] = '';
 		
 		$po_refinery_instance->setReturnsMultipleValues(true);
 		
@@ -911,6 +912,8 @@
 							if (isset($pa_options['defaultParentID']) && (!isset($va_val['parent_id']) || !$va_val['parent_id'])) {
 								$va_val['parent_id'] = $va_val['_parent_id'] = $pa_options['defaultParentID'];
 							}
+							
+							$pa_source_data['PARENT_IDNO'] = $va_val['parent_id'] ? $ps_table::getIdnoForId($va_val['parent_id'], ['transaction' => $o_trans]) : 'o_trans';
 						}
 				
 						if(isset($pa_options['hierarchyID']) && $pa_options['hierarchyID'] && ($vs_hier_id_fld = $t_instance->getProperty('HIERARCHY_ID_FLD'))) {

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -11403,12 +11403,14 @@ $pa_options["display_form_field_tips"] = true;
 	 * @param int $pn_id Primary key value
 	 * @param array $pa_options Options include:
 	 *      checkAccess = Array of access values to filter returned values on. If omitted no filtering is performed. [Default is null]
+	 *		transaction = optional Transaction instance. If set then all database access is done within the context of the transaction
 	 *
 	 * @return string idno value, null if id does not exist or false if id exists but fails checkAccess checks
 	 */
 	public static function getIdnoForID($pn_id, $pa_options=null) {
+		$o_trans = caGetOption('transaction', $pa_options, null);
 		if (($t_instance = Datamodel::getInstance(static::class, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
-			$o_db = new Db();
+			$o_db = $o_trans ? $o_trans->getDb() : new Db();
 			$qr_res = $o_db->query("SELECT {$vs_idno_fld} FROM ".$t_instance->tableName()." WHERE ".$t_instance->primaryKey()." = ?", [(int)$pn_id]);
 			
 			$pa_check_access = caGetOption('checkAccess', $pa_options, null);
@@ -11426,12 +11428,14 @@ $pa_options["display_form_field_tips"] = true;
 	 * @param string $ps_idno Identifier value
 	 * @param array $pa_options Options include:
 	 *      checkAccess = Array of access values to filter returned values on. If omitted no filtering is performed. [Default is null]
+	 *		transaction = optional Transaction instance. If set then all database access is done within the context of the transaction
 	 *
 	 * @return int primary key id value, null if idno does not exist or false if id exists but fails checkAccess checks
 	 */
 	public static function getIDForIdno($ps_idno, $pa_options=null) {
+		$o_trans = caGetOption('transaction', $pa_options, null);
 		if (($t_instance = Datamodel::getInstance(static::class, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
-			$o_db = new Db();
+			$o_db = $o_trans ? $o_trans->getDb() : new Db();
 			$vs_pk = $t_instance->primaryKey();
 			$qr_res = $o_db->query("SELECT {$vs_pk} FROM ".$t_instance->tableName()." WHERE {$vs_idno_fld} = ?", [$ps_idno]);
 			


### PR DESCRIPTION
Change allows use of ^PARENT_IDNO in splitter "attributes" blocks when used in conjunction with "parents" block. ^PARENT_IDNO will be set to the lowest-level record created in the "parents" block.