### PR TITLE
PROV-2917 Use user preferred locale when parsing dates

### DIFF
--- a/app/lib/Attributes/Values/DateRangeAttributeValue.php
+++ b/app/lib/Attributes/Values/DateRangeAttributeValue.php
@@ -256,8 +256,12 @@
  			parent::__construct($pa_value_array);
  			if(!DateRangeAttributeValue::$o_tep) { 
  				self::$locale = __CA_DEFAULT_LOCALE__;
- 				if ($g_request && method_exists($g_request, "isLoggedIn") && $g_request->isLoggedIn()) {
- 					self::$locale = $g_request->user->getPreference('ui_locale');
+ 				if (	$g_request &&
+ 					 	method_exists($g_request, "isLoggedIn") && 
+ 						$g_request->isLoggedIn() && 
+ 						($preferred_locale = trim($g_request->user->getPreference('ui_locale'))) 
+ 				) {
+ 					self::$locale = $preferred_locale;
  				}
  				DateRangeAttributeValue::$o_tep = new TimeExpressionParser(); 
  				DateRangeAttributeValue::$o_tep->setLanguage(self::$locale);

--- a/assets/jquery/jquery-ui/i18n/jquery.ui.datepicker-nl_BE.js
+++ b/assets/jquery/jquery-ui/i18n/jquery.ui.datepicker-nl_BE.js
@@ -1,0 +1,23 @@
+﻿/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Written by Mathias Bynens <http://mathiasbynens.be/> */
+jQuery(function($){
+	$.datepicker.regional['nl'] = {
+		closeText: 'Sluiten',
+		prevText: '←',
+		nextText: '→',
+		currentText: 'Vandaag',
+		monthNames: ['januari', 'februari', 'maart', 'april', 'mei', 'juni',
+		'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
+		monthNamesShort: ['jan', 'feb', 'maa', 'apr', 'mei', 'jun',
+		'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
+		dayNames: ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
+		dayNamesShort: ['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
+		dayNamesMin: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+		weekHeader: 'Wk',
+		dateFormat: 'dd-mm-yy',
+		firstDay: 1,
+		isRTL: false,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['nl']);
+});


### PR DESCRIPTION
• Use user preferred locale when parsing dates, falling back to default locale when required. Previous behavior was to use the system default locale in all cases.
• Add date picker translation for Flemish
