### PR TITLE
NOJIRA Test params to value to avoid cache errors

### DIFF
--- a/app/lib/Media.php
+++ b/app/lib/Media.php
@@ -506,6 +506,7 @@ class Media extends BaseObject {
 	 * @return string Mimetype or null if extension is not recognized.
 	 */
 	public static function getMimetypeForExtension($ps_extension) {
+		if(!$ps_extension) { return null; }
 		if (CompositeCache::contains($ps_extension, 'Media_getMimetypeForExtension')) {
 			return CompositeCache::fetch($ps_extension, 'Media_getMimetypeForExtension');
 		}
@@ -531,6 +532,7 @@ class Media extends BaseObject {
 	 * @return string File extension or null if mimetype is not recognized.
 	 */
 	public static function getExtensionForMimetype($ps_mimetype) {
+		if(!$ps_mimetype) { return null; }
 		if (CompositeCache::contains($ps_mimetype, 'Media_getExtensionForMimetype')) {
 			return CompositeCache::fetch($ps_mimetype, 'Media_getExtensionForMimetype');
 		}
@@ -553,6 +555,7 @@ class Media extends BaseObject {
 	 * @return string Type name or null if mimetype is not recognized.
 	 */
 	public static function getTypenameForMimetype($ps_mimetype) {
+		if(!$ps_mimetype) { return null; }
 		if (CompositeCache::contains($ps_mimetype, "Media_getTypenameForMimetype")) {
 			return CompositeCache::fetch($ps_mimetype, "Media_getTypenameForMimetype");
 		}


### PR DESCRIPTION
In cases where the file mimetype or extension values are null the caching library will throw an exception. This change catches those null invocations and returns null without attempting to access the cache.