### PR TITLE
NOJIRA increase field size to avoid spacing issues

### DIFF
--- a/app/conf/annotation_types.conf
+++ b/app/conf/annotation_types.conf
@@ -11,7 +11,7 @@ types = {
 				displayType = DT_FIELD,
 				label = _("Start"),
 				description = _("Timecode of start point in hh:mm:ss:ff format (where hh=hours; mm=minutes; ss=seconds and ff=frames. You may use decimal seconds in lieu of frames if desired."),
-				fieldWidth = 8,
+				fieldWidth = 20,
 				fieldHeight = 1
 			},
 			endTimecode = {
@@ -19,7 +19,7 @@ types = {
 				displayType = DT_FIELD,
 				label = _("End"),
 				description = _("Timecode of end point in hh:mm:ss:ff format (where hh=hours; mm=minutes; ss=seconds and ff=frames. You may use decimal seconds in lieu of frames if desired."),
-				fieldWidth = 8,
+				fieldWidth = 20,
 				fieldHeight = 1
 			}
 		}
@@ -36,7 +36,7 @@ types = {
 				displayType = DT_FIELD,
 				label = _("Start"),
 				description = _("Timecode of start point in hh:mm:ss:ff format (where hh=hours; mm=minutes; ss=seconds and ff=frames. You may use decimal seconds in lieu of frames if desired."),
-				fieldWidth = 8,
+				fieldWidth = 20,
 				fieldHeight = 1
 			},
 			endTimecode = {
@@ -44,7 +44,7 @@ types = {
 				displayType = DT_FIELD,
 				label = _("End"),
 				description = _("Timecode of end point in hh:mm:ss:ff format (where hh=hours; mm=minutes; ss=seconds and ff=frames. You may use decimal seconds in lieu of frames if desired."),
-				fieldWidth = 8,
+				fieldWidth = 20,
 				fieldHeight = 1
 			}
 		}


### PR DESCRIPTION
The annotation editor fields for start and end time code used for time-based media were too small for most timecode. This commit increases the field size to a comfortable width.