### PR TITLE
PROV-2919 Use EXIFTOOL to extract metadata from Office files

### DIFF
--- a/app/lib/Plugins/Media/Office.php
+++ b/app/lib/Plugins/Media/Office.php
@@ -406,6 +406,7 @@ class WLPlugMediaOffice Extends BaseMediaPlugin Implements IWLPlugMedia {
 			}
 		}
 		$this->filepath = $ps_filepath;
+		$this->opa_metadata = caExtractMetadataWithExifTool($ps_filepath);
 		
 		// Hardcode width/height since we haven't any way of calculating these short of generating a PDF
 		$this->set('width', 612);


### PR DESCRIPTION
Embedded metadata is not extracted from Office (Word, Excel or Powerpoint) files when uploaded as media. This PR adds support for running Exiftool over these files.