### PR TITLE
change guzzle query request array

### DIFF
--- a/app/lib/Plugins/InformationService/VIAF.php
+++ b/app/lib/Plugins/InformationService/VIAF.php
@@ -80,7 +80,7 @@ class WLPlugInformationServiceVIAF extends BaseInformationServicePlugin implemen
             'headers' => [
                 'Accept' => 'application/json'
             ],
-            ['query' => "'".$ps_search."'"]
+            'query' => ['query'=>$ps_search]
         ]);
         #$vo_request->setHeader('Accept', 'application/json');
         #$vo_request->getQuery()->add('query', "'".$ps_search."'");


### PR DESCRIPTION
Hi,
the query parameter for this guzzle request to viaf was set in a separate array and should be nested in the options array. 
The old code resulted in a 500 error at VIAF, now results in the resultset by VIAF