### PR TITLE
PROV-2869 Add detailed field-level logging

### DIFF
--- a/app/helpers/logHelpers.php
+++ b/app/helpers/logHelpers.php
@@ -76,6 +76,14 @@
 	 * @throws ApplicationException
 	 */
 	function caGetLogger($options=null, $opt_name=null) {
+		$log_dir = caGetLogPath($options, $opt_name);
+		return new KLogger($log_dir, caLogLevelStringToNumber(caGetOption('logLevel', $options, 'INFO')), caGetOption('logName', $options, null));
+	}
+	# ---------------------------------------
+	/**
+	 *
+	 */
+	function caGetLogPath($options=null, $opt_name=null) {
 		$config = Configuration::load();
 		if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $config->get($opt_name)))) {
 			$log_dir = '.';
@@ -91,12 +99,7 @@
 				throw new ApplicationException(_t("Cannot write log to %1 or temporary directory %2. Please check directory permissions and retry.", $log_dir, $tmp_dir));
 			}
 		}
-		
-		$log = new KLogger($log_dir, caLogLevelStringToNumber(caGetOption('logLevel', $options, 'INFO')), caGetOption('logName', $options, null));
-		if ($log_dir !== $orig_log_dir) {
-			$log->logInfo(_t('Logging to temporary directory %1 because configured log directory %2 is not writeable', $log_dir, $orig_log_dir));
-		}
-		return $log;
+		return $log_dir;
 	}
 	# ---------------------------------------
 	/**

--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -454,6 +454,8 @@
 			$vb_direct = (bool)$po_opts->getOption('direct');
 			$vb_no_search_indexing = (bool)$po_opts->getOption('no-search-indexing');
 			$vb_use_temp_directory_for_logs_as_fallback = (bool)$po_opts->getOption('log-to-tmp-directory-as-fallback');
+			
+			$vs_detailed_log_name = (string)$po_opts->getOption('detailed-log-name');
 
 			$vb_dryrun = (bool)$po_opts->getOption('dryrun');
 			$vs_format = $po_opts->getOption('format');
@@ -465,7 +467,16 @@
 				define("__CA_DONT_DO_SEARCH_INDEXING__", true);
 			}
 
-			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, array('dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 'format' => $vs_format, 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 'limitLogTo' => $po_opts->getOption('limit-log-to'), 'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 'addToSet' => $vs_add_to_set, 'environment' => $env))) {
+			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, 
+				[	'dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 
+					'format' => $vs_format, 'showCLIProgressBar' => true, 
+					'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 
+					'limitLogTo' => $po_opts->getOption('limit-log-to'), 
+					'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 
+					'addToSet' => $vs_add_to_set, 'environment' => $env,
+					'detailedLogName' => $vs_detailed_log_name
+				]
+			)) {
 				CLIUtils::addError(_t("Could not import source %1: %2", $vs_data_source, join("; ", ca_data_importers::getErrorList())));
 				return false;
 			} else {
@@ -490,7 +501,8 @@
 				"dryrun" => _t('If set import is performed without data actually being saved to the database. This is useful for previewing an import for errors.'),
 				"direct" => _t('If set import is performed without a transaction. This allows viewing of imported data during the import, which may be useful during debugging/development. It may also lead to data corruption and should only be used for testing.'),
 				"no-search-indexing" => _t('If set indexing of changes made during import is not done. This may significantly reduce import time, but will neccessitate a reindex of the entire database after the import.'),
-				"log-to-tmp-directory-as-fallback" => _t('Use the system temporary directory for the import log if the application logging directory is not writable. Default report an error if the application log directory is not writeable.')
+				"log-to-tmp-directory-as-fallback" => _t('Use the system temporary directory for the import log if the application logging directory is not writable. Default report an error if the application log directory is not writeable.'),
+				"detailed-log-name" => _t('Name to use for detailed field-level error log. By default these log files are named with the date and code for the import mapping.')
 			);
 		}
 		# -------------------------------------------------------


### PR DESCRIPTION
Add Excel-based detailed logging of field-level import errors. Errors are broken out by field, with each field with errors having its own worksheet. Error output includes date/time of error, row in data set, idno of record being imported, error message, values that caused error and, in some cases, additional notes.