### PR TITLE
NOJIRA Change search indexing load increment size to 100

### DIFF
--- a/app/models/ca_search_indexing_queue.php
+++ b/app/models/ca_search_indexing_queue.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015-2018 Whirl-i-Gig
+ * Copyright 2015-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -257,7 +257,7 @@ class ca_search_indexing_queue extends BaseModel {
 			
 			do {
 				$num_entries = 0;
-				if ($o_result = $o_db->query("SELECT * FROM ca_search_indexing_queue WHERE started_on IS NULL ORDER BY entry_id LIMIT 1000")) {
+				if ($o_result = $o_db->query("SELECT * FROM ca_search_indexing_queue WHERE started_on IS NULL ORDER BY entry_id LIMIT 100")) {
 					$num_entries = (int)$o_result->numRows();
 					if($num_entries > 0) {
 						$o_si = new SearchIndexer($o_db);


### PR DESCRIPTION
Change load size for search indexing queue to maximum 100 indexes, from 1000.  This helps to avoid MySQL query failures on some systems due to memory exhaustion.