### PR TITLE
PROV-2869 Improve detailed logging

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -4105,6 +4105,7 @@ if (!$vb_batch) {
 							} else {
 								$bundles_to_save = caGetOption('showBundlesForEditing', $va_bundle_settings, [], ['castTo' => 'array']);
 							}
+							if(!in_array('is_primary', $bundles_to_save)) { $bundles_to_save[] = 'is_primary'; }
 							$bundles_on_screen_proc = array_map(function($v) { return array_pop(explode('.', $v)); }, $bundles_to_save);
 							foreach($va_reps as $vn_i => $va_rep) {
 								$this->clearErrors();
@@ -4125,8 +4126,8 @@ if (!$vb_batch) {
                                 	if(is_array($bundles_to_save)) {
                                    		foreach($bundles_to_save as $b) {
                                    			$f = array_pop(explode('.', $b));
-                                   			if ($v = $po_request->getParameter($vs_prefix_stub.$f.'_'.$va_rep['relation_id'], pString)) {
-                                   				$vals[$f] = $v;
+                                   			if (!is_null($po_request->parameterExists($vs_prefix_stub.$f.'_'.$va_rep['relation_id']))) {
+                                   				$vals[$f] = $po_request->getParameter($vs_prefix_stub.$f.'_'.$va_rep['relation_id'], pString);
                                    			} 
                                    		}
                                 	}

--- a/app/lib/Controller/Request/RequestHTTP.php
+++ b/app/lib/Controller/Request/RequestHTTP.php
@@ -537,7 +537,7 @@ class RequestHTTP extends Request {
 				$vm_val = $this->opa_params[$ps_http_method][$ps_name];
 			} else {
 				foreach(array('GET', 'POST', 'PATH', 'COOKIE', 'REQUEST') as $http_method) {
-					$vm_val = (isset($this->opa_params[$http_method]) && isset($this->opa_params[$http_method][$ps_name])) ? $this->opa_params[$http_method][$ps_name] : null;
+					$vm_val = (array_key_exists($http_method, $this->opa_params) && array_key_exists($ps_name, $this->opa_params[$http_method])) ? $this->opa_params[$http_method][$ps_name] : null;
 					if (isset($vm_val)) {
 						break;
 					}


### PR DESCRIPTION
Improvements to detailed logging of field-level errors in data importer:

• Refactor stop-on-error handling
• Don't write detailed log when no errors occur, as the result is an invalid Excel file
• Add missing parameter when formatting values for log