### PR TITLE
PROV-2869 Improve detailed logging content; use CSV as detailed log format

### DIFF
--- a/app/lib/Attributes/Values/ListAttributeValue.php
+++ b/app/lib/Attributes/Values/ListAttributeValue.php
@@ -427,7 +427,14 @@ class ListAttributeValue extends AuthorityAttributeValue implements IAttributeVa
 		}
 		
 		if ((!$vn_id) && ($o_log = caGetOption('log', $pa_options, null)) && (strlen($ps_value) > 0)) {
-			$o_log->logError(_t('Value %1 was not set for %2 because it does not exist in list %3', $ps_value, caGetOption('logReference', $pa_options, '???'), caGetListCode($pa_element_info['list_id'])));
+			$o_log->logError(_t('Value %1 was not set for %2 because it does not exist in list %3', $ps_value, caGetOption('logReference', $pa_options, '???'), caGetListCode($pa_element_info['list_id'])), 
+				[	'bundle' => $pa_element_info['element_code'], 
+					'values' => $ps_value, 
+					'dataset' => caGetOption('dataset', $pa_options, null),
+					'idno' => caGetOption('idno', $pa_options, null),
+					'row' => caGetOption('row', $pa_options, null),
+					'notes' => caGetOption('notes', $pa_options, null)
+				]);
 		}
 		
 		if (!$vb_require_value && !$vn_id) {

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -1128,7 +1128,9 @@
 						$format = $t_mapping->getSetting('inputFormats');
 						if(is_array($format)) { $format = array_shift($format); }
 						if ($o_log) { $o_log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-						ca_data_importers::importDataFromSource($vs_directory.'/'.$f, $vn_mapping_id, ['logLevel' => $o_config->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_instance->getPrimaryKey()]]); 
+						
+						$t_importer = new ca_data_importers();
+						$t_importer->importDataFromSource($vs_directory.'/'.$f, $vn_mapping_id, ['logLevel' => $o_config->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_instance->getPrimaryKey()]]); 
 					}
 					
 					
@@ -1149,7 +1151,9 @@
 						$format = $t_mapping->getSetting('inputFormats');
 						if(is_array($format)) { $format = array_shift($format); }
 						if ($o_log) { $o_log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-						ca_data_importers::importDataFromSource($vs_directory.'/'.$f, $vn_object_representation_mapping_id, ['logLevel' => $o_config->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_new_rep->getPrimaryKey()]]); 
+						
+						$t_importer = new ca_data_importers();
+						$t_importer->importDataFromSource($vs_directory.'/'.$f, $vn_object_representation_mapping_id, ['logLevel' => $o_config->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_new_rep->getPrimaryKey()]]); 
 					}
 
 					$va_notices[$t_instance->getPrimaryKey()] = array(
@@ -1367,7 +1371,8 @@
 			$vn_file_num = 0;
 			foreach($va_sources as $vs_source) {
 				$vn_file_num++;
-				if (!ca_data_importers::importDataFromSource($vs_source, $ps_importer, array('originalFilename' => caGetOption('originalFilename', $pa_options, null), 'fileNumber' => $vn_file_num, 'numberOfFiles' => sizeof($va_sources), 'logDirectory' => $o_config->get('batch_metadata_import_log_directory'), 'request' => $po_request,'format' => $ps_input_format, 'showCLIProgressBar' => false, 'useNcurses' => false, 'progressCallback' => isset($pa_options['progressCallback']) ? $pa_options['progressCallback'] : null, 'reportCallback' => isset($pa_options['reportCallback']) ? $pa_options['reportCallback'] : null,  'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level, 'limitLogTo' => $limit_log_to, 'dryRun' => $vb_dry_run, 'importAllDatasets' => $vb_import_all_datasets))) {
+				$t_importer = new ca_data_importers();
+				if (!$t_importer->importDataFromSource($vs_source, $ps_importer, array('originalFilename' => caGetOption('originalFilename', $pa_options, null), 'fileNumber' => $vn_file_num, 'numberOfFiles' => sizeof($va_sources), 'logDirectory' => $o_config->get('batch_metadata_import_log_directory'), 'request' => $po_request,'format' => $ps_input_format, 'showCLIProgressBar' => false, 'useNcurses' => false, 'progressCallback' => isset($pa_options['progressCallback']) ? $pa_options['progressCallback'] : null, 'reportCallback' => isset($pa_options['reportCallback']) ? $pa_options['reportCallback'] : null,  'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level, 'limitLogTo' => $limit_log_to, 'dryRun' => $vb_dry_run, 'importAllDatasets' => $vb_import_all_datasets))) {
 					$va_errors['general'][] = array(
 						'idno' => "*",
 						'label' => "*",

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -203,9 +203,8 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 					} else {
 						// is root
 						$va_type_list = $this->getTypeList(array('directChildrenOnly' => true, 'item_id' => null));
-						if (!isset($va_type_list[$this->getTypeID()])) {
+						if (!isset($va_type_list[$this->getTypeID()]) && ($t = $this->getTypeInstance())) {
 							// if all ancestors for type are not enabled then we can allow this type even in strict mode
-							$t = $this->getTypeInstance();
 							$ancestors = $t->getHierarchyAncestors(null, ['includeSelf' => false]);
 							if (sizeof(array_filter($ancestors, function($v) {
 								return (!is_null($v['NODE']['parent_id']) && (bool)$v['NODE']['is_enabled']);
@@ -4180,7 +4179,9 @@ if (!$vb_batch) {
 											$format = $t_mapping->getSetting('inputFormats');
 											if(is_array($format)) { $format = array_shift($format); }
 											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-											ca_data_importers::importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
+											
+											$t_importer = new ca_data_importers();
+											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
 										}
 									}
 									
@@ -4357,7 +4358,9 @@ if (!$vb_batch) {
 											$format = $t_mapping->getSetting('inputFormats');
 											if(is_array($format)) { $format = array_shift($format); }
 											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-											ca_data_importers::importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
+											
+											$t_importer = new ca_data_importers();
+											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
 										}
                                     }
                                 }

--- a/app/lib/Utils/CLIUtils/Configuration.php
+++ b/app/lib/Utils/CLIUtils/Configuration.php
@@ -179,7 +179,6 @@
 				"admin-email|e=s" => _t('Email address of the system administrator (user@domain.tld).'),
 				"overwrite" => _t('Flag must be set in order to overwrite an existing installation.  Also, the __CA_ALLOW_INSTALLER_TO_OVERWRITE_EXISTING_INSTALLS__ global must be set to a true value.'),
 				"debug|d" => _t('Debug flag for installer.'),
-				"quiet|q" => _t('Suppress progress messages.'),
 				"skip-roles|s" => _t('Skip Roles. Default is false, but if you have many roles and access control enabled then install may take some time')
 			);
 		}

--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -455,7 +455,7 @@
 			$vb_no_search_indexing = (bool)$po_opts->getOption('no-search-indexing');
 			$vb_use_temp_directory_for_logs_as_fallback = (bool)$po_opts->getOption('log-to-tmp-directory-as-fallback');
 			
-			$vs_detailed_log_name = (string)$po_opts->getOption('detailed-log-name');
+			$vs_detailed_log_name = $po_opts->getOption('detailed-log-name');
 
 			$vb_dryrun = (bool)$po_opts->getOption('dryrun');
 			$vs_format = $po_opts->getOption('format');
@@ -467,7 +467,8 @@
 				define("__CA_DONT_DO_SEARCH_INDEXING__", true);
 			}
 
-			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, 
+			$t_importer = new ca_data_importers();
+			if (!$t_importer->importDataFromSource($vs_data_source, $vs_mapping, 
 				[	'dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 
 					'format' => $vs_format, 'showCLIProgressBar' => true, 
 					'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 

--- a/app/lib/Utils/CLIUtils/Maintenance.php
+++ b/app/lib/Utils/CLIUtils/Maintenance.php
@@ -1459,7 +1459,8 @@
 				$va_sources[] = $vs_source;
 			}
 
-			ca_data_importers::importDataFromSource(join(',', $va_sources), $vs_mapping, array('format' => 'ULAN', 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level));
+			$t_importer = new ca_data_importers();
+			$t_importer->importDataFromSource(join(',', $va_sources), $vs_mapping, array('format' => 'ULAN', 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level));
 
 			return true;
 		}

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -225,13 +225,28 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	public $SETTINGS;
 	
 	
+	/**
+	 * Number of errors for current import
+	 */
 	public $num_import_errors = 0;
+	
+	/**
+	 * Number of record processed by current import
+	 */
 	public $num_records_processed = 0;
+	
+	/**
+	 * Number of records skipped in current import
+	 */
 	public $num_records_skipped = 0;
+	
+	/**
+	 * List of error message for current import
+	 */
 	public $import_error_list = [];
 	
 	/** 
-	 *
+	 * KLogger instance for import log
 	 */
 	private $log = null;
 	
@@ -241,12 +256,12 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	private $detlog = [];
 	
 	/**
-	 * Path to 
+	 * Path to import log
 	 */
 	private $log_path;
 	
 	/**
-	 *
+	 * Name to use for detailed log
 	 */
 	private $detailed_log_name;
 	
@@ -1170,7 +1185,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	}
 	# ------------------------------------------------------
 	/**
-	 *
+	 * Alias for ca_data_importers::logImportError
 	 */
 	public function logError($ps_message, $pa_options=null) {
 		return $this->logImportError($ps_message, $pa_options);
@@ -3321,7 +3336,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	 *
 	 * @return array
 	 */
-	public static function getErrorList() {
+	public function getErrorList() {
 		return $this->import_error_list;
 	}
 	# ------------------------------------------------------
@@ -3520,7 +3535,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	}
 	# ------------------------------------------------------
 	/**
+	 * Close open log files
 	 * 
+	 * return void
 	 */
 	private function _closeLogs() {
 		if(is_array($this->detlog)) {

--- a/app/plugins/ResourceSpace/controllers/ImportController.php
+++ b/app/plugins/ResourceSpace/controllers/ImportController.php
@@ -134,7 +134,8 @@
  			$o_progress->setMode('WebUI');
  			$o_progress->setTotal(sizeof($pa_resourcespace_ids));
 
- 			$vn_status = ca_data_importers::importDataFromSource($pa_resourcespace_ids, $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'resourcespace', 'logLevel' => $pn_log_level));
+			$t_importer = new ca_data_importers();
+ 			$vn_status = $t_importer->importDataFromSource($pa_resourcespace_ids, $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'resourcespace', 'logLevel' => $pn_log_level));
 
  			$va_job_info = $o_progress->getDataForJobID($ps_job_id);
 

--- a/app/plugins/ULAN/controllers/ImportController.php
+++ b/app/plugins/ULAN/controllers/ImportController.php
@@ -124,7 +124,8 @@ class ImportController extends ActionController {
 		$o_progress->setMode('WebUI');
 		$o_progress->setTotal(sizeof($pa_ulan_ids));
 
-		$vn_status = ca_data_importers::importDataFromSource(join(",", $pa_ulan_ids), $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'ULAN', 'logLevel' => $pn_log_level));
+		$t_importer = new ca_data_importers();
+		$vn_status = $t_importer->importDataFromSource(join(",", $pa_ulan_ids), $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'ULAN', 'logLevel' => $pn_log_level));
 
 		$this->view->setVar('info', array(
 			'status' => $vn_status,

--- a/app/plugins/WorldCat/controllers/ImportController.php
+++ b/app/plugins/WorldCat/controllers/ImportController.php
@@ -120,7 +120,8 @@
  			$o_progress->setMode('WebUI');
  			$o_progress->setTotal(sizeof($pa_worldcat_ids));
  			
- 			$vn_status = ca_data_importers::importDataFromSource(join(",", $pa_worldcat_ids), $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'WorldCat', 'logLevel' => $pn_log_level));
+			$t_importer = new ca_data_importers();
+ 			$vn_status = $t_importer->importDataFromSource(join(",", $pa_worldcat_ids), $pn_importer_id, array('progressBar' => $o_progress, 'format' => 'WorldCat', 'logLevel' => $pn_log_level));
  		
  			$va_job_info = $o_progress->getDataForJobID($ps_job_id);
  			

--- a/support/bin/caUtils
+++ b/support/bin/caUtils
@@ -84,6 +84,7 @@
 	$va_available_cli_opts = array_merge(array(
 			"hostname-s" => 'Hostname of installation. If omitted default installation is used.',
 			"setup-s" => 'Specify the path to an alternate setup.php.',
+			"quiet" => 'Do not emit headers and copyright information.'
 		), $va_command_opts);
 
 	try {
@@ -95,10 +96,12 @@
 	if ($vs_hostname = $o_opts->getOption('hostname')) {
 		$_SERVER['HTTP_HOST'] = $vs_hostname;
 	}
+	
+	$quiet = (bool)$o_opts->getOption('quiet');
 
 	$va_args = $o_opts->getRemainingArgs();
 
-	$vs_app_heading = CLIUtils::textWithColor(_t("CollectiveAccess %1 (%2/%3) Utilities\n(c) 2013-2020 Whirl-i-Gig",__CollectiveAccess__, __CollectiveAccess_Schema_Rev__, __CollectiveAccess_Release_Type__), "bold_blue")."\n\n";
+	$vs_app_heading = $quiet ? '' : CLIUtils::textWithColor(_t("CollectiveAccess %1 (%2/%3) Utilities\n(c) 2013-2020 Whirl-i-Gig",__CollectiveAccess__, __CollectiveAccess_Schema_Rev__, __CollectiveAccess_Release_Type__), "bold_blue")."\n\n";
 
 	print $vs_app_heading;
 


### PR DESCRIPTION
Improve detailed import logging:

• Use CSV as detailed log format as XLSX causes performance and memory issues
• Log attribute set()-level errors (a prime use-case for detailed logging)
• Convert primary import method from static to instance to simplify access to logging instances

These changes are precursors to a much-needed significant refactoring of the data importer.