### PR TITLE
NOJIRA Smaller default for max_indexing_buffer_size (5000) 

### DIFF
--- a/app/conf/search.conf
+++ b/app/conf/search.conf
@@ -13,7 +13,7 @@ cache_timeout = 0
 # indexing, excessive memory use or lost indexing trying reducing the value of 
 # this setting and then reindex.
 #
-max_indexing_buffer_size = 500000
+max_indexing_buffer_size = 5000
 
 # -------------------
 # SqlSearch plugin configuration


### PR DESCRIPTION
Help to avoid max-allowed-packet errors on some systems