### PR TITLE
NOJIRA When rewriting searches only apply rules configured for the current table

### DIFF
--- a/app/lib/Search/SearchEngine.php
+++ b/app/lib/Search/SearchEngine.php
@@ -177,17 +177,19 @@ class SearchEngine extends SearchBase {
 		
 		// apply query rewrites
 		if (is_array($va_rewrite_regexs = $this->opo_search_config->get('rewrite_regexes'))) {
-			if (isset($va_rewrite_regexs[$this->ops_tablename]) && is_array($va_rewrite_regexs[$this->ops_tablename])) { $va_rewrite_regexs = $va_rewrite_regexs[$this->ops_tablename]; }
-			foreach($va_rewrite_regexs as $vs_regex_name => $va_rewrite_regex) {
-				$ps_search = preg_replace("!".trim($va_rewrite_regex[0])."!", trim($va_rewrite_regex[1]), $ps_search);
+			if (isset($va_rewrite_regexs[$this->ops_tablename]) && is_array($va_rewrite_regexs[$this->ops_tablename])) { 
+				foreach($va_rewrite_regexs[$this->ops_tablename] as $vs_regex_name => $va_rewrite_regex) {
+					$ps_search = preg_replace("!".trim($va_rewrite_regex[0])."!", trim($va_rewrite_regex[1]), $ps_search);
+				}
 			}
 		}
 		
         if ((is_array($va_idno_regexs = $this->opo_search_config->get('idno_regexes'))) && (!preg_match("!".$this->ops_tablename.".{$vs_idno_fld}!", $ps_search))) {
-			if (isset($va_idno_regexs[$this->ops_tablename]) && is_array($va_idno_regexs[$this->ops_tablename])) { $va_idno_regexs = $va_idno_regexs[$this->ops_tablename]; }
-			foreach($va_idno_regexs as $vs_idno_regex) {
-				if ((preg_match("!{$vs_idno_regex}!", $ps_search, $va_matches)) && ($t_instance = Datamodel::getInstanceByTableName($this->ops_tablename, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
-					$ps_search = str_replace($va_matches[0], $this->ops_tablename.".{$vs_idno_fld}:\"".$va_matches[0]."\"", $ps_search);
+			if (isset($va_idno_regexs[$this->ops_tablename]) && is_array($va_idno_regexs[$this->ops_tablename])) { 
+				foreach($va_idno_regexs[$this->ops_tablename] as $vs_idno_regex) {
+					if ((preg_match("!{$vs_idno_regex}!", $ps_search, $va_matches)) && ($t_instance = Datamodel::getInstanceByTableName($this->ops_tablename, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
+						$ps_search = str_replace($va_matches[0], $this->ops_tablename.".{$vs_idno_fld}:\"".$va_matches[0]."\"", $ps_search);
+					}
 				}
 			}
 		}
@@ -301,7 +303,7 @@ class SearchEngine extends SearchBase {
 				$vb_do_acl = $this->opo_app_config->get('perform_item_level_access_checking') && method_exists($t_table, "supportsACL") && $t_table->supportsACL();
 
 				$o_res =  $this->opo_engine->search($this->opn_tablenum, $vs_search, $this->opa_result_filters, $o_rewritten_query);
-			
+				
 				// cache the results
 				$va_hits = $o_res->getPrimaryKeyValues($vb_do_acl ? null : $vn_limit);
 				
@@ -601,15 +603,16 @@ class SearchEngine extends SearchBase {
 		
 		// is it an idno?
 		if (is_array($va_idno_regexs = $this->opo_search_config->get('idno_regexes'))) {
-			if (isset($va_idno_regexs[$this->ops_tablename]) && is_array($va_idno_regexs[$this->ops_tablename])) { $va_idno_regexs = $va_idno_regexs[$this->ops_tablename]; }
-			foreach($va_idno_regexs as $vs_idno_regex) {
-				if ((preg_match("!{$vs_idno_regex}!", (string)$po_term->getTerm()->text, $va_matches)) && ($t_instance = Datamodel::getInstanceByTableName($this->ops_tablename, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
-					$vs_table_name = $t_instance->tableName();
-					return array(
-						'terms' => array(new Zend_Search_Lucene_Index_Term((string)((sizeof($va_matches) > 1) ? $va_matches[1] : $va_matches[0]), "{$vs_table_name}.{$vs_idno_fld}")),
-						'signs' => array($pb_sign),
-						'options' => array()
-					);
+			if (isset($va_idno_regexs[$this->ops_tablename]) && is_array($va_idno_regexs[$this->ops_tablename])) {
+				foreach($va_idno_regexs[$this->ops_tablename] as $vs_idno_regex) {
+					if ((preg_match("!{$vs_idno_regex}!", (string)$po_term->getTerm()->text, $va_matches)) && ($t_instance = Datamodel::getInstanceByTableName($this->ops_tablename, true)) && ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD'))) {
+						$vs_table_name = $t_instance->tableName();
+						return array(
+							'terms' => array(new Zend_Search_Lucene_Index_Term((string)((sizeof($va_matches) > 1) ? $va_matches[1] : $va_matches[0]), "{$vs_table_name}.{$vs_idno_fld}")),
+							'signs' => array($pb_sign),
+							'options' => array()
+						);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When applying rewrites the search engine will look for rules for the specific table, but fall back to applying any rule if no specific ones exist. This is generally undesirable and confusing, although there was a reason for it for one user way back when. This PR ensures that only specific rules are used, which is the general case.. 