### PR TITLE
Fix minor caUtils issues 

### DIFF
--- a/app/lib/Utils/CLIProgressBar.php
+++ b/app/lib/Utils/CLIProgressBar.php
@@ -227,8 +227,6 @@ class CLIProgressBar
         if (empty($options['total'])) {
             $options['total'] = 0;
         }
-        
-        self::$window =  $options['window'];
 
         self::$done = $options['done'];
         self::$format = $options['format'];

--- a/app/lib/Utils/CLIUtils/Media.php
+++ b/app/lib/Utils/CLIUtils/Media.php
@@ -269,7 +269,6 @@
 				"versions|v-s" => _t("Limit re-processing to specified versions. Separate multiple versions with commas."),
 				"log|L-s" => _t('Path to directory in which to log import details. If not set no logs will be recorded.'),
 				"log_level|d-s" => _t('Logging threshold. Possible values are, in ascending order of important: DEBUG, INFO, NOTICE, WARN, ERR, CRIT, ALERT. Default is INFO.'),
-				"quiet|q" => _t('Suppress progress messages.'),
 				"start_id|s-n" => _t('Representation id to start reloading at'),
 				"end_id|e-n" => _t('Representation id to end reloading at'),
 				"id|i-n" => _t('Representation id to reload'),


### PR DESCRIPTION
PR addresses two issues raised by recent changes:

• Remove extra declaration of "quiet" option on reprocess-media
• Remove reference to old nurses window