### PR TITLE
PROV-2892 Improvements to external export system

### DIFF
--- a/app/lib/ExternalExportManager.php
+++ b/app/lib/ExternalExportManager.php
@@ -246,6 +246,11 @@ class ExternalExportManager {
 						
 						$this->log->logDebug(_t('[ExternalExportManager] Found %1 unique ids for target %2 using "query" value %3', sizeof($ids_from_query), $target, $query));
 					}
+					if (!is_null($access = caGetOption('access', $trigger, null)) && $search = caGetSearchInstance($target_table)) {
+						$ids_from_query = $target_table::find(['access' => $access], ['returnAs' => 'ids', 'restrictToTypes' => caGetOption('restrictToTypes', $target_info, null), 'checkAccess' => caGetOption('checkAccess', $target_info, null)]);
+						
+						$this->log->logDebug(_t('[ExternalExportManager] Found %1 unique ids for target %2 using "access" value %3', sizeof($ids_from_query), $target, $access));
+					}
 					
 					if(!is_null($ids_from_log)) { $ids = $ids_from_log; }
 					if(!is_null($ids_from_query)) {

--- a/app/lib/Plugins/ExternalExport/BaseExternalExportFormatPlugin.php
+++ b/app/lib/Plugins/ExternalExport/BaseExternalExportFormatPlugin.php
@@ -179,7 +179,6 @@ abstract class BaseExternalExportFormatPlugin Extends WLPlug {
 				$mimetypes = $t->get("{$pathless_spec}.mimetype",['returnAsArray' => true, 'filterNonPrimaryRepresentations' => false]);
 				$file_mod_times = $t->get("{$pathless_spec}.fileModificationTime",['returnAsArray' => true, 'filterNonPrimaryRepresentations' => false]);
 			   
-				$ids = $t->get("{$pathless_spec}.id", ['returnAsArray' => true, 'filterNonPrimaryRepresentations' => false]);
 				$files = $t->get($get_spec, ['returnAsArray' => true, 'filterNonPrimaryRepresentations' => false]);
 				
 				$seen_files = [];
@@ -194,7 +193,7 @@ abstract class BaseExternalExportFormatPlugin Extends WLPlug {
 					
 					$e = $export_filename = self::processExportFilename($export_filename_spec, [
 						'extension' => $extension,
-						'original_filename' => $original_basename ? "{$original_basename}.{$extension}" : null, 'original_basename' => $original_basename,
+						'original_filename' => $original_basename ? "{$original_basename}.{$extension}" : "media_{$i}.{$extension}", 'original_basename' => $original_basename,
 						'filename' => "{$basename}.{$extension}", "basename" => $basename, 
 					]);
 					


### PR DESCRIPTION
PR makes the following improvements to the external export system:

• Force default media file name when no "original" name is defined. This prevents writing of null names into ZIP-based archives, which are effectively unretrievable.
• Add "access" trigger to pull all records with a specific access value on trigger