### PR TITLE
PROV-2931 Remove hardcoded path in PDF.js support

### DIFF
--- a/themes/default/views/mediaViewers/pdfjs.php
+++ b/themes/default/views/mediaViewers/pdfjs.php
@@ -394,5 +394,5 @@
  	window.pdfjsContentURL = '<?= $this->getVar('media_url'); ?>';
  	window.pdfjsContainerID = 'caMediaOverlayContent';
  </script>
- <script src="/assets/pdfjs/viewer/viewer.js"></script>
+ <script src="<?= $this->request->getBaseUrlPath(); ?>/assets/pdfjs/viewer/viewer.js"></script>
  


### PR DESCRIPTION
PR replaces hardcoded path that assumes application is running in the web server root with a dynamically generated one.