### PR TITLE
PROV-2935 Add new app.conf setting for default display templates for editor relationship bundles

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1452,7 +1452,7 @@ ca_item_tags_lookup_sort = _natural
 
 
 # -----------------------------------
-# Default bundle display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.)
+# Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in displays **
 # -----------------------------------
 ca_objects_default_bundle_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</ifdef>
 ca_entities_default_bundle_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</ifdef>
@@ -1464,6 +1464,21 @@ ca_loans_default_bundle_display_template = <l>^ca_loans.preferred_labels.name</l
 ca_movements_default_bundle_display_template = <l>^ca_movements.preferred_labels.name</l> (^relationship_typename)
 ca_object_representations_default_bundle_display_template = <l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l> (^relationship_typename)
 ca_list_items_default_bundle_display_template = <l>^ca_list_items.preferred_labels.name_plural</l> (^relationship_typename)
+
+# -----------------------------------
+# Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in user interfaces **
+# -----------------------------------
+ca_objects_default_editor_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</ifdef>
+ca_entities_default_editor_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</ifdef>
+ca_places_default_editor_display_template = <l>^ca_places.preferred_labels.name</l> (^relationship_typename)
+ca_occurrences_default_editor_display_template = <l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)
+ca_object_lots_default_editor_display_template = <l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)
+ca_storage_locations_default_editor_display_template = <l>^ca_storage_locations.preferred_labels.name</l> (^relationship_typename)
+ca_loans_default_editor_display_template = <l>^ca_loans.preferred_labels.name</l> (^relationship_typename)
+ca_movements_default_editor_display_template = <l>^ca_movements.preferred_labels.name</l> (^relationship_typename)
+ca_object_representations_default_editor_display_template = <l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l> (^relationship_typename)
+ca_list_items_default_editor_display_template = <l>^ca_list_items.preferred_labels.name_plural</l> (^relationship_typename)
+
 
 # -----------------------------------
 # Default template for media viewer caption

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -4219,7 +4219,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
                     throw new ApplicationException(_t('Cannot view media'));
                 }
 				if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype($ps_display_type, $vs_mimetype = $t_instance->getMediaInfo('value_blob', 'original', 'MIMETYPE')))) {
-					throw new ApplicationException(_t('Invalid viewer'));
+					throw new ApplicationException(_t('Invalid viewer: %1/%2', $ps_display_type, $vs_mimetype));
 				}
 
 				$vs_viewer = $vs_viewer_name::getViewerHTML(

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3309,9 +3309,11 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 
 		// If no display_template set try to get a default out of the app.conf file
 		if (!$vs_template) {
-			if (is_array($va_lookup_settings = $pt_subject->getAppConfig()->getList("{$ps_related_table}_lookup_settings"))) {
-				if (!($vs_lookup_delimiter = $pt_subject->getAppConfig()->get("{$ps_related_table}_lookup_delimiter"))) { $vs_lookup_delimiter = ''; }
-				$vs_template = join($vs_lookup_delimiter, $va_lookup_settings);
+			if(!trim($vs_template = $pt_subject->getAppConfig()->get("{$ps_related_table}_default_editor_display_template"))) {	// use explicit setting
+				if (is_array($va_lookup_settings = $pt_subject->getAppConfig()->getList("{$ps_related_table}_lookup_settings"))) {	// fall back to derive from lookup setting
+					if (!($vs_lookup_delimiter = $pt_subject->getAppConfig()->get("{$ps_related_table}_lookup_delimiter"))) { $vs_lookup_delimiter = ''; }
+					$vs_template = join($vs_lookup_delimiter, $va_lookup_settings);
+				}
 			}
 		}
 


### PR DESCRIPTION
PR adds new app.conf settings that allow setting of default display templates for relationship bundles such as "ca_objects" and "ca_entities" in editor user interfaces. Previously, defaults were derived from the templates used to format type-ahead lookups, which weren't always suitable for defaults. With this PR, the template in the new setting is used and, if not present, values for lookups (ie. the old behavior) are used.