### PR TITLE
PROV-2869 Use instance, not static

### DIFF
--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -478,7 +478,7 @@
 					'detailedLogName' => $vs_detailed_log_name
 				]
 			)) {
-				CLIUtils::addError(_t("Could not import source %1: %2", $vs_data_source, join("; ", ca_data_importers::getErrorList())));
+				CLIUtils::addError(_t("Could not import source %1: %2", $vs_data_source, join("; ", $t_importer->getErrorList())));
 				return false;
 			} else {
 				CLIUtils::addMessage(_t("Imported data from source %1", $vs_data_source));


### PR DESCRIPTION
PR fixes issue in caUtils import/export handler where static call is used where instance is now required when getting error messages.