### PR TITLE
PROV-2937 Add stripTags option to remove HTML from export output 

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -984,7 +984,8 @@ class SearchResult extends BaseObject {
 	 *          convertCodesToValue = Convert list item_ids to item value's (ca_list_items.item_value). If convertCodesToDisplayText is also set then it will take precedence. [Default is false]
 	 *			output = Convert list item_ids to display text in user's preferred locale ("text") or idno ("idno"). This is an easier to type alternative to the convertCodesToDisplayText and convertCodesToIdno options. [Default is null]
 	 *			sort = Array list of bundles to sort returned values on. Currently sort is only supported when getting related values via simple related <table_name> and <table_name>.related bundle specifiers. Eg. from a ca_objects results you can sort when fetching 'ca_entities', 'ca_entities.related', 'ca_objects.related', etc.. The sortable bundle specifiers are fields with or without tablename. Only those fields returned for the related tables (intrinsics and label fields) are sortable. You can also sort on attributes if returnWithStructure is set. [Default is null]
-	*
+	 *			stripTags = Remove HTML/XML tags from returned values. [Default is false]
+	 *
 	 *		[Formatting for strings only]
  	 *			toUpper = Force all values to upper case. [Default is false]
 	 *			toLower = Force all values to lower case. [Default is false]
@@ -1072,6 +1073,7 @@ class SearchResult extends BaseObject {
 		$vb_convert_codes_to_idno 			= isset($pa_options['convertCodesToIdno']) ? (bool)$pa_options['convertCodesToIdno'] : false;
 		$vb_convert_codes_to_value 			= isset($pa_options['convertCodesToValue']) ? (bool)$pa_options['convertCodesToValue'] : false;
 		
+		$vb_strip_tags			 			= isset($pa_options['stripTags']) ? (bool)$pa_options['stripTags'] : false;
 		
 		$va_exclude_values 					= (isset($pa_options['excludeValues']) && $pa_options['excludeValues']) ? is_array($pa_options['excludeValues']) ? $pa_options['excludeValues'] : [$pa_options['excludeValues']] : [];
 		$va_exclude_idnos					= (isset($pa_options['excludeIdnos']) && $pa_options['excludeIdnos']) ? is_array($pa_options['excludeIdnos']) ? $pa_options['excludeIdnos'] : [$pa_options['excludeIdnos']] : [];
@@ -1806,9 +1808,16 @@ class SearchResult extends BaseObject {
 		
 		if ($vb_convert_line_breaks) {
 			if(is_array($vm_val)) {
-				return array_map(function($v) { return !is_array($vm_val) ? nl2br($v) : $v; }, $vm_val);
+				return array_map(function($v) { return !is_array($v) ? nl2br($v) : $v; }, $vm_val);
 			} else {
 				return nl2br($vm_val);
+			}
+		}
+		if ($vb_strip_tags) {
+			if(is_array($vm_val)) {
+				return array_map(function($v) { return !is_array($v) ? strip_tags($v) : $v; }, $vm_val);
+			} else {
+				return strip_tags($vm_val);
 			}
 		}
 		

--- a/app/models/ca_data_exporter_items.php
+++ b/app/models/ca_data_exporter_items.php
@@ -331,6 +331,20 @@ class ca_data_exporter_items extends BaseModel {
 			'label' => _t('Return id numbers for List attribute values'),
 			'description' => _t('If set, idnos are returned for List attribute values instead of primary key values. Do not combine this with convertCodesToDisplayText!')
 		);
+		
+		$va_settings['stripTags'] = array(
+			'formatType' => FT_BIT,
+			'displayType' => DT_SELECT,
+			'width' => 40, 'height' => 1,
+			'takesLocale' => false,
+			'default' => 0,
+			'options' => array(
+				_t('yes') => 1,
+				_t('no') => 0
+			),
+			'label' => _t('Remove HTML pages from output?'),
+			'description' => _t('If set, HTML/XML tags are removed from output.')
+		);
 
 		$va_settings['skipIfExpression'] = array(
 			'formatType' => FT_TEXT,

--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1900,7 +1900,11 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 		if($t_exporter_item->getSetting('timeOmit')) {
 			$va_get_options['timeOmit'] = true;
 		}
-
+		
+		if($t_exporter_item->getSetting('stripTags')) {
+			$va_get_options['stripTags'] = true;
+		}
+		
 		if($t_exporter_item->getSetting('dontReturnValueIfOnSameDayAsStart')) {
 			$va_get_options['dontReturnValueIfOnSameDayAsStart'] = true;
 		}


### PR DESCRIPTION
PR added new stripTags export mapping option, that will remove all HTML tags from exporter output. Also implements a generally available stripTags option for BaseModel::get()