### PR TITLE
PROV-2892 Add option to skip records without media (CTDA requirement)

### DIFF
--- a/app/lib/ExternalExportManager.php
+++ b/app/lib/ExternalExportManager.php
@@ -269,6 +269,15 @@ class ExternalExportManager {
 					foreach($ids as $id) {
 						if($seen["{$target_table}/{$id}"]) { continue; }
 						
+						if ((caGetOption('requireMedia', $target_info, false, ['castTo' => 'bool']))) {
+							if ($t = $target_table::find($id, ['returnAs' => 'firstModelInstance'])) {
+								if (!is_array($rep_ids = $t->get('ca_object_representations.representation_id', ['returnAsArray' => true])) || (sizeof($rep_ids) === 0)) {
+									$this->log->logDebug(_t('[ExternalExportManager] Skipped id %1 for target %2 because media is required and no media was foound', $id, $target));
+									continue; 
+								}
+							}
+						}
+						
 						$this->log->logDebug(_t('[ExternalExportManager] Processing %1 for target %2', "{$target_table}:{$id}", $target));
 						$files = $this->process($target_table, $id, array_merge($options, ['target' => $target, 'skipTransport' => true]));
 						$seen["{$target_table}/{$id}"] = true;


### PR DESCRIPTION
PR adds external export option to require media to be related to a record for it to be exported. This oddly specific flag is required by the CTDA.