### PR TITLE
PROV-2938 Urls with trailing  double slash ("//") can cause crashes

### DIFF
--- a/app/lib/Auth/Adapters/Okta.php
+++ b/app/lib/Auth/Adapters/Okta.php
@@ -235,7 +235,8 @@ class OktaAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
                 throw new OktaException(_t('Verification of Okta JWT failed'));
             }
             setcookie("access_token", $exchange['access_token'],time()+$exchange['expires_in'],"/",false);
-            header('Location: /'.$this->config->get('default_action'));
+            if(!($redirect_url = Session::getVar('pawtucket2_last_page')) && ($redirect_url !== '/')) { $redirect_url = $this->config->get('default_action'); }
+            header('Location: '.$this->config->get('site_host').'/'.$redirect_url);
             return;
         }
         throw new OktaException(_t('An Okta error during login has occurred'));

--- a/app/lib/Controller/Request/RequestHTTP.php
+++ b/app/lib/Controller/Request/RequestHTTP.php
@@ -194,6 +194,7 @@ class RequestHTTP extends Request {
 		$this->ops_base_path = join('/', $va_tmp);
 		$this->ops_full_path = $_SERVER['REQUEST_URI'];
 		if (!caUseCleanUrls() && !preg_match("!/index.php!", $this->ops_full_path) && !preg_match("!/service.php!", $this->ops_full_path)) { $this->ops_full_path = rtrim($this->ops_full_path, "/")."/index.php"; }
+		$this->ops_full_path = preg_replace("![/]+!", "/", $this->ops_full_path);
 		$vs_path_info = str_replace($_SERVER['SCRIPT_NAME'], "", str_replace("?".$_SERVER['QUERY_STRING'], "", $this->ops_full_path));
 		
 		$this->ops_path_info = $vs_path_info ? $vs_path_info : (isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '');


### PR DESCRIPTION
PR addresses issue where access using urls with trailing double slashes (Ex. http://myarchive.org//) can cause infinite recursion and eventual memory exhaustion. PR does the following:

• Rewrites urls with double slashes to use single slashes
• Ensures Okta auth plugin does not redirect to a double-slash url on login.

(Also uses last page url for Okta destination url).