### PR TITLE
PROV-2788 Add missing quote around rank field

### DIFF
--- a/app/controllers/administrate/setup/ElementsController.php
+++ b/app/controllers/administrate/setup/ElementsController.php
@@ -467,7 +467,7 @@ class ElementsController extends BaseEditorController {
 				(SELECT `rank`,count(*) as count
 					FROM ca_metadata_elements
 					WHERE parent_id=?
-					GROUP BY `rank) as `lambda`
+					GROUP BY `rank`) as `lambda`
 			WHERE
 				count > 1;
 		",$pn_parent_id);


### PR DESCRIPTION
PR adds missing quote in SQL query, resolving issue introduced by work to support MySQL 8. This typo would cause a SQL error when attempting to reposition fields within and editor UI container bundle.