### PR TITLE
NOJIRA Add "start" option to find(); apply start and limit at query level

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -11497,7 +11497,8 @@ $pa_options["display_form_field_tips"] = true;
 	 *
 	 *			The default is ids
 	 *	
-	 *		limit = if searchResult, ids or modelInstances is set, limits number of returned matches. Default is no limit
+	 *		start = if searchResult, ids or modelInstances is set, starts returned list of matches at specified index. Default is 0.
+	 *		limit = if searchResult, ids or modelInstances is set, limits number of returned matches. Default is no limit.
 	 *		boolean = determines how multiple field values in $pa_values are combined to produce the final result. Possible values are:
 	 *			AND						= find rows that match all criteria in $pa_values
 	 *			OR						= find rows that match any criteria in $pa_values
@@ -11743,8 +11744,14 @@ $pa_options["display_form_field_tips"] = true;
 			$o_db = new Db();
 		}
 		
-		$vn_limit = (isset($pa_options['limit']) && ((int)$pa_options['limit'] > 0)) ? (int)$pa_options['limit'] : null;
-		$qr_res = $o_db->query($vs_sql, array_merge($va_sql_params, $va_type_restriction_params));
+		$start = (isset($pa_options['start']) && ((int)$pa_options['start'] > 0)) ? (int)$pa_options['start'] : 0;
+		$limit = (isset($pa_options['limit']) && ((int)$pa_options['limit'] > 0)) ? (int)$pa_options['limit'] : null;
+		
+		$limit_sql = '';
+		if ($start > 0) { $limit_sql = "{$start}"; }
+		if ($limit > 0) { $limit_sql .= $limit_sql ? ", {$limit}" : "{$limit}"; }
+		
+		$qr_res = $o_db->query($vs_sql.($limit_sql ? " LIMIT {$limit_sql}" : ''), array_merge($va_sql_params, $va_type_restriction_params));
 
 		if ($vb_purify_with_fallback && ($qr_res->numRows() == 0)) {
 			return self::find($pa_values, array_merge($pa_options, ['purifyWithFallback' => false, 'purify' => false]));
@@ -11776,7 +11783,7 @@ $pa_options["display_form_field_tips"] = true;
 					if ($t_instance->load($qr_res->get($vs_pk))) {
 						$va_instances[] = $t_instance;
 						$vn_c++;
-						if ($vn_limit && ($vn_c >= $vn_limit)) { break; }
+						if ($limit && ($vn_c >= $limit)) { break; }
 					}
 				}
 				return $va_instances;
@@ -11795,7 +11802,7 @@ $pa_options["display_form_field_tips"] = true;
 				while($qr_res->nextRow()) {
 					$va_rows[] = $qr_res->getRow();
 					$vn_c++;
-					if ($vn_limit && ($vn_c >= $vn_limit)) { break; }
+					if ($limit && ($vn_c >= $limit)) { break; }
 				}
 				return $va_rows;
 				break;
@@ -11805,7 +11812,7 @@ $pa_options["display_form_field_tips"] = true;
 				$va_ids = array();
 				while($qr_res->nextRow()) {
 					$va_ids[$vn_v = $qr_res->get($vs_pk)] = $vn_v;
-					if ($vn_limit && (sizeof($va_ids) >= $vn_limit)) { break; }
+					if ($limit && (sizeof($va_ids) >= $limit)) { break; }
 				}
 				if ($ps_return_as == 'searchresult') {
 					return $t_instance->makeSearchResult($t_instance->tableName(), array_values($va_ids));

--- a/app/lib/LabelableBaseModelWithAttributes.php
+++ b/app/lib/LabelableBaseModelWithAttributes.php
@@ -482,7 +482,8 @@
 		 *		
 		 *			The default is ids
 		 *	
-		 *		limit = if searchResult, ids or modelInstances is set, limits number of returned matches. Default is no limit
+		 *		start = if searchResult, ids or modelInstances is set, starts returned list of matches at specified index. Default is 0.
+		 *		limit = if searchResult, ids or modelInstances is set, limits number of returned matches. Default is no limit.
 		 *		boolean = determines how multiple field values in $pa_values are combined to produce the final result. Possible values are:
 		 *			AND						= find rows that match all criteria in $pa_values
 		 *			OR						= find rows that match any criteria in $pa_values
@@ -969,10 +970,15 @@
 				}
 				if ($vs_orderby) { $vs_sql .= $vs_orderby; }
 			}
+
+			$start = (isset($pa_options['start']) && ((int)$pa_options['start'] > 0)) ? (int)$pa_options['start'] : 0;
+			$limit = (isset($pa_options['limit']) && ((int)$pa_options['limit'] > 0)) ? (int)$pa_options['limit'] : null;
 		
-			$vn_limit = (isset($pa_options['limit']) && ((int)$pa_options['limit'] > 0)) ? (int)$pa_options['limit'] : null;
-	
-			$qr_res = $o_db->query($vs_sql, array_merge($va_sql_params, $va_type_restriction_params));
+			$limit_sql = '';
+			if ($start > 0) { $limit_sql = "{$start}"; }
+			if ($limit > 0) { $limit_sql .= $limit_sql ? ", {$limit}" : "{$limit}"; }
+		
+			$qr_res = $o_db->query($vs_sql.($limit_sql ? " LIMIT {$limit_sql}" : ''), array_merge($va_sql_params, $va_type_restriction_params));
 
 			if ($vb_purify_with_fallback && ($qr_res->numRows() == 0)) {
 				return self::find($pa_values, array_merge($pa_options, ['purifyWithFallback' => false, 'purify' => false]));
@@ -1003,7 +1009,7 @@
 						if ($o_instance->load($qr_res->get($vs_pk))) {
 							$va_instances[] = $o_instance;
 							$vn_c++;
-							if ($vn_limit && ($vn_c >= $vn_limit)) { break; }
+							if ($limit && ($vn_c >= $limit)) { break; }
 						}
 					}
 					return $va_instances;
@@ -1022,7 +1028,7 @@
 					while($qr_res->nextRow()) {
 						$va_rows[] = $qr_res->getRow();
 						$vn_c++;
-						if ($vn_limit && ($vn_c >= $vn_limit)) { break; }
+						if ($limit && ($vn_c >= $limit)) { break; }
 					}
 					return $va_rows;
 					break;
@@ -1033,7 +1039,7 @@
 					while($qr_res->nextRow()) {
 						$va_ids[] = $qr_res->get($vs_pk);
 						$vn_c++;
-						if ($vn_limit && ($vn_c >= $vn_limit)) { break; }
+						if ($limit && ($vn_c >= $limit)) { break; }
 					}
 					if ($ps_return_as == 'searchresult') {
 						return $t_instance->makeSearchResult($t_instance->tableName(), $va_ids, ['sort' => $ps_sort, 'sortDirection' => $ps_sort_direction]);


### PR DESCRIPTION
PR adds "start" option to BaseModel::find(); in conjunction with existing "limit" parameter this provides a mechanism for paging. Also moves application of start and limit to query, rather than chopping full result set after it's pulled from the database. This greatly improves performance with large datasets.