### PR TITLE
NOJIRA fix typo that breaks BaseModel::get() "returnPath" option for media

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -1068,7 +1068,7 @@ class SearchResult extends BaseObject {
 		$vb_unserialize 					= isset($pa_options['unserialize']) ? (bool)$pa_options['unserialize'] : false;
 		
 		$vb_return_url 						= isset($pa_options['returnURL']) ? (bool)$pa_options['returnURL'] : false;
-		$vb_return_path 					= isset($pa_options['returnPath']) ? (bool)$pa_options['returnPAth'] : false;
+		$vb_return_path 					= isset($pa_options['returnPath']) ? (bool)$pa_options['returnPath'] : false;
 		$vb_convert_codes_to_display_text 	= isset($pa_options['convertCodesToDisplayText']) ? (bool)$pa_options['convertCodesToDisplayText'] : false;
 		$vb_convert_codes_to_idno 			= isset($pa_options['convertCodesToIdno']) ? (bool)$pa_options['convertCodesToIdno'] : false;
 		$vb_convert_codes_to_value 			= isset($pa_options['convertCodesToValue']) ? (bool)$pa_options['convertCodesToValue'] : false;


### PR DESCRIPTION
PR fixes capitalization error in option name that breaks the "returnPath" option on get(). This option forces media values to be returned as an absolute file path rather than a tag or url. It is often useful when working with media in PDF output, where absolute paths may be more reliable than URLs in some cases.