### PR TITLE
Misc import fixes

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -344,7 +344,7 @@ function caFileIsIncludable($ps_file) {
 		if(substr($dir, -1, 1) == "/"){
 			$dir = substr($dir, 0, strlen($dir) - 1);
 		}
-
+		if(!file_exists($dir)) { return []; }
 		if($va_paths = scandir($dir, 0)) {
 			foreach($va_paths as $item) {
 				if ($item != "." && $item != ".." && ($pb_include_hidden_files || (!$pb_include_hidden_files && $item{0} !== '.'))) {

--- a/app/lib/Import/DataReaders/ExcelDataReader.php
+++ b/app/lib/Import/DataReaders/ExcelDataReader.php
@@ -160,7 +160,8 @@ class ExcelDataReader extends BaseDataReader {
 		    try {
 			    $pn_col = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFromString($pn_col);
 			} catch(Exception $e) {
-			    throw new ApplicationException(_t('Invalid Excel (XLSX) column specified \'%1\'', $pn_col));
+			    //throw new ApplicationException(_t('Invalid Excel (XLSX) column specified \'%1\'', $pn_col));
+			    return null;
 			}
 		}
 

--- a/app/lib/Plugins/Media/PDFWand.php
+++ b/app/lib/Plugins/Media/PDFWand.php
@@ -79,9 +79,15 @@ class WLPlugMediaPDFWand Extends BaseMediaPlugin implements IWLPlugMedia {
 		
 		"TRANSFORMATIONS" => array(
 			"SCALE" 			=> array("width", "height", "mode", "antialiasing"),
-			"SHARPEN"			=> ['radius', 'sigma'], // dummy
+			'CROP' 				=> array('width', 'height', 'x', 'y'),					// dummy
+			"SHARPEN"			=> ['radius', 'sigma'], 								// dummy
 			"ANNOTATE"	=> array("text", "font", "size", "color", "position", "inset"),	// dummy
 			"WATERMARK"	=> array("image", "width", "height", "position", "opacity"),	// dummy
+			'ROTATE' 			=> array('angle'),										// dummy
+			'FLIP'				=> array('direction'),									// dummy
+			'MEDIAN'			=> array('radius'),										// dummy
+			'DESPECKLE'			=> array(''),											// dummy
+			'UNSHARPEN_MASK'	=> array('radius', 'sigma', 'amount', 'threshold'),		// dummy
 			"SET" 				=> array("property", "value")
 		),
 		

--- a/app/lib/Plugins/Media/PDFWand.php
+++ b/app/lib/Plugins/Media/PDFWand.php
@@ -79,6 +79,7 @@ class WLPlugMediaPDFWand Extends BaseMediaPlugin implements IWLPlugMedia {
 		
 		"TRANSFORMATIONS" => array(
 			"SCALE" 			=> array("width", "height", "mode", "antialiasing"),
+			"SHARPEN"			=> ['radius', 'sigma'], // dummy
 			"ANNOTATE"	=> array("text", "font", "size", "color", "position", "inset"),	// dummy
 			"WATERMARK"	=> array("image", "width", "height", "position", "opacity"),	// dummy
 			"SET" 				=> array("property", "value")


### PR DESCRIPTION
PR fixes a handful of importer issues:

• Excel data reader now returns null when an invalid column specifier is used rather than propagating a PHPSpreadsheet exception
• caGetDirectoryContentsAsList() now returns an empty array rather than a messy warning if the directory does not exist
• PDFWand media importer now supports all image transformations as pass throughs, avoiding errors when previously unsupported image options were set.