### PR TITLE
PROV-2935 Make storage location default show full hierarchy by default

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1473,7 +1473,7 @@ ca_entities_default_editor_display_template = <ifdef code='ca_entities.preferred
 ca_places_default_editor_display_template = <l>^ca_places.preferred_labels.name</l> (^relationship_typename)
 ca_occurrences_default_editor_display_template = <l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)
 ca_object_lots_default_editor_display_template = <l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)
-ca_storage_locations_default_editor_display_template = <l>^ca_storage_locations.preferred_labels.name</l> (^relationship_typename)
+ca_storage_locations_default_editor_display_template = <l>^ca_storage_locations.hierarchy.preferred_labels.name</l> (^relationship_typename)
 ca_loans_default_editor_display_template = <l>^ca_loans.preferred_labels.name</l> (^relationship_typename)
 ca_movements_default_editor_display_template = <l>^ca_movements.preferred_labels.name</l> (^relationship_typename)
 ca_object_representations_default_editor_display_template = <l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l> (^relationship_typename)


### PR DESCRIPTION
PR modified default template relationship bundle template for storage locations to display full hierarchy path, which is the most commonly requested format.