### PR TITLE
PROV-2890 Sub-types in menus don't show below first enabled type

### DIFF
--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -1389,7 +1389,7 @@ class BaseEditorController extends ActionController {
 						// If in strict mode and a top-level type is disabled, then show sub-types so user can select an enabled type
 				) {
 					if (isset($va_item['item_id']) && isset($va_types_by_parent_id[$va_item['item_id']]) && is_array($va_types_by_parent_id[$va_item['item_id']])) {
-						$va_subtypes = $this->_getSubTypes($va_types_by_parent_id[$va_item['item_id']], $va_types_by_parent_id, $vn_sort_type, $va_restrict_to_types, ['firstEnabled' => true]);
+						$va_subtypes = $this->_getSubTypes($va_types_by_parent_id[$va_item['item_id']], $va_types_by_parent_id, $vn_sort_type, $va_restrict_to_types, ['firstEnabled' => !(bool)$va_item['is_enabled']]);
 					}
 				}
 


### PR DESCRIPTION
PR addresses regression caused by new default behavior introduced ion PROV-2890 that prevents sub-types below the first sub-type that is enabled from showing in menus. The default is now to show all sub-types, in line with previous behavior.