### PR TITLE
PROV-2945 Implement options for skipping mappings/groups/rows when placeholder values are empty

### DIFF
--- a/app/models/ca_data_importer_items.php
+++ b/app/models/ca_data_importer_items.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2017 Whirl-i-Gig
+ * Copyright 2012-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -247,6 +247,61 @@ class ca_data_importer_items extends BaseModel {
 			),
 			'label' => _t('Skip mapping if empty'),
 			'description' => _t('Skip mapping if value for this element is empty.')
+		);
+		
+		$va_settings['skipWhenEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip mapping if any listed elements is empty'),
+			'description' => _t('Skip mapping if any values for listed elements are empty.')
+		);
+		$va_settings['skipWhenAllEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip mapping if all listed elements are empty'),
+			'description' => _t('Skip mapping if all values for listed elements are empty.')
+		);
+		$va_settings['skipGroupWhenEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip group if any listed elements is empty'),
+			'description' => _t('Skip group if any values for listed elements are empty.')
+		);
+		$va_settings['skipGroupWhenAllEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip group if all listed elements are empty'),
+			'description' => _t('Skip group if all values for listed elements are empty.')
+		);
+		$va_settings['skipRowWhenEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip row if any listed elements is empty'),
+			'description' => _t('Skip row if any values for listed elements are empty.')
+		);
+		$va_settings['skipRowWhenAllEmpty'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 10,
+			'takesLocale' => false,
+			'default' => null,
+			'label' => _t('Skip row if all listed elements are empty'),
+			'description' => _t('Skip row if all values for listed elements are empty.')
 		);
 		$va_settings['skipIfValue'] = array(
 			'formatType' => FT_TEXT,

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -2059,7 +2059,79 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						}
 
 						// Do value conversions
-						foreach ( $va_vals as $vn_i => $vm_val ) {
+						foreach($va_vals as $vn_i => $vm_val) {
+							if ($va_item['settings']['skipWhenEmpty'] && !is_array($va_item['settings']['skipWhenEmpty'])) { $va_item['settings']['skipWhenEmpty'] = array($va_item['settings']['skipWhenEmpty']); }
+							if (isset($va_item['settings']['skipWhenEmpty']) && is_array($va_item['settings']['skipWhenEmpty'])) {
+								foreach($va_item['settings']['skipWhenEmpty'] as $v) {
+									if(!strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										if($log_skip) { $o_log->logInfo(_t('[%1] Skipped mapping for %2 because at least one value in list (%3) is empty', $vs_idno, $va_item['destination'], join('; ', $va_item['settings']['skipWhenEmpty']))); }
+										continue(2);
+									}
+								}
+							}
+							if ($va_item['settings']['skipWhenAllEmpty'] && !is_array($va_item['settings']['skipWhenAllEmpty'])) { $va_item['settings']['skipWhenAllEmpty'] = array($va_item['settings']['skipWhenAllEmpty']); }
+							if (isset($va_item['settings']['skipWhenAllEmpty']) && is_array($va_item['settings']['skipWhenAllEmpty'])) {
+								$all_empty = true;
+								foreach($va_item['settings']['skipWhenAllEmpty'] as $v) {
+									if(strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										$all_empty = false;
+										break;
+									}
+								}
+								if($all_empty) {
+									if($log_skip) { $o_log->logInfo(_t('[%1] Skipped mapping for %2 because all values in list (%3) are empty', $vs_idno, $vn_row, join('; ', $va_item['settings']['skipWhenEmpty']))); }
+									continue(2);
+								}
+							}
+							
+							if ($va_item['settings']['skipGroupWhenEmpty'] && !is_array($va_item['settings']['skipGroupWhenEmpty'])) { $va_item['settings']['skipGroupWhenEmpty'] = array($va_item['settings']['skipGroupWhenEmpty']); }
+							if (isset($va_item['settings']['skipGroupWhenEmpty']) && is_array($va_item['settings']['skipGroupWhenEmpty'])) {
+								foreach($va_item['settings']['skipGroupWhenEmpty'] as $v) {
+									if(!strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										if($log_skip) { $o_log->logInfo(_t('[%1] Skipped group %2 because at least one value in list (%3) is empty', $vs_idno, $vn_group_id, join('; ', $va_item['settings']['skipGroupWhenEmpty']))); }
+										continue(3);
+									}
+								}
+							}
+							if ($va_item['settings']['skipGroupWhenAllEmpty'] && !is_array($va_item['settings']['skipGroupWhenAllEmpty'])) { $va_item['settings']['skipGroupWhenAllEmpty'] = array($va_item['settings']['skipGroupWhenAllEmpty']); }
+							if (isset($va_item['settings']['skipGroupWhenAllEmpty']) && is_array($va_item['settings']['skipGroupWhenAllEmpty'])) {
+								$all_empty = true;
+								foreach($va_item['settings']['skipGroupWhenAllEmpty'] as $v) {
+									if(strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										$all_empty = false;
+										break;
+									}
+								}
+								if($all_empty) {
+									if($log_skip) { $o_log->logInfo(_t('[%1] Skipped group %2 because all values in list (%3) are empty', $vs_idno, $vn_group_id, join('; ', $va_item['settings']['skipGroupWhenAllEmpty']))); }
+									continue(3);
+								}
+							}
+							
+							if ($va_item['settings']['skipRowWhenEmpty'] && !is_array($va_item['settings']['skipRowWhenEmpty'])) { $va_item['settings']['skipRowWhenEmpty'] = array($va_item['settings']['skipRowWhenEmpty']); }
+							if (isset($va_item['settings']['skipRowWhenEmpty']) && is_array($va_item['settings']['skipRowWhenEmpty'])) {
+								foreach($va_item['settings']['skipRowWhenEmpty'] as $v) {
+									if(!strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										if($log_skip) { $o_log->logInfo(_t('[%1] Skipped row %2 because at least one value in list (%3) is empty', $vs_idno, $vn_row, join('; ', $va_item['settings']['skipRowWhenEmpty']))); }
+										continue(4);
+									}
+								}
+							}
+							if ($va_item['settings']['skipRowWhenAllEmpty'] && !is_array($va_item['settings']['skipRowWhenAllEmpty'])) { $va_item['settings']['skipRowWhenAllEmpty'] = array($va_item['settings']['skipRowWhenAllEmpty']); }
+							if (isset($va_item['settings']['skipRowWhenAllEmpty']) && is_array($va_item['settings']['skipRowWhenAllEmpty'])) {
+								$all_empty = true;
+								foreach($va_item['settings']['skipRowWhenAllEmpty'] as $v) {
+									if(strlen($vp = BaseRefinery::parsePlaceholder($v, $use_raw ? $va_raw_row : $va_row_with_replacements, $va_item, $vn_i, ['reader' => $o_reader, 'returnAsString' => true]))) {
+										$all_empty = false;
+										break;
+									}
+								}
+								if($all_empty) {
+									if($log_skip) { $o_log->logInfo(_t('[%1] Skipped row %2 because all values in list (%3) are empty', $vs_idno, $vn_row, join('; ', $va_item['settings']['skipRowWhenAllEmpty']))); }
+									continue(4);
+								}
+							}
+						
 							// Evaluate skip-if-empty options before setting default value, adding prefix/suffix or formatting with templates
 							// because "empty" refers to the source value before this sort of additive processing.
 							if ( isset( $va_item['settings']['skipRowIfEmpty'] )


### PR DESCRIPTION
PR adds six new data importer mapping options enabling skipping of mappings, groups or rows when any one or all values in a list of placeholder values are empty. This provides additional flexibility in skipping import of empty values without having to resort to writing expressions.