### PR TITLE
NOJIRA Use error objects, not error strings when merging errors lists

### DIFF
--- a/app/controllers/manage/CommentsController.php
+++ b/app/controllers/manage/CommentsController.php
@@ -65,6 +65,7 @@
  		 * (eg. CollectionSearch for collections, EntitySearch for entities) and pass it to BaseSearchController->Index() 
  		 */ 
  		public function Index($pa_options=null) {
+ 			$this->view->setVar('mode', 'search');
  			$pa_options['search'] = new ItemCommentSearch();
  			
  			$this->view->setVar('table_list', $table_list = caGetPrimaryTablesForHTMLSelect());
@@ -115,6 +116,7 @@
  		# -------------------------------------------------------
  		public function ListUnmoderated() {
  			$t_comments = new ca_item_comments();
+ 			$this->view->setVar('mode', 'list');
  			$this->view->setVar('t_comments', $t_comments);
  			$this->view->setVar('comments_list', $t_comments->getUnmoderatedComments(['returnAs' => 'searchResult']));
  			if(sizeof($t_comments->getUnmoderatedComments()) == 0){
@@ -157,12 +159,13 @@
  					$this->ListUnmoderated();
  				break;
  				# -----------------------
- 				case "search":
- 					$this->Index();
- 				break;
- 				# -----------------------
  				case "dashboard":
  					$this->response->setRedirect(caNavUrl($this->request, "", "Dashboard", "Index"));
+ 				break;
+ 				# -----------------------
+ 				case "search":
+ 				default:
+ 					$this->Index();
  				break;
  				# -----------------------
  			}

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -2726,7 +2726,6 @@ class BaseModel extends BaseObject {
 						$this->postError($vn_err_num, $o_e->getErrorDescription().' ['.$vn_err_num.']', "BaseModel->insert()", $this->tableName().'.'.$vs_field);
 						break;
 				}
-
 			}
 			if ($vb_we_set_transaction) { $this->removeTransaction(false); }
 			if ($we_set_change_log_unit_id) { BaseModel::unsetChangeLogUnitID(); }
@@ -9089,7 +9088,7 @@ $pa_options["display_form_field_tips"] = true;
 					$t_item_rel->insert();
 					
 					if ($t_item_rel->numErrors() > 0) {
-						$this->errors = array_merge($this->getErrors(), $t_item_rel->getErrors());
+						$this->errors = array_merge($this->errors(), $t_item_rel->errors());
 						return false;
 					}
 					
@@ -9102,7 +9101,7 @@ $pa_options["display_form_field_tips"] = true;
 							$t_item_rel->update();
 							
 							if ($t_item_rel->numErrors() > 0) {
-								$this->errors = array_merge($this->getErrors(), $t_item_rel->getErrors());
+								$this->errors = array_merge($this->errors(), $t_item_rel->errors());
 								return false;
 							}
 						} else {
@@ -9112,7 +9111,7 @@ $pa_options["display_form_field_tips"] = true;
 							$t_item_rel->insert();
 							
 							if ($t_item_rel->numErrors() > 0) {
-								$this->errors = array_merge($this->getErrors(), $t_item_rel->getErrors());
+								$this->errors = array_merge($this->errors(), $t_item_rel->errors());
 								return false;
 							}
 						}
@@ -9122,7 +9121,7 @@ $pa_options["display_form_field_tips"] = true;
 						$this->update();
 					
 						if ($this->numErrors() > 0) {
-							$this->errors = array_merge($this->getErrors(), $t_item_rel->getErrors());
+							$this->errors = array_merge($this->errors(), $t_item_rel->errors());
 							return false;
 						}
 						return $this;

--- a/app/lib/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch.php
@@ -1620,7 +1620,7 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 											break;
 									}
 
-									$pa_direct_sql_query_params = array();
+									$pa_direct_sql_query_params = null;
 								}
 							}
 						}
@@ -1810,7 +1810,7 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 									$vs_sql .= " HAVING count(distinct sw.stem) >= {$vn_num_terms}";
 								}
 								$t = new Timer();
-								
+								print_R($pa_direct_sql_query_params);
 								$pa_direct_sql_query_params = is_array($pa_direct_sql_query_params) ? $pa_direct_sql_query_params : array((int)$pn_subject_tablenum);
 								if(strpos($vs_sql, '?') === false) { $pa_direct_sql_query_params = array(); }
 								$qr_res = $this->opo_db->query($vs_sql, $pa_direct_sql_query_params);

--- a/app/lib/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch.php
@@ -1810,7 +1810,7 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 									$vs_sql .= " HAVING count(distinct sw.stem) >= {$vn_num_terms}";
 								}
 								$t = new Timer();
-								print_R($pa_direct_sql_query_params);
+								
 								$pa_direct_sql_query_params = is_array($pa_direct_sql_query_params) ? $pa_direct_sql_query_params : array((int)$pn_subject_tablenum);
 								if(strpos($vs_sql, '?') === false) { $pa_direct_sql_query_params = array(); }
 								$qr_res = $this->opo_db->query($vs_sql, $pa_direct_sql_query_params);

--- a/themes/default/views/manage/Results/ca_item_comments_list_html.php
+++ b/themes/default/views/manage/Results/ca_item_comments_list_html.php
@@ -36,6 +36,7 @@
 			<?php print _t('Batch actions'); ?>: <a href='#' onclick='jQuery("#commentListForm").attr("action", "<?php print caNavUrl($this->request, 'manage', 'Comments', 'Approve'); ?>").submit();' class='form-button'><span class='form-button approveDelete'><?php print caNavIcon(__CA_NAV_ICON_APPROVE__, 1); ?><span class='formtext'><?php print _t("Approve"); ?></span></span></a>
 			<a href='#' onclick='jQuery("#commentListForm").attr("action", "<?php print caNavUrl($this->request, 'manage', 'Comments', 'Delete'); ?>").submit();' class='form-button'><span class='form-button approveDelete'><?php print caNavIcon(__CA_NAV_ICON_DELETE__, 1); ?><span class='formtext'><?php print _t("Delete"); ?></span></span></a>
 		</div>
+<form action='#' id='commentListForm'>
 		<table id="caItemList" class="listtable" border="0" cellpadding="0" cellspacing="1" style="margin-top:10px;">
 			<thead>
 				<tr>
@@ -117,4 +118,6 @@
 ?>
 			</tbody>
 		</table>
+	<?= caHTMLHiddenInput('mode', ['value' => $this->getVar('mode')]); ?>
+</form>
 	</div><!--end commentsResults -->

--- a/themes/default/views/manage/Results/ca_item_comments_no_results_html.php
+++ b/themes/default/views/manage/Results/ca_item_comments_no_results_html.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2014 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -30,16 +30,7 @@
  	$vs_search = $this->getVar('search');
 ?>	
 <div id="resultBox">
-	<div class="subTitle"><?php print $this->getVar('search') ? _t("Your search found no %1", $this->getVar('mode_type_plural')) : _t("Please enter a search"); ?>
-<?php
-	$o_search = caGetSearchInstance($t_subject->tableNum());
-	if (sizeof($va_suggestions = $o_search->suggest($vs_search, array('returnAsLink' => true, 'request' => $this->request)))) {
-		if (sizeof($va_suggestions) > 1) {
-			print "<div class='searchSuggestion'>"._t("Did you mean one of these: %1 ?", join(', ', $va_suggestions))."</div>";
-		} else {
-			print "<div class='searchSuggestion'>"._t("Did you mean %1 ?", join(', ', $va_suggestions))."</div>";
-		}
-	}
-?>
+	<div class="subTitle">
+		<?php print $this->getVar('search') ? _t("Your search found no %1", $this->getVar('mode_type_plural')) : _t("Please enter a search"); ?>
 	</div>
 </div><!-- end resultbox -->

--- a/themes/default/views/manage/Results/ca_item_tags_no_results_html.php
+++ b/themes/default/views/manage/Results/ca_item_tags_no_results_html.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2014 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -30,16 +30,7 @@
  	$vs_search = $this->getVar('search');
 ?>	
 <div id="resultBox">
-	<div class="subTitle"><?php print $this->getVar('search') ? _t("Your search found no %1", $this->getVar('mode_type_plural')) : _t("Please enter a search"); ?>
-<?php
-	$o_search = caGetSearchInstance($t_subject->tableNum());
-	if (sizeof($va_suggestions = $o_search->suggest($vs_search, array('returnAsLink' => true, 'request' => $this->request)))) {
-		if (sizeof($va_suggestions) > 1) {
-			print "<div class='searchSuggestion'>"._t("Did you mean one of these: %1 ?", join(', ', $va_suggestions))."</div>";
-		} else {
-			print "<div class='searchSuggestion'>"._t("Did you mean %1 ?", join(', ', $va_suggestions))."</div>";
-		}
-	}
-?>
+	<div class="subTitle">
+		<?php print $this->getVar('search') ? _t("Your search found no %1", $this->getVar('mode_type_plural')) : _t("Please enter a search"); ?>
 	</div>
 </div><!-- end resultbox -->


### PR DESCRIPTION
PR resolves fatal errors when handling some types of errors conditions due to returned error list consisting of error message strings rather than error objects. Also resolves PROV-2946 and PROV-2947 – issues with user generated content management UI.