### PR TITLE
Clear ElasticSearch mapping when saving metadata elements.

### DIFF
--- a/app/models/ca_metadata_elements.php
+++ b/app/models/ca_metadata_elements.php
@@ -329,6 +329,7 @@ class ca_metadata_elements extends LabelableBaseModelWithAttributes implements I
 				CompositeCache::delete($vs_cache_key, 'ElementList');
 			}
 		}
+		$this->resetElasticSearchMappingRefresh();
 	}
 	# ------------------------------------------------------
 	# Element set methods
@@ -1678,4 +1679,19 @@ class ca_metadata_elements extends LabelableBaseModelWithAttributes implements I
 		return null;
 	}
 	# ------------------------------------------------------
+	/**
+	 * Ensure that ElasticSearch mapping gets updated on next indexing run by setting the last time to be the start of the epoch.
+	 */
+	private function resetElasticSearchMappingRefresh() {
+		if ($this->getAppConfig()->get('search_engine_plugin') === 'ElasticSearch') {
+			if (!$this->opo_app_vars) {
+				$this->opo_app_vars = new ApplicationVars($this->getDb());
+			}
+			$vs_var = 'ElasticSearchMappingRefresh';
+			if ($this->opo_app_vars->getVar($vs_var) > 0) {
+				$this->opo_app_vars->setVar($vs_var,0);
+				$this->opo_app_vars->save();
+			}
+		}
+	}
 }


### PR DESCRIPTION
* Previously updates to the ES mapping were only shipped at  most once every 24 hours. Now we can queue them up to be shipped at next index.
  * This reulted in a problem that if a user creates a new field and then saves data, the data mapping is guessed by ElasticSearch unless it's been specified.
  * Now we queue ES mapping update.