### PR TITLE
NOJIRA Don't wipe the ES index on profile updates, just write the config changes.

### DIFF
--- a/app/lib/Utils/CLIUtils/Configuration.php
+++ b/app/lib/Utils/CLIUtils/Configuration.php
@@ -133,7 +133,7 @@
 			$vo_installer->processMetadataAlerts();
 
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Performing post install tasks")); }
-			$vo_installer->performPostInstallTasks();
+			$vo_installer->performPostInstallTasks($pb_installing);
 
 			if (!$vb_quiet) { CLIUtils::addMessage(_t("Installation complete")); }
 

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -384,7 +384,7 @@ class Installer {
 		return true;
 	}
 	# --------------------------------------------------
-	public function performPostInstallTasks() {
+	public function performPostInstallTasks($pb_installing) {
 	    // process metadata element settings that couldn't be processed during install
 	    // (Eg. those for hideIfSelected_*)
 	    if (sizeof($this->opa_metadata_element_deferred_settings_processing)) {
@@ -413,8 +413,8 @@ class Installer {
 		// refresh mapping if ElasticSearch is used
 		$o_config = Configuration::load();
 		if ($o_config->get('search_engine_plugin') == 'ElasticSearch') {
-			$o_si = new SearchIndexer();
-			$o_si->reindex(null, array('showProgress' => false, 'interactiveProgressDisplay' => false));
+			$o_es = new WLPlugSearchEngineElasticSearch();
+			$o_es->refreshMapping(true);
 			CompositeCache::flush();
 		}
 	}


### PR DESCRIPTION
* Large collections have large indexes which can take days to reindex. A profile update is normally not destructive, so doing a full reindex seems OTT.

relates to https://github.com/collectiveaccess/providence/pull/538