### PR TITLE
PROV-2951 "Before" dates not working with ElasticSearch

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1374,10 +1374,14 @@
 		// substitute start and end of universe values with ElasticSearch's builtin boundaries
 		$ps_date = str_replace(TEP_START_OF_UNIVERSE,"-292275054",$ps_date);
 		$ps_date = str_replace(TEP_END_OF_UNIVERSE,"9999",$ps_date);
-
-		if(preg_match("/(\d+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)Z/", $ps_date, $va_date_parts)) {
+		if(preg_match("/^([\-]{0,1}[\d]+)\-(\d+)\-(\d+)T(\d+)\:(\d+)\:(\d+)Z/", $ps_date, $va_date_parts)) {
 			// fix large (positive) years
-			if(intval($va_date_parts[1]) > 9999) { $va_date_parts[1] = "9999"; }
+			if(intval($va_date_parts[1]) > 9999) { $va_date_parts[1] = 9999; }
+			
+			$is_bc = (intval($va_date_parts[1]) < 0);
+			if(intval($va_date_parts[1]) < -9999) { $va_date_parts[1] = -9999; }
+			
+			if ($is_bc) { $va_date_parts[1] = abs($va_date_parts[1]); }
 			// fix month-less dates
 			if(intval($va_date_parts[2]) < 1) { $va_date_parts[2]  = ($pb_is_start ?  "01" : "12"); }
 			// fix messed up months
@@ -1396,6 +1400,8 @@
 			if(intval($va_date_parts[5]) < 0) { $va_date_parts[5]  = ($pb_is_start ?  "00" : "59"); }
 			if(intval($va_date_parts[6]) > 59) { $va_date_parts[6] = "59"; }
 			if(intval($va_date_parts[6]) < 0) { $va_date_parts[6]  = ($pb_is_start ?  "00" : "59"); }
+			
+			if ($is_bc) { $va_date_parts[1] = 'BC '.$va_date_parts[1]; }
 
 			return "{$va_date_parts[1]}-{$va_date_parts[2]}-{$va_date_parts[3]}T{$va_date_parts[4]}:{$va_date_parts[5]}:{$va_date_parts[6]}Z";
 		} else {

--- a/tests/lib/Search/ElasticSearch/FieldTypes/DateRangeTest.php
+++ b/tests/lib/Search/ElasticSearch/FieldTypes/DateRangeTest.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015-2018 Whirl-i-Gig
+ * Copyright 2015-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -49,7 +49,25 @@ class DateRangeTest extends TestCase {
 				1 => '2015-03-01T23:59:59Z'
 			)
 		), $va_ret);
+	}
+	
+	public function testBeforeDateRange() {
+		$o_range = new ElasticSearch\FieldTypes\DateRange(
+			'ca_objects', 'dates_value'
+		);
 
+		$va_ret = $o_range->getIndexingFragment('before 2012', []);
+
+		$this->assertEquals(array(
+			'ca_objects/dates_value_text' => 'before 2012',
+			'ca_objects/dates_value' => array(
+				0 => 'BC 9999-01-01T00:00:00Z',
+				1 => '2012-12-31T23:59:59Z'
+			)
+		), $va_ret);
+	}
+	
+	public function testAfterDateRange() {
 		$o_range = new ElasticSearch\FieldTypes\DateRange(
 			'ca_objects', 'dates_value'
 		);


### PR DESCRIPTION
PR fixes issue where incorrect "start" date is indexed in ElasticSearch for "before xxxx" date expressions. Also adds missing test case for this formulation.