### PR TITLE
Make REST API session lifetime configurable

### DIFF
--- a/app/conf/services.conf
+++ b/app/conf/services.conf
@@ -36,7 +36,7 @@ exclude_logins = []
 # default: 7200 (60 * 60 * 2)
 # ---------------------------------------
 
-api_session_lifetime = 36000
+api_session_lifetime = 7200
 
 # ---------------------------------------
 # enable switches for service groups that

--- a/app/conf/services.conf
+++ b/app/conf/services.conf
@@ -31,7 +31,12 @@ simple_api_endpoints = {
 #
 exclude_logins = []
 
+# ---------------------------------------
+# API session logout time in seconds
+# default: 7200 (60 * 60 * 2)
+# ---------------------------------------
 
+api_session_lifetime = 36000
 
 # ---------------------------------------
 # enable switches for service groups that

--- a/app/lib/Controller/Request/Session.php
+++ b/app/lib/Controller/Request/Session.php
@@ -63,6 +63,11 @@ class Session {
 	/**
 	 *
 	 */
+	private static $api_session_lifetime = "";		# session length for REST API 
+
+	/**
+	 *
+	 */
 	private static $start_time = 0;	# microtime session object was created - used for page performance measurements
 
 	/**
@@ -97,6 +102,7 @@ class Session {
 		Session::$name = ($vs_app_name = $o_config->get("app_name")) ? $vs_app_name : $ps_app_name;
 		Session::$domain = $o_config->get("session_domain");
 		Session::$lifetime = (int) $o_config->get("session_lifetime");
+		Session::$api_session_lifetime = (int) $o_config->get("api_session_lifetime");
 
 		if(!Session::$lifetime) {
 			Session::$lifetime = 3600 * 24 * 7;
@@ -162,8 +168,8 @@ class Session {
 		}
 
 		// save mappings in both directions for easy lookup. they are valid for 2 hrs (@todo maybe make this configurable?)
-		ExternalCache::save($session_id, $vs_token, 'SessionIDToServiceAuthTokens', 60 * 60 * 2);
-		ExternalCache::save($vs_token, $session_id, 'ServiceAuthTokensToSessionID', 60 * 60 * 2);
+		ExternalCache::save($session_id, $vs_token, 'SessionIDToServiceAuthTokens', Session::$api_session_lifetime);
+		ExternalCache::save($vs_token, $session_id, 'ServiceAuthTokensToSessionID', Session::$api_session_lifetime);
 
 		return $vs_token;
 	}


### PR DESCRIPTION
This make REST API session lifetime configurable in services.conf instead of hard coded 2 hours. Default is still 2 hours.