### PR TITLE
PROV-2954 Implement "template" row type for data exporter; fix issue that may prevent live update of editor bundles

### DIFF
--- a/assets/ca/ca.bundleupdate.js
+++ b/assets/ca/ca.bundleupdate.js
@@ -79,14 +79,14 @@ var caBundleUpdateManager = null;
 			if (b) {
 				jQuery.each(b, function(k, v) {
 					for(var i in v) {
-						var loadURL = that.url + "/" + that.key + "/" + that.id + "/bundle/" + v[i].bundle + "/placement_id/" + v[i].placement_id;
+						var loadURL = that.url + "/" + that.key + "/" + that.id + "/bundle/" + v.bundle + "/placement_id/" + v.placement_id;
 					
 						if (options) { 
 							for(var k in options) {
 								loadURL += "/" + k + "/" + options[k];
 							}
 						}
-						jQuery("#" + v[i].id).load(loadURL);
+						jQuery("#" + v['id']).load(loadURL);
 					}
 				});
 			}


### PR DESCRIPTION
PR improves the data exporter repeatmappings system. Repeatmappings allows one to reuse existing export mappings in multiple locations in an export. This is useful for export formats where the same data structures are used in multiple locations. (For instance, in EAD where the same record structure is used for arbitrarily deep hierarchies.)

The current implementation only allows reuse of mappings that are actually in-use parts of the export format, and only after they have been defined. That is, anything you need to repeat needs to be defined earlier in the format than where it's referenced and will be used as part of the export format in that first location.

This PR implements a new mapping  "template" row type (in addition to the current "mapping", "constant" and "variable") that allows definition of rows that are not part of the export format, but are available for use with repeatmapping. This allows definition of repeatmapping "templates" in clearly defined blocks of rows at the top of a format definition that can then be referenced later on in the format, and should improve readability and maintainability.

PR also fixes a bug that can prevent live update of editor bundles.