### PR TITLE
Localize metadata import result status

### DIFF
--- a/themes/default/views/batch/metadataimport/batch_results_html.php
+++ b/themes/default/views/batch/metadataimport/batch_results_html.php
@@ -105,14 +105,13 @@
 			foreach($pa_notices as $vn_id => $va_notice) {
 				switch($va_notice['status']) {
 					case 'SUCCESS':
-						$vs_buf .= "<li><em>".caEditorLink($po_request, $va_notice['label'], '', $pa_general['table'], $vn_id)."</em> (".$va_notice['idno']."): ".$va_notice['status']."</li>";
+						$vs_buf .= "<li><em>".caEditorLink($po_request, $va_notice['label'], '', $pa_general['table'], $vn_id)."</em> (".$va_notice['idno']."): "._t("SUCCESS")."</li>";
 						break;
-					case 'SKIPPED':
-					case 'MATCHED':
-						$vs_buf .= "<li><em>".$va_notice['label']."</em>: ".$va_notice['message']."</li>";
+					case 'ERROR':
+						$vs_buf .= "<li><em>".$va_notice['label']."</em> (".$va_notice['idno']."): "._t("ERROR")."</li>";
 						break;
-					default:
-						$vs_buf .= "<li><em>".$va_notice['label']."</em> (".$va_notice['idno']."): ".$va_notice['status']."</li>";
+					default: // defensive default (unreachable)
+						$vs_buf .= "<li><em>".$va_notice['label']."</em> (".$va_notice['idno']."): [".$va_notice['status']."]</li>";
 						break;
 				}
 			}


### PR DESCRIPTION
Per our previous conversation, with explicit strings for translation. Curiously, either the code was confused or I am, as the various 'status' values listed originally seem to pertain to batch media imports and not to metadata imports. If this is ok I can fix themes/default/views/batch/mediaimport/batch_results_html.php  which already contains a similar non-extractable _t() string.