### PR TITLE
PROV-2914 idno normalization should use default value for element when specified

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -117,7 +117,7 @@
 						if ($last['type'] == 'SERIAL') {
 							$n[] = '%';
 						} else {
-							$n[] = '1';
+							$n[] = isset($last['default']) ? $last['default'] : '1';
 						}
 					}
 					$vs_idno = join($sep, $n);


### PR DESCRIPTION
PR modifies idno normalization in data importer hierarchy builder to use multipart id numbering element default value for inserted element values rather than always inserting "1". Since "1" is typical, it remains the default in the absence of a default value set in multipart_id_numbering.conf.