### PR TITLE
PROV-2892 Strip problem chars from file names

### DIFF
--- a/app/lib/Plugins/ExternalExport/Output/SimpleZip.php
+++ b/app/lib/Plugins/ExternalExport/Output/SimpleZip.php
@@ -109,7 +109,7 @@ class WLPlugSimpleZip Extends BaseExternalExportFormatPlugin Implements IWLPlugE
         
         $output_config = caGetOption('output', $target_info, null);
         $target_options = caGetOption('options', $output_config, null);
-        $name = $t_instance->getWithTemplate(caGetOption('name', $output_config, null));
+        $name = preg_replace("![^A-Za-z0-9\-\.\_]+!", "_", $t_instance->getWithTemplate(caGetOption('name', $output_config, null)));
                 
         $zip = new ZipFile(__CA_APP_DIR__."/tmp");
         


### PR DESCRIPTION
PR fixes issue in external export framework where derivate filenames with OS-specific special characters (eg "/") cause fatal errors. We now strip all non-alphanumeric chars from file name to ensure interoperability across storage media and OS's.