### PR TITLE
NOJIRA Allow `_guid` values to be returned in display templates.

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -1233,7 +1233,7 @@ class SearchResult extends BaseObject {
 					break;
 				case 'hierarchy':
 					$vs_opt_md5 = caMakeCacheKeyFromOptions($pa_options);
-					
+
 					// generate the hierarchy
 					if ($va_path_components['related']) {
 						// [RELATED TABLE HIERARCHY]
@@ -1537,6 +1537,9 @@ class SearchResult extends BaseObject {
 //
 				if ($va_path_components['field_name'] == '_guid') {
 					$vm_val = ca_guids::getForRow(Datamodel::getTableNum($va_path_components['table_name']), $vn_row_id);
+					if ($vb_return_as_array && !is_array($vm_val)){
+						$vm_val= [$vm_val];
+					}
 					goto filter;
 				}
 
@@ -1702,7 +1705,7 @@ class SearchResult extends BaseObject {
 		
 		filter:
 		
-		
+
 		// Sort structures by key
 		$va_sort_fields = caGetOption('sort', $pa_options, null);
 		if($va_sort_fields && !is_array($va_sort_fields)) { $va_sort_fields = [$va_sort_fields]; }
@@ -1730,7 +1733,7 @@ class SearchResult extends BaseObject {
 				}
 			}
 		}
-		
+
 		// process excludes 
 		if (sizeof($va_exclude_values) > 0) {
 			if ($vb_return_as_array && is_array($vm_val)) {
@@ -1757,7 +1760,7 @@ class SearchResult extends BaseObject {
 				}
 			} elseif (in_array($vm_val, $va_exclude_values)) { $vm_val = null; } 
 		}
-		
+
 		if ($vb_return_as_array && sizeof($va_filters)) {
 			$va_tmp = explode(".", $ps_field);
 			if (sizeof($va_tmp) > 1) { array_pop($va_tmp); }
@@ -1805,7 +1808,7 @@ class SearchResult extends BaseObject {
 				}
 			}
 		}
-		
+
 		if ($vb_convert_line_breaks) {
 			if(is_array($vm_val)) {
 				return array_map(function($v) { return !is_array($v) ? nl2br($v) : $v; }, $vm_val);
@@ -1820,7 +1823,7 @@ class SearchResult extends BaseObject {
 				return strip_tags($vm_val);
 			}
 		}
-		
+
 		if ($vb_return_as_search_result) {
 			if (!is_array($vm_val) || !sizeof($vm_val)) { return null; }
 			return caMakeSearchResult($va_path_components['table_name'], $vm_val, $pa_options);


### PR DESCRIPTION
* Previously this would only return string values, but templates are generally processed to return as array, so this makes it possible to return the values.

Now you can use values like:
```
^ca_objects._guid
```
in display templates.