### PR TITLE
fix PR #551 REST api session lifetime

### DIFF
--- a/app/lib/Controller/Request/Session.php
+++ b/app/lib/Controller/Request/Session.php
@@ -91,6 +91,8 @@ class Session {
 	 */
 	public static function init($ps_app_name=null, $pb_dont_create_new_session=false) {
  		$o_config = Configuration::load();
+ 		$service_config = Configuration::load(__CA_CONF_DIR__."/services.conf");
+
 		# --- Init
 		if (defined("__CA_MICROTIME_START_OF_REQUEST__")) {
 			Session::$start_time = __CA_MICROTIME_START_OF_REQUEST__;
@@ -102,7 +104,7 @@ class Session {
 		Session::$name = ($vs_app_name = $o_config->get("app_name")) ? $vs_app_name : $ps_app_name;
 		Session::$domain = $o_config->get("session_domain");
 		Session::$lifetime = (int) $o_config->get("session_lifetime");
-		Session::$api_session_lifetime = (int) $o_config->get("api_session_lifetime");
+		Session::$api_session_lifetime = (int) $service_config->get("api_session_lifetime");
 
 		if(!Session::$lifetime) {
 			Session::$lifetime = 3600 * 24 * 7;


### PR DESCRIPTION
My first PR #551  to Providence was horribly broken as it broke REST API sessions. I assumed that Configuration::load(); would load ALL config files.
This PR actually reads "services.conf" file and therefore makes REST API session lifetime configurable via "api_session_lifetime".

Sorry!