### PR TITLE
PROV-2957 Implement BETWEEN operator in find()

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4105,6 +4105,9 @@ function caFileIsIncludable($ps_file) {
 			case 'not in':
 				return ($pb_is_list) ? true : false;
 				break;
+			case 'between':
+				return ($pb_is_list) ? true : false;
+				break;
 		}
 		return false;
 	}

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -11476,9 +11476,13 @@ $pa_options["display_form_field_tips"] = true;
 	 *
 	 * 		["idno" => ['=', '2012.001'], "access" => ['>', 1]]
 	 *
-	 * 		You may also specify lists of values for use with the IN operator:
+	 * 		You may also specify lists of values for use with the IN and NOT IN operators:
 	 *
 	 * 		["idno" => ['=', '2012.001'], "access" => ['IN', [1,2,3]]]
+	 *
+	 * 		Range searches may be performed using the BETWEEN operator:
+	 *
+	 * 		["idno" => ['=', '2012.001'], "access" => ['BETWEEN', [1,3]]]
 	 *
 	 *		 If you pass an integer instead of an array it will be used as the primary key value for the table; result will be returned as "firstModelInstance" unless the returnAs option is explicitly set.
 	 *
@@ -11544,7 +11548,6 @@ $pa_options["display_form_field_tips"] = true;
 	
 		// Convert value array such that all values use operators
 		$pa_values = caNormalizeValueArray($pa_values, ['purify' => $vb_purify]);
-		
 		$va_sql_params = [];
 		
 		$vs_type_restriction_sql = '';
@@ -11682,8 +11685,14 @@ $pa_options["display_form_field_tips"] = true;
 						if ($vs_op !== '=') { $vs_op = 'IS'; }
 						$va_sql_wheres[] = "({$vs_field} {$vs_op} NULL)";
 					} elseif (is_array($vm_value) && sizeof($vm_value)) {
-						if (strtoupper($vs_op) !== 'NOT IN') { $vs_op = 'IN'; }
-						$va_sql_wheres[] = "({$vs_field} {$vs_op} (".join(',', $vm_value)."))";
+						if (!in_array(strtoupper($vs_op), ['=', 'NOT IN', 'BETWEEN'])) { $vs_op = 'IN'; }
+						if (strtoupper($vs_op) === 'BETWEEN') {
+							$va_sql_wheres[] = "({$vs_field} BETWEEN ? AND ?)";
+							$va_sql_params[] = $vm_value[0];
+							$va_sql_params[] = $vm_value[1];
+						} else {
+							$va_sql_wheres[] = "({$vs_field} {$vs_op} (".join(',', $vm_value)."))";
+						}
 					} elseif (caGetOption('allowWildcards', $pa_options, false) && (strpos($vm_value, '%') !== false)) {
 						$va_sql_wheres[] = "({$vs_field} LIKE {$vm_value})";
 					} else {

--- a/tests/testsWithData/find/FindTest.php
+++ b/tests/testsWithData/find/FindTest.php
@@ -63,7 +63,8 @@ class FindTest extends BaseTestWithData {
 			'intrinsic_fields' => array(
 				'type_id' => 'image',
 				'idno' => 'TEST & STUFF',
-				'acquisition_type_id' => 'gift'
+				'acquisition_type_id' => 'gift',
+				'extent' => 10
 			),
 			'preferred_labels' => array(
 				array(
@@ -144,7 +145,8 @@ class FindTest extends BaseTestWithData {
 		$this->assertGreaterThan(0, $this->opn_object_id2 = $this->addTestRecord('ca_objects', array(
 			'intrinsic_fields' => array(
 				'type_id' => 'dataset',
-				'idno' => 'Another TEST'
+				'idno' => 'Another TEST',
+				'extent' => 3
 			),
 			'preferred_labels' => array(
 				array(
@@ -349,8 +351,68 @@ Said, hey honey, take a walk on the wild side.'
 		$this->assertIsArray($vm_ret);
 		$this->assertCount(2, $vm_ret);
 		$this->assertContains($this->opn_object_id, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);	
+	}
+	# -------------------------------------------------------
+	public function testBaseModelFindByIntrinsicWithNotInOperator() {	
+		$vm_ret = ca_objects::find(['idno' => ['NOT IN', ['INVALID VALUE', 'Another TEST']]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['idno' => ['NOT IN', ['TEST & STUFF']]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
 		$this->assertContains($this->opn_object_id2, $vm_ret);
 		
+		$vm_ret = ca_objects::find(['idno' => ['NOT IN', ['INVALID VALUE']]], ['purify' => false, 'returnAs' => 'ids']);
+
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(2, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);	
+	}
+	# -------------------------------------------------------
+	public function testBaseModelFindByIntrinsicWithBetweenOperator() {	
+		$vm_ret = ca_objects::find(['extent' => ['BETWEEN', [1, 5]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['extent' => ['BETWEEN', [3, 100]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(2, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['extent' => ['BETWEEN', [8, 100]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['extent' => ['BETWEEN', [0, 2]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(0, $vm_ret);
+	}
+	# -------------------------------------------------------
+	public function testBaseModelFindByAttributeWithBetweenOperator() {	
+		$vm_ret = ca_objects::find(['integer_test' => ['BETWEEN', [400, 600]]], ['purify' => true, 'returnAs' => 'ids']);
+	
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['integer_test' => ['BETWEEN', [0, 1000]]], ['purify' => true, 'returnAs' => 'ids']);
+
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(2, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);
+		
+		$vm_ret = ca_objects::find(['integer_test' => ['BETWEEN', [5000, 100000]]], ['purify' => true, 'returnAs' => 'ids']);
+
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(0, $vm_ret);
 	}
 	# -------------------------------------------------------
 	public function testFindByPreferredLabelWithInOperator() {	
@@ -367,6 +429,18 @@ Said, hey honey, take a walk on the wild side.'
 		$this->assertCount(2, $vm_ret);
 		$this->assertContains($this->opn_object_id, $vm_ret);
 		$this->assertContains($this->opn_object_id2, $vm_ret);
+	}
+	# -------------------------------------------------------
+	public function testFindByPreferredLabelWithNotInOperator() {	
+		$vm_ret = ca_objects::find(['preferred_labels' => ['name' => ['NOT IN', ['Sound & Motion']]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id2, $vm_ret);	
+		
+		$vm_ret = ca_objects::find(['preferred_labels' => ['name' => ['NOT IN', ['INVALID VALUE', 'A Walk on the Wild Side']]]], ['purify' => true, 'returnAs' => 'ids']);
+		$this->assertIsArray($vm_ret);
+		$this->assertCount(1, $vm_ret);
+		$this->assertContains($this->opn_object_id, $vm_ret);
 	}
 	# -------------------------------------------------------
 	public function testFindByNonPreferredLabelWithInOperator() {	


### PR DESCRIPTION
PR adds support for BETWEEN range queries on scalar values in BaseModel::find() and LabelableBaseModelWithAttributes::find()