### PR TITLE
PROV-2860 Strip file extensions off of generated download file names 

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -4922,7 +4922,8 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 			case 'original_name':
 			default:
 				if (strpos($mode, "^") !== false) { // template
-				   $filename = caProcessTemplateForIDs($mode, 'ca_object_representations', [$data['representation_id']]);
+				   $filename = preg_replace('!\.[A-Za-z]{1}[A-Za-z0-9]{1,3}$!', '', caProcessTemplateForIDs($mode, 'ca_object_representations', [$data['representation_id']]));
+				   
 				} elseif ($data['original_filename']) {
 					$tmp = explode('.', $data['original_filename']);
 					if (sizeof($tmp) > 1) { 


### PR DESCRIPTION
PR alters download file naming to strip file extensions off of generated download file names before appending current extension. The avoids ugly double extensions.