### PR TITLE
NOJIRA Support SSL for ElasticSearch hosts.

### DIFF
--- a/app/lib/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch.php
@@ -239,7 +239,7 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 	protected function getClient() {
 		if(!self::$client) {
 			self::$client = Elasticsearch\ClientBuilder::create()
-				->setHosts([$this->elasticsearch_base_url])
+				->setHosts([parse_url($this->elasticsearch_base_url)])
 				->setRetries(3)
 				->build();
 		}


### PR DESCRIPTION
* Prior to this when trying to connect to an instance on SSL this would lead to an exceptoin as ES uses http by default.