### PR TITLE
Tolerate invalid dependent value template tags

### DIFF
--- a/assets/ca/ca.displaytemplateparser.js
+++ b/assets/ca/ca.displaytemplateparser.js
@@ -188,8 +188,6 @@ var caUI = caUI || {};
                         if (d) { 
                         	t=t.replace(tag, d.replace('&nbsp;', ' ').trim());
                         	bAtLeastOneValueIsSet = true; 
-                        } else {
-                        	t=t.replace(tag, '');
                         }
                         cmds.push(null);
                         qtys.push(null);


### PR DESCRIPTION
PR avoid javascript errors when invalid tags are used in dependent value templates. Invalid tags are left as-is so they can be detected and resolved.