### PR TITLE
PROV-2959,2960, 2961, 2962, 2965 Various bug fixes 

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -799,7 +799,7 @@
 								if ($vs_laddered_val = BaseRefinery::parsePlaceholder($va_p[$vs_display_field], $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true, 'returnDelimitedValueAt' => $vn_x))) {
 									$vs_item = $vs_laddered_val;
 									if ($o_log) { $o_log->logDebug(_t("[{$ps_refinery_name}] Used parent value %1 because the mapped value was blank", $vs_item)); }
-									$va_val['_type'] = BaseRefinery::parsePlaceholder($va_p['type'], $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true, 'returnDelimitedValueAt' => $vn_x));
+									$va_val['_type'] = BaseRefinery::parsePlaceholder($va_p['type'], $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true, 'returnDelimitedValueAt' => $vn_x, 'applyImportItemSettings' => false));
 									if ($vs_idno_fld = $t_instance->getProperty('ID_NUMBERING_ID_FIELD')) {
 									    $va_val[$vs_idno_fld] = BaseRefinery::parsePlaceholder($va_p[$vs_idno_fld], $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true, 'returnDelimitedValueAt' => $vn_x));
 									}
@@ -828,12 +828,12 @@
 							&&
 							($vs_type_opt = $pa_item['settings']["{$ps_refinery_name}_{$ps_item_prefix}Type"])
 						) {
-							$va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader));
+							$va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader, 'applyImportItemSettings' => false));
 						}
 			
 						if((!isset($va_val['_type']) || !$va_val['_type']) && ($vs_type_opt = $pa_item['settings']["{$ps_refinery_name}_{$ps_item_prefix}TypeDefault"])) {
-							if (!($va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnDelimitedValueAt' => $vn_x)))) {
-								$va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader));
+							if (!($va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnDelimitedValueAt' => $vn_x, 'applyImportItemSettings' => false)))) {
+								$va_val['_type'] = BaseRefinery::parsePlaceholder($vs_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader, 'applyImportItemSettings' => false));
 							}
 						}
 				
@@ -1077,7 +1077,7 @@
 							&&
 							($vs_rel_type_opt = $pa_item['settings']["{$ps_refinery_name}_relationshipType"])
 						) {
-							$va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader));
+							$va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('returnAsString' => true, 'reader' => $o_reader, 'applyImportItemSettings' => false));
 						}
 			
 						if (
@@ -1085,8 +1085,8 @@
 							&& 
 							($vs_rel_type_opt = $pa_item['settings']["{$ps_refinery_name}_relationshipTypeDefault"])	
 						) {
-							if (!($va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true,  'returnDelimitedValueAt' => $vn_x)))) {
-								$va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'returnAsString' => true));
+							if (!($va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'delimiter' => $va_delimiter, 'returnAsString' => true,  'returnDelimitedValueAt' => $vn_x, 'applyImportItemSettings' => false)))) {
+								$va_val['_relationship_type'] = BaseRefinery::parsePlaceholder($vs_rel_type_opt, $pa_source_data, $pa_item, $pn_value_index, array('reader' => $o_reader, 'returnAsString' => true, 'applyImportItemSettings' => false));
 							}
 						}
 

--- a/app/helpers/preload.php
+++ b/app/helpers/preload.php
@@ -95,7 +95,7 @@ spl_autoload_register(function ($class) {
     }
     
     // search common locations for class
-    $paths = [__CA_LIB_DIR__, __CA_LIB_DIR__.'/Utils', __CA_LIB_DIR__.'/Parsers'];
+    $paths = [__CA_LIB_DIR__, __CA_LIB_DIR__.'/Utils', __CA_LIB_DIR__.'/Parsers', __CA_LIB_DIR__.'/Media'];
     foreach($paths as $path) {
         if(file_exists("{$path}/{$class}.php")) {
             if(require("{$path}/{$class}.php")) { return true; }   

--- a/app/lib/Attributes/Values/LCSHAttributeValue.php
+++ b/app/lib/Attributes/Values/LCSHAttributeValue.php
@@ -345,7 +345,7 @@
 									'value_longtext2' => $vs_url,							// uri
 									'value_decimal1' => is_numeric($vs_id) ? $vs_id : null	// id
 								);
-							
+								break;
 							}
 						}
 					}	

--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -368,8 +368,8 @@
 			
 			$purifier = new HTMLPurifier();
 			foreach($pa_row_ids as $vn_i => $vn_row_id) {
-			    $vn_row_id = $purifier->purify(urldecode($vn_row_id)); // sanitize facet values
-				$va_criteria[$ps_facet_name][urldecode($vn_row_id)] = true;
+			    $vn_row_id = str_replace("&amp;", "&", $purifier->purify(rawurldecode($vn_row_id))); // sanitize facet values
+				$va_criteria[$ps_facet_name][$vn_row_id] = true;
 				
 				if (isset($pa_display_strings[$vn_i])) { $va_criteria_display_strings[$ps_facet_name][urldecode($vn_row_id)] = $pa_display_strings[$vn_i]; }
 			}

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -2973,6 +2973,9 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			'limit' => $limit
 		];
 
+
+		$policy = caGetOption('showCurrentOnly', $pa_bundle_settings, false) ? caGetOption('policy', $pa_bundle_settings, null) : null;
+
 		if($ps_related_table == 'ca_sets') {
 			// sets special case
 			
@@ -2994,8 +2997,19 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			}
 
 			return $va_vals;
-		} elseif (sizeof($va_items = $this->getRelatedItems($ps_related_table, array_merge($va_get_related_opts, ['returnAs' => 'data', 'sort' => $sort, 'sortDirection' => $sort_direction, 'start' => $start, 'limit' => $limit])))) { //, ['start' => caGetOption('start', $pa_options, 0), 'limit' => $limit]
-			// Show full list
+		} else {
+			if (($policy) && is_array($h = $this->getContents($policy, ['returnHistoryTrackingData' => true]))) {	
+				$rel_table_num = (int)$t_rel->tableNum(); 
+				$rel_pk = $t_rel->primaryKey();
+				
+				$va_items = array_map(function($v) use ($rel_pk) { 
+					return ['relation_id' => $v['tracked_row_id'], $rel_pk => $v['row_id']];	// Convert history list to item list format required below
+				}, array_filter($h, function($v) use ($rel_table_num) {
+					return ((int)$v['table_num'] === $rel_table_num);		// Filter out any current values thar aren't for the the related table
+				}));
+			} else {
+				$va_items = $this->getRelatedItems($ps_related_table, array_merge($va_get_related_opts, ['returnAs' => 'data', 'sort' => $sort, 'sortDirection' => $sort_direction, 'start' => $start, 'limit' => $limit]));
+			}
 			
 			if ($vb_is_many_many) {
 				$va_ids = caExtractArrayValuesFromArrayOfArrays($va_items, 'relation_id');

--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -1863,6 +1863,7 @@
 		 * @param string $policy 
 		 * @param array $options Array of options. Options include:
 		 *		row_id = 
+		 *		returnHistoryTrackingData = Return arrray with internal history tracking data. [Default is false]
 		 *
 		 * @return SearchResult 
 		 */
@@ -1871,7 +1872,8 @@
 			if (!$policy) { if (!($policy = $this->getDefaultHistoryTrackingCurrentValuePolicy())) { return null; } }
 		
 			$values = ca_history_tracking_current_values::find(['policy' => $policy, 'current_table_num' => $this->tableNum(), 'current_row_id' => $row_id], ['returnAs' => 'arrays', 'transaction' => $this->getTransaction()]);
-		
+			if(caGetOption('returnHistoryTrackingData', $options, false)) { return $values; }
+			
 			$ids = array_map(function($v) { return $v['row_id']; }, $values);
 			$row = array_shift($values);
 	

--- a/app/lib/Import/BaseRefinery.php
+++ b/app/lib/Import/BaseRefinery.php
@@ -135,6 +135,7 @@
 		 *		returnAsString = Return array of repeating values as string using delimiter. Has effect only is $pn_index parameter is set to null. [Default is false]
 		 *		delimiter = Delimiter to join array values with when returnAsString option is set; or the delimiter to use when breaking apart a value for return via the returnDelimitedValueAt option. [Default is ";"]
 		 *		returnDelimitedValueAt = Return a specific part of a value delimited by the "delimiter" option. Only has effect when returning a specific index of a repeating value (Eg. $pn_index is not null). The option value is a zero-based index. [Default is null – return entire value]
+		 *		applyImportItemSettings = Apply mapping options such as applyRegularExpressions to value. [Default is true]
 		 *
 		 * @return mixed An array or string
 		 */
@@ -256,11 +257,16 @@
 				}
 			}
 			if (!is_array($vm_val)) { $vm_val = [$vm_val]; }
+			
+			$apply_import_item_settings = caGetOption('applyImportItemSettings', $pa_options, true);
 			foreach($vm_val as $i => $v) {
                 if (is_array($pa_item['settings']['original_values']) && (($vn_i = array_search(mb_strtolower($v), $pa_item['settings']['original_values'])) !== false)) {
                     $v = $pa_item['settings']['replacement_values'][$vn_i];
                 }
-                $v = caProcessImportItemSettingsForValue($v, $pa_item['settings']);
+                
+                if ($apply_import_item_settings) {
+               		$v = caProcessImportItemSettingsForValue($v, $pa_item['settings']);
+               	}
                 $vm_val[$i] = $v;
             }
 			

--- a/app/lib/Media.php
+++ b/app/lib/Media.php
@@ -374,7 +374,7 @@ class Media extends BaseObject {
 		$this->instance->set('version', '');
 		$files = $this->instance->writePreviews($this->filepath, $options);
 		
-		if(caGetOption('cleanupFiles', $options, true)) {
+		if(is_array($files) && caGetOption('cleanupFiles', $options, true)) {
 			$this->tmp_files = array_unique(array_merge($this->tmp_files, $files));
 		}
 		return $files;

--- a/app/lib/Media.php
+++ b/app/lib/Media.php
@@ -48,26 +48,65 @@ class Media extends BaseObject {
 	# ----------------------------------------------------------
 	# Properties
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public $DEBUG = false;
-	private $plugins = array();
+	
+	/**
+	 *
+	 */
+	private $plugins = [];
+	
+	/**
+	 *
+	 */
 	private $instance;
 	
 	# --- 
 	# Cache loaded plug-ins
 	# ---
-	static $WLMedia_plugin_cache = array();
-	static $WLMedia_unregistered_plugin_cache = array();
+	/**
+	 *
+	 */
+	static $WLMedia_plugin_cache = [];
+	
+	/**
+	 *
+	 */
+	static $WLMedia_unregistered_plugin_cache = [];
+	
+	/**
+	 *
+	 */
 	static $WLMedia_plugin_names = null;
 	
+	/**
+	 *
+	 */
 	static $plugin_path = null;
 	
+	/**
+	 *
+	 */
 	static $s_file_extension_to_plugin_map = null; 
 	
+	/**
+	 *
+	 */
 	static $s_divine_cache = [];
+	
+	/**
+	 *
+	 */
+	 private $tmp_files = [];
 	
 	# ----------------------------------------------------------
 	# Methods
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function __construct($pb_no_cache=false) { 
 		if (!Media::$plugin_path) { Media::$plugin_path = __CA_LIB_DIR__.'/Plugins/Media'; }
 		
@@ -77,10 +116,13 @@ class Media extends BaseObject {
 		Media::$s_file_extension_to_plugin_map = CompositeCache::fetch('media_file_extension_to_plugin_map');
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getPluginNames() {
 		if (is_array(Media::$WLMedia_plugin_names)) { return Media::$WLMedia_plugin_names; }
 		
-		Media::$WLMedia_plugin_names = array();
+		Media::$WLMedia_plugin_names = [];
 		$dir = opendir(Media::$plugin_path);
 		if (!$dir) { throw new ApplicationException(_t('Cannot open media plugin directory %1', Media::$plugin_path)); }
 	
@@ -103,16 +145,16 @@ class Media extends BaseObject {
 	/**
 	 *
 	 */
-	public function getPlugin($ps_plugin_name) {
-		if (!($p = $this->getUnregisteredPlugin($ps_plugin_name))) { return null; }
+	public function getPlugin($plugin_name) {
+		if (!($p = $this->getUnregisteredPlugin($plugin_name))) { return null; }
 		
 		# register the plugin's capabilities
 		if ($vo_instance = $p->register()) {
-			if ($this->DEBUG) {	print "[DEBUG] LOADED $ps_plugin_name<br>\n"; }
-			return Media::$WLMedia_plugin_cache[$ps_plugin_name] = $vo_instance;
+			if ($this->DEBUG) {	print "[DEBUG] LOADED $plugin_name<br>\n"; }
+			return Media::$WLMedia_plugin_cache[$plugin_name] = $vo_instance;
 		} else {
-			if ($this->DEBUG) {	print "[DEBUG] DID NOT LOAD $ps_plugin_name<br>\n"; }
-			Media::$WLMedia_plugin_cache[$ps_plugin_name] = false;
+			if ($this->DEBUG) {	print "[DEBUG] DID NOT LOAD $plugin_name<br>\n"; }
+			Media::$WLMedia_plugin_cache[$plugin_name] = false;
 			return null;
 		}
 	}
@@ -120,35 +162,38 @@ class Media extends BaseObject {
 	/**
 	 *
 	 */
-	public function getUnregisteredPlugin($ps_plugin_name) {
-		if(!in_array($ps_plugin_name, $this->getPluginNames())) { return null; }
+	public function getUnregisteredPlugin($plugin_name) {
+		if(!in_array($plugin_name, $this->getPluginNames())) { return null; }
 		
 		$plugin_dir = Media::$plugin_path;
 		
 		# load the plugin
-		if (!class_exists("WLPlugMedia{$ps_plugin_name}")) { 
-			require_once("{$plugin_dir}/{$ps_plugin_name}.php"); 
+		if (!class_exists("WLPlugMedia{$plugin_name}")) { 
+			require_once("{$plugin_dir}/{$plugin_name}.php"); 
 		}
-		$ps_plugin_class = "WLPlugMedia{$ps_plugin_name}";
+		$ps_plugin_class = "WLPlugMedia{$plugin_name}";
 		$p = new $ps_plugin_class();
 		
-		Media::$WLMedia_unregistered_plugin_cache[$ps_plugin_name] = $p;
+		Media::$WLMedia_unregistered_plugin_cache[$plugin_name] = $p;
 		
 		return $p;
 	}
 	# ----------------------------------------------------------
-	public function checkPluginStatus($ps_plugin_name) {
+	/**
+	 *
+	 */
+	public function checkPluginStatus($plugin_name) {
 		
-		if(!in_array($ps_plugin_name, $this->getPluginNames())) { return null; }
-		if (isset(Media::$WLMedia_plugin_cache[$ps_plugin_name])) { return Media::$WLMedia_plugin_cache[$ps_plugin_name]; }
+		if(!in_array($plugin_name, $this->getPluginNames())) { return null; }
+		if (isset(Media::$WLMedia_plugin_cache[$plugin_name])) { return Media::$WLMedia_plugin_cache[$plugin_name]; }
 		
 		$plugin_dir = Media::$plugin_path;
 		
 		# load the plugin
-		if (!class_exists("WLPlugMedia{$ps_plugin_name}")) { 
-			require_once("{$plugin_dir}/{$ps_plugin_name}.php"); 
+		if (!class_exists("WLPlugMedia{$plugin_name}")) { 
+			require_once("{$plugin_dir}/{$plugin_name}.php"); 
 		}
-		$vs_classname = "WLPlugMedia{$ps_plugin_name}";
+		$vs_classname = "WLPlugMedia{$plugin_name}";
 		$p = new $vs_classname;
 		# register the plugin's capabilities
 		
@@ -159,15 +204,15 @@ class Media extends BaseObject {
 	 * Determine format of a file
 	 *
 	 * @param string $ps_filepath
-	 * @param array $pa_options Options include:
+	 * @param array $options Options include:
 	 *		noCache = don't use cache. [Default is false]
 	 *		returnPluginInstance = Return instance of media plugin rather than mimetype. [Default is false]
 	 *
 	 * @return mixed String Mimetype of file, or null if file is in an unknown format. If returnPluginInstance option is set then a plugin capable of handling the file is returned.
 	 */
-	function divineFileFormat($ps_filepath, $pa_options=null) {
-		$pb_return_plugin_instance = caGetOption('returnPluginInstance', $pa_options, false);
-		$pb_no_cache = caGetOption('noCache', $pa_options, false);
+	function divineFileFormat($ps_filepath, $options=null) {
+		$pb_return_plugin_instance = caGetOption('returnPluginInstance', $options, false);
+		$pb_no_cache = caGetOption('noCache', $options, false);
 		
 		if (!$pb_no_cache && $pb_return_plugin_instance && isset(Media::$s_divine_cache[$ps_filepath.'_plugin'])) { return Media::$s_divine_cache[$ps_filepath.'_plugin']; }
 		if (!$pb_no_cache && isset(Media::$s_divine_cache[$ps_filepath])) { return Media::$s_divine_cache[$ps_filepath]; }
@@ -205,48 +250,72 @@ class Media extends BaseObject {
 		}
 	}
 	# ----------------------------------------------------------
-	public function getMimetypeTypename($ps_mimetype) {
+	/**
+	 *
+	 */
+	public function getMimetypeTypename($mimetype) {
 		$va_plugin_names = $this->getPluginNames();
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			$va_plugin_info = $this->getPlugin($vs_plugin_name);
 			$o_plugin = $va_plugin_info["INSTANCE"];
-			if (isset($o_plugin->typenames[$ps_mimetype]) && ($vs_typename = $o_plugin->typenames[$ps_mimetype])) {
+			if (isset($o_plugin->typenames[$mimetype]) && ($vs_typename = $o_plugin->typenames[$mimetype])) {
 				return $vs_typename;
 			}
 		}
 		return "unknown";
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function get($property) {
 		if (!$this->instance) { return ""; }
 		return $this->instance->get($property);
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getProperties() {
 		if (!$this->instance) { return ""; }
 		return $this->instance->properties;
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function set($property, $value) {
 		if (!$this->instance) { return false; }
 		$this->instance->set($property, $value);
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getExtractedText() {
 		if (!$this->instance) { return false; }
 		return $this->instance->getExtractedText();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getExtractedTextLocations() {
 		if (!$this->instance) { return false; }
 		return $this->instance->getExtractedTextLocations();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getExtractedMetadata() {
 		if (!$this->instance) { return false; }
 		return $this->instance->getExtractedMetadata();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function read($filepath, $mimetype=null, $options=null) {
 		if ((!$this->instance) || ($filepath != $this->filepath)) {
 			$this->instance = $this->divineFileFormat($filepath, ['returnPluginInstance' => true]);
@@ -267,6 +336,9 @@ class Media extends BaseObject {
 		}
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function transform($operation, $parameters) {
 		if (!$this->instance) { return false; }
 		if (!($vb_ret = $this->instance->transform($operation, $parameters))) {
@@ -275,59 +347,88 @@ class Media extends BaseObject {
 		return $vb_ret;
 	}
 	# ----------------------------------------------------------
-	public function write($filepath, $mimetype, $pa_options=null) {
+	/**
+	 *
+	 */
+	public function write($filepath, $mimetype, $options=null) {
 		if (!$this->instance) { return false; }
 		
 		# TODO: support for cross-plugin writes; that is, allow a file to be read in
 		# by a plugin and convert to an intermediate format supported by a second plugin
 		# in order to allow the second plug-in to write out the file in the desired format.
-		$rc = $this->instance->write($filepath, $mimetype, $pa_options);
+		$rc = $this->instance->write($filepath, $mimetype, $options);
 		$this->errors = $this->instance->errors;
 		return $rc;
 	}
 	# ----------------------------------------------------------
-	public function writePreviews($pa_options) {
+	/**
+	 * Write media preview files for currently loaded media
+	 *
+	 * @param array $options Options include:
+	 *		cleanupFiles = Delete generated files when Media instance is garbage collected. [Default is true]
+	 */
+	public function writePreviews($options=null) {
 		if (!$this->instance) { return false; }
 	
 		if (!method_exists($this->instance, 'writePreviews')) { return false; }
 		$this->instance->set('version', '');
-		return $this->instance->writePreviews($this->filepath, $pa_options);
-	}
-	# ----------------------------------------------------------
-	public function joinArchiveContents($pa_files, $pa_options = array()) {
-		if (!$this->instance) { return false; }
-	
-		if (!method_exists($this->instance, 'joinArchiveContents')) { return false; }
-		$this->instance->set('version', '');
-		return $this->instance->joinArchiveContents($pa_files, $pa_options);
+		$files = $this->instance->writePreviews($this->filepath, $options);
+		
+		if(caGetOption('cleanupFiles', $options, true)) {
+			$this->tmp_files = array_unique(array_merge($this->tmp_files, $files));
+		}
+		return $files;
 	}
 	# ----------------------------------------------------------
 	/**
 	 *
 	 */
-	public function writeClip($ps_filename, $ps_start_, $ps_end, $pa_options=null) {
+	public function joinArchiveContents($pa_files, $options = []) {
+		if (!$this->instance) { return false; }
+	
+		if (!method_exists($this->instance, 'joinArchiveContents')) { return false; }
+		$this->instance->set('version', '');
+		return $this->instance->joinArchiveContents($pa_files, $options);
+	}
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
+	public function writeClip($ps_filename, $ps_start_, $ps_end, $options=null) {
 		if (!$this->instance) { return false; }
 		
 		if (method_exists($this->instance, "writeClip")) {
-			return $this->instance->writeClip($ps_filename, $ps_start_, $ps_end, $pa_options);
+			return $this->instance->writeClip($ps_filename, $ps_start_, $ps_end, $options);
 		}
 		return null;
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getOutputFormats() {
 		if (!$this->instance) { return false; }
 		return $this->instance->getOutputFormats();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function getTransformations() {
 		if (!$this->instance) { return false; }
 		return $this->instance->getTransformations();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function reset() {
 		return $this->instance->reset();
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function cleanup() {
 		if ($this->instance) {
 			return $this->instance->cleanup();
@@ -336,31 +437,43 @@ class Media extends BaseObject {
 		}
 	}
 	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function dump() {
 		print_r($this->getPluginNames());
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function mimetype2extension($mimetype) {
 		if (!$this->instance) {
 			return "";
 		}
 		return $this->instance->mimetype2extension($mimetype);
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function extension2mimetype($extension) {
 		if (!$this->instance) {
 		  	return "";
 		}
 		return $this->instance->extension2mimetype($extension);
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
 	public function mimetype2typename($mimetype) {
 		if (!$this->instance) {
 		  return "";
 		}
 		return $this->instance->mimetype2typename($mimetype);
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return list of file extensions for media formats supported for import
 	 *
@@ -374,7 +487,7 @@ class Media extends BaseObject {
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$va_extensions = array();
+		$va_extensions = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
@@ -384,7 +497,7 @@ class Media extends BaseObject {
 		CompositeCache::save('getImportFileExtensions', $va_extensions = array_unique($va_extensions), 'Media');
 		return $va_extensions;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return list of file extensions for media formats supported for import
 	 *
@@ -409,7 +522,7 @@ class Media extends BaseObject {
 		CompositeCache::save('getPluginImportFileExtensionMap', $va_map, 'Media');
 		return $va_map;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return list of mimetypes for media formats supported for import
 	 *
@@ -422,7 +535,7 @@ class Media extends BaseObject {
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$va_extensions = array();
+		$va_extensions = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
@@ -432,14 +545,14 @@ class Media extends BaseObject {
 		CompositeCache::save('getImportMimetypes', $va_extensions = array_unique($va_extensions), 'Media');
 		return $va_extensions;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	private function getPluginsForMimetypes() {
 		if (CompositeCache::contains('getPluginsForMimetypes', 'Media')) {
 			return CompositeCache::fetch('getPluginsForMimetypes', 'Media');
 		}
 		$va_plugin_names = $this->getPluginNames();
 
-		$va_return = array();
+		$va_return = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $this->getPlugin($vs_plugin_name)) { continue; }
 			/** @var BaseMediaPlugin $o_plugin */
@@ -451,7 +564,7 @@ class Media extends BaseObject {
 		CompositeCache::save('getPluginsForMimetypes', $va_return, 'Media');
 		return $va_return;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return list of file extensions for media formats supported for export
 	 *
@@ -465,7 +578,7 @@ class Media extends BaseObject {
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$va_extensions = array();
+		$va_extensions = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
@@ -475,7 +588,7 @@ class Media extends BaseObject {
 		CompositeCache::save('getExportFileExtensions', $va_extensions = array_unique($va_extensions), 'Media');
 		return $va_extensions;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return list of mimetypes for media formats supported for export
 	 *
@@ -489,7 +602,7 @@ class Media extends BaseObject {
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$mimetypes = array();
+		$mimetypes = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
@@ -499,7 +612,7 @@ class Media extends BaseObject {
 		CompositeCache::save('getExportMimetypes', $mimetypes = array_unique($mimetypes), 'Media');
 		return $mimetypes;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return mimetype for given file extension. Only formats supported by an installed plugin for import or export are recognized.
 	 *
@@ -514,7 +627,7 @@ class Media extends BaseObject {
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$va_formats = array();
+		$va_formats = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
@@ -525,39 +638,39 @@ class Media extends BaseObject {
 		CompositeCache::save($ps_extension, $ret = $va_formats[strtolower($ps_extension)], 'Media_getMimetypeForExtension');
 		return $ret;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return file extension for given mimetype. Only formats supported by an installed plugin for import or export are recognized.
 	 *
 	 * @return string File extension or null if mimetype is not recognized.
 	 */
-	public static function getExtensionForMimetype($ps_mimetype) {
-		if(!$ps_mimetype) { return null; }
-		if (CompositeCache::contains($ps_mimetype, 'Media_getExtensionForMimetype')) {
-			return CompositeCache::fetch($ps_mimetype, 'Media_getExtensionForMimetype');
+	public static function getExtensionForMimetype($mimetype) {
+		if(!$mimetype) { return null; }
+		if (CompositeCache::contains($mimetype, 'Media_getExtensionForMimetype')) {
+			return CompositeCache::fetch($mimetype, 'Media_getExtensionForMimetype');
 		}
 		$o_media = new Media();
 		$va_plugin_names = $o_media->getPluginNames();
 		
-		$va_formats = array();
+		$va_formats = [];
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
 			$va_formats = array_merge($va_formats, $o_plugin->getImportFormats(), $o_plugin->getExportFormats());
 		}
-		CompositeCache::save($ps_mimetype, $ret = $va_formats[strtolower($ps_mimetype)], 'Media_getExtensionForMimetype');
+		CompositeCache::save($mimetype, $ret = $va_formats[strtolower($mimetype)], 'Media_getExtensionForMimetype');
 		return $ret;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	/**
 	 * Return file type name for given mimetype. Only formats supported by an installed plugin for import or export are recognized.
 	 *
 	 * @return string Type name or null if mimetype is not recognized.
 	 */
-	public static function getTypenameForMimetype($ps_mimetype) {
-		if(!$ps_mimetype) { return null; }
-		if (CompositeCache::contains($ps_mimetype, "Media_getTypenameForMimetype")) {
-			return CompositeCache::fetch($ps_mimetype, "Media_getTypenameForMimetype");
+	public static function getTypenameForMimetype($mimetype) {
+		if(!$mimetype) { return null; }
+		if (CompositeCache::contains($mimetype, "Media_getTypenameForMimetype")) {
+			return CompositeCache::fetch($mimetype, "Media_getTypenameForMimetype");
 		}
 		
 		$o_media = new Media();
@@ -565,30 +678,47 @@ class Media extends BaseObject {
 		foreach ($va_plugin_names as $vs_plugin_name) {
 			if (!$va_plugin_info = $o_media->getPlugin($vs_plugin_name)) { continue; }
 			$o_plugin = $va_plugin_info["INSTANCE"];
-			if ($vs_typename = $o_plugin->mimetype2typename($ps_mimetype)) {
-				CompositeCache::save($ps_mimetype, $vs_typename, "Media_getTypenameForMimetype");
+			if ($vs_typename = $o_plugin->mimetype2typename($mimetype)) {
+				CompositeCache::save($mimetype, $vs_typename, "Media_getTypenameForMimetype");
 				return $vs_typename;
 			}
 		}
-		CompositeCache::save($ps_mimetype, null, "Media_getTypenameForMimetype");
+		CompositeCache::save($mimetype, null, "Media_getTypenameForMimetype");
 		return null;
 	}
-	# ------------------------------------------------
+	# ----------------------------------------------------------
 	# --- 
-	# ------------------------------------------------
-	public function htmlTag($ps_mimetype, $ps_url, $pa_properties, $pa_options=null, $pa_volume_info=null) {
-		if (!$ps_mimetype) { return _t('No media available'); }
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
+	public function htmlTag($mimetype, $ps_url, $pa_properties, $options=null, $pa_volume_info=null) {
+		if (!$mimetype) { return _t('No media available'); }
 		
 		$map = $this->getPluginsForMimetypes();
-		if(is_array($map[$ps_mimetype]) && ($vs_plugin_name = $map[$ps_mimetype][0])) {
+		if(is_array($map[$mimetype]) && ($vs_plugin_name = $map[$mimetype][0])) {
 			$p = $this->getUnregisteredPlugin($vs_plugin_name);
-			if ((isset($p->info['EXPORT'][$ps_mimetype])) || (isset($p->info['IMPORT'][$ps_mimetype]))) {
-				$pa_properties["mimetype"] = $ps_mimetype;
-				return $p->htmlTag($ps_url, $pa_properties, $pa_options, $pa_volume_info);
+			if ((isset($p->info['EXPORT'][$mimetype])) || (isset($p->info['IMPORT'][$mimetype]))) {
+				$pa_properties["mimetype"] = $mimetype;
+				return $p->htmlTag($ps_url, $pa_properties, $options, $pa_volume_info);
 			}
 		}
 		
-		return _t("Could not find plug-in for mimetype %1", $ps_mimetype);
+		return _t("Could not find plug-in for mimetype %1", $mimetype);
+	}
+	# ----------------------------------------------------------
+	# --- 
+	# ----------------------------------------------------------
+	/**
+	 * 
+	 */
+	public function __destruct() {
+		// Clean up tmp files
+		if(is_array($tmp_files)) {
+			foreach($tmp_files as $f) {
+				@unlink($f);
+			}
+		}
 	}
 	# ------------------------------------------------
 }

--- a/app/models/ca_editor_ui_screens.php
+++ b/app/models/ca_editor_ui_screens.php
@@ -858,6 +858,25 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 								'width' => "475px", 'height' => '100px',
 								'label' => _t('Relationship display template'),
 								'description' => _t('Layout for relationship when displayed in list (can include HTML). Element code tags prefixed with the ^ character can be used to represent the value in the template. For example: <i>^my_element_code</i>.')
+							),
+							'showCurrentOnly' => array(
+								'formatType' => FT_TEXT,
+								'displayType' => DT_CHECKBOXES,
+								'width' => 10, 'height' => 1,
+								'takesLocale' => false,
+								'showOnSelect' => 'policy',
+								'default' => '0',
+								'label' => _t('Show current only?'),
+								'description' => _t('If checked only current relationships are displayed.')
+							),
+							'policy' => array(
+								'formatType' => FT_TEXT,
+								'displayType' => DT_SELECT,
+								'default' => '__default__',
+								'width' => "275px", 'height' => 1,
+								'useHistoryTrackingReferringPolicyList' => true,
+								'label' => _t('Use history tracking policy'),
+								'description' => ''
 							)
 						);	
 						

--- a/app/models/ca_sets.php
+++ b/app/models/ca_sets.php
@@ -2537,7 +2537,8 @@ LEFT JOIN ca_object_representations AS cor ON coxor.representation_id = cor.repr
 				$va_sets[$set_id = $qr_res->get('set_id')] = array_merge($qr_res->getRow(), [
 					'set_content_type' => $vs_set_type, 'set_type' => $vs_type,
 					'label' => $labels[$set_id], 'count' => isset($counts[$set_id]) ? $counts[$set_id] : 0,
-					'item_type_singular' => Datamodel::getTableProperty($vn_table_num, 'NAME_SINGULAR'), 'item_type_plural' => Datamodel::getTableProperty($vn_table_num, 'NAME_PLURAL')
+					'item_type_singular' => Datamodel::getTableProperty($vn_table_num, 'NAME_SINGULAR'), 'item_type_plural' => Datamodel::getTableProperty($vn_table_num, 'NAME_PLURAL'),
+					'created' => $created['timestamp'], 'created_display' => caGetLocalizedDate($created['timestamp'])
 				]);
 			}
 			return $va_sets;

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -7721,3 +7721,7 @@ div.mediaMetadataActionButton a, div.mediaMetadataActionButton span a {
     text-decoration: none;
     color: #000;
 }
+
+p.abbreviatedPath, div.abbreviatedPath, span.abbreviatedPath {
+	cursor: help;
+}

--- a/themes/default/views/manage/set_list_html.php
+++ b/themes/default/views/manage/set_list_html.php
@@ -144,7 +144,9 @@ if (!$this->request->isAjax()) {
 					<input type="checkbox" class="algebraSetSelector set-table-<?php print $va_set["table_num"]; ?>" name="algebra_set_id[]" data-table_num="<?php print $va_set["table_num"]; ?>" value="<?php print $va_set["set_id"]; ?>">
 				</td>
 				<td>
-					<div class="caItemListName"><?php print $va_set['name'].($va_set['set_code'] ? "<br/>(".$va_set['set_code'].")" : ""); ?></div>
+					<div class="caItemListName"><?php print $va_set['name'].($va_set['set_code'] ? 
+					((mb_strlen($va_set['set_code']) > 20) ? "<br/>(<span class='abbreviatedPath' title='{$va_set['set_code']}'>".
+					caTruncateStringWithEllipsis($va_set['set_code'], 20, 'start')."</span>)" : '<br/>('.$va_set['set_code'].')') : ""); ?></div>
 				</td>
 				<td>
 					<div><?php print $va_set['set_content_type']; ?></div>


### PR DESCRIPTION
PR addresses various issues:

PROV-2965 search issue when using terms containing ampersands passed through the browse as a _search facet. HTMLPurifier will encode ampersands. This change unescapes them prior to use.

PROV-2959 don't apply regexes to splitter option settings

PROV-2960 Use first match for LCSH lookups in import context

PROV-2961 Add current location support for related list bundles

PROV-2962 Clean up caMultiplagePreview tmp files generated by PDFWand plugin

Other: truncate long paths in media importer and set editor, add creation date to set list feed, extend autoloading to Media libs