### PR TITLE
PROV-2887 Patch to properly handle 180 degree orientation flip 

### DIFF
--- a/app/lib/Parsers/TilepicParser.php
+++ b/app/lib/Parsers/TilepicParser.php
@@ -1402,6 +1402,9 @@ class TilepicParser {
 					return false;
 				}
 				
+				
+				if($rotation == 180) { $slice->rotateimage("#FFFFFF", $rotation); }
+				
 				if (!$slice->setimageformat($magick)) {
 					$this->error = "Tile conversion failed: $reason; $description";
 					return false;


### PR DESCRIPTION
PR adds additional rotation to properly orient tilepic tiles when EXIF orientation flag indicates 180 degree rotation. For some reason, recent Gmagick versions fail to retain 180 degree rotation when clone() is used. Clone is used on Gmagick handles when generating tiles. The fix is to add a per-slice 180 degree rotation. Oddly, 90 and -90 degree rotations _do_ persist across clone()s.