### PR TITLE
PR-572 Anchor lookup lists

### DIFF
--- a/assets/ca/ca.relationbundle.js
+++ b/assets/ca/ca.relationbundle.js
@@ -119,7 +119,9 @@ var caUI = caUI || {};
 			var autocompleter_id = options.fieldNamePrefix + 'autocomplete' + id;
 
 			jQuery('#' + autocompleter_id).relationshipLookup( 
-				jQuery.extend({ minLength: ((parseInt(options.minChars) > 0) ? options.minChars : 3), delay: 800, html: true,
+				jQuery.extend({ 
+					minLength: ((parseInt(options.minChars) > 0) ? options.minChars : 3), delay: 800, html: true,
+					appendTo:options.container,
 					source: function( request, response ) {
 						$.ajax({
 							url: options.autocompleteUrl,


### PR DESCRIPTION
We found that the autocomplete lookup field for related fields (related collections, related entities,..) had side-effects: when the dropdown was shown, and the user scrolled outside this list, the body scrolled and the list got detached from the input field.
It appeared that the jquery autocomplete had no specific element referenced as the appendTo, thus defaults to appending it to the body.
I specified the appendTo as the 'parent' container via options.container option, and that keeps the dropdown in situ.