### PR TITLE
Refactor to use AAT query mocks

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -1448,15 +1448,19 @@ function caProcessRefineryRelatedMultiple($po_refinery_instance, &$pa_item, $pa_
 		return $po_sheet->getCellByColumnAndRow($pm_col, $pn_row_num);
 	}
 	# ---------------------------------------------------------------------
-	/**
-	 * Try to match given (partial) hierarchy path to a single subject in getty linked data AAT service
-	 * @param array $pa_hierarchy_path
-	 * @param int $pn_threshold
-	 * @param array $pa_options
-	 * 		removeParensFromLabels = Remove parens from labels for search and string comparison. This can improve results in specific cases.
-	 * @return bool|string
-	 */
-	function caMatchAAT($pa_hierarchy_path, $pn_threshold=180, $pa_options = array()) {
+    /**
+     * Try to match given (partial) hierarchy path to a single subject in getty linked data AAT service
+     *
+     * @param array $pa_hierarchy_path
+     * @param int   $pn_threshold
+     * @param array $pa_options
+     *        removeParensFromLabels = Remove parens from labels for search and string comparison. This can improve results in specific cases.
+     * @param null  $o_service
+     *
+     * @return bool|string
+     * @throws MemoryCacheInvalidParameterException
+     */
+	function caMatchAAT($pa_hierarchy_path, $pn_threshold=180, $pa_options = array(), $o_service=null) {
 		$vs_cache_key = md5(print_r($pa_hierarchy_path, true));
 		if(MemoryCache::contains($vs_cache_key, 'AATMatches')) {
 			return MemoryCache::fetch($vs_cache_key, 'AATMatches');
@@ -1475,7 +1479,9 @@ function caProcessRefineryRelatedMultiple($po_refinery_instance, &$pa_item, $pa_
 			$vs_lookup = $vs_bot;
 		}
 
-		$o_service = new WLPlugInformationServiceAAT();
+		if (is_null($o_service)) {
+		    $o_service = new WLPlugInformationServiceAAT();
+        }
 
 		$va_hits = $o_service->lookup(array(), $vs_lookup, array('phrase' => true, 'raw' => true, 'limit' => 2000));
 		if(!is_array($va_hits)) { return false; }

--- a/tests/helpers/ImportHelpersTest.php
+++ b/tests/helpers/ImportHelpersTest.php
@@ -269,21 +269,20 @@ class ImportHelpersTest extends TestCase {
         );
 
         $this->groups = array();
-
     }
 
     /**
      * Delete all records we created for this test to avoid side effects with other tests
      */
-    protected function tearDown() : void {
-        if($this->opb_care_about_side_effects) {
-            foreach($this->opa_record_map as $vs_table => &$va_records) {
+    protected function tearDown(): void {
+        if ($this->opb_care_about_side_effects) {
+            foreach ($this->opa_record_map as $vs_table => &$va_records) {
                 $t_instance = Datamodel::getInstance($vs_table);
                 // delete in reverse order so that we can properly
                 // catch potential hierarchical relationships
                 rsort($va_records);
-                foreach($va_records as $vn_id) {
-                    if($t_instance->load($vn_id)) {
+                foreach ($va_records as $vn_id) {
+                    if ($t_instance->load($vn_id)) {
                         $t_instance->setMode(ACCESS_WRITE);
                         $t_instance->delete(true, array('hard' => true));
                     }
@@ -294,27 +293,29 @@ class ImportHelpersTest extends TestCase {
             $this->checkRecordCounts();
         }
     }
+
     # -------------------------------------------------------
     private function checkRecordCounts() {
         // ensure there are no lingering records
         $o_db = new Db();
-        foreach(self::$opa_valid_tables as $vs_table) {
+        foreach (self::$opa_valid_tables as $vs_table) {
             $qr_rows = $o_db->query("SELECT count(*) AS c FROM {$vs_table}");
             $qr_rows->nextRow();
 
             // these two are allowed to have hierarchy roots
-            if(in_array($vs_table, array('ca_storage_locations', 'ca_places'))) {
+            if (in_array($vs_table, array('ca_storage_locations', 'ca_places'))) {
                 $vn_allowed_records = 1;
-            } else {
+            }
+            else {
                 $vn_allowed_records = 0;
             }
 
-            $this->assertEquals($vn_allowed_records, $qr_rows->get('c'), "Table {$vs_table} should be empty to avoid side effects between tests");
+            $this->assertEquals($vn_allowed_records, $qr_rows->get('c'),
+                    "Table {$vs_table} should be empty to avoid side effects between tests");
         }
     }
 
     protected function _runGenericImportSplitter($ps_refinery_name, $ps_table, $ps_type) {
-
         global $g_ui_locale_id;
         $g_ui_locale_id = 1;
         $ps_item_prefix = "";
@@ -338,7 +339,8 @@ class ImportHelpersTest extends TestCase {
      */
     protected function _loadRefinery($refinery_name): string {
         $refinery_class = $refinery_name . 'Refinery';
-        require_once(join(DIRECTORY_SEPARATOR, [__CA_APP_DIR__, 'refineries', $refinery_name, $refinery_class . '.php']));
+        require_once(join(DIRECTORY_SEPARATOR,
+                [__CA_APP_DIR__, 'refineries', $refinery_name, $refinery_class . '.php']));
         return $refinery_class;
     }
 
@@ -365,7 +367,8 @@ class ImportHelpersTest extends TestCase {
         $pa_options = array(
                 'refinery' => $stubRefinery,
         );
-        $result = caProcessRefineryParents($ps_refinery_name, $ps_table, $pa_parents, $pa_source_data, $pa_item, $pn_c, $pa_options);
+        $result = caProcessRefineryParents($ps_refinery_name, $ps_table, $pa_parents, $pa_source_data, $pa_item, $pn_c,
+                $pa_options);
         return $result;
     }
 
@@ -387,7 +390,8 @@ class ImportHelpersTest extends TestCase {
     public function testAATMatchPrints() {
         // some real-world examples
         $vm_ret = caMatchAAT(
-                explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings')
+                explode(':',
+                        'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings')
         );
 
         $this->assertEquals('http://vocab.getty.edu/aat/300041365', $vm_ret);
@@ -396,7 +400,8 @@ class ImportHelpersTest extends TestCase {
     public function testAATMatchPaper() {
         // some real-world examples
         $vm_ret = caMatchAAT(
-                explode(':', 'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper')
+                explode(':',
+                        'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper')
         );
 
         $this->assertEquals('http://vocab.getty.edu/aat/300189621', $vm_ret);
@@ -406,7 +411,8 @@ class ImportHelpersTest extends TestCase {
         // some real-world examples
 
         $vm_ret = caMatchAAT(
-                explode(':', 'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract'),
+                explode(':',
+                        'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract'),
                 180, array('removeParensFromLabels' => true)
         );
 
@@ -417,7 +423,8 @@ class ImportHelpersTest extends TestCase {
         // some real-world examples
 
         $vm_ret = caMatchAAT(
-                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art'),
+                explode(':',
+                        'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art'),
                 180, array('removeParensFromLabels' => true)
         );
 
@@ -428,7 +435,8 @@ class ImportHelpersTest extends TestCase {
         // some real-world examples
 
         $vm_ret = caMatchAAT(
-                explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)'),
+                explode(':',
+                        'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)'),
                 180, array('removeParensFromLabels' => true)
         );
 
@@ -439,14 +447,14 @@ class ImportHelpersTest extends TestCase {
         // some real-world examples
 
         $vm_ret = caMatchAAT(
-                explode(':', 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)'),
+                explode(':',
+                        'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)'),
                 180, array('removeParensFromLabels' => true)
         );
 
         $this->assertEquals('http://vocab.getty.edu/aat/300054216', $vm_ret);
     }
     # -------------------------------------------------------
-
 
     /**
      *

--- a/tests/helpers/ImportHelpersTest.php
+++ b/tests/helpers/ImportHelpersTest.php
@@ -185,10 +185,11 @@ class ImportHelpersTest extends TestCase {
     # -------------------------------------------------------
     public function testAATMatchPeople() {
         // some real-world examples
-        $vm_ret = caMatchAAT(
-                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression: visual arts:abstraction')
-        );
+        $o_service = new WLPlugInformationServiceAAT();
 
+        $vm_ret = caMatchAAT(
+                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression: visual arts:abstraction'),
+                null, null, $o_service);
         $this->assertEquals('http://vocab.getty.edu/aat/300056508', $vm_ret);
     }
 

--- a/tests/helpers/ImportHelpersTest.php
+++ b/tests/helpers/ImportHelpersTest.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once(__CA_APP_DIR__ . "/helpers/importHelpers.php");
 
+
 class ImportHelpersTest extends TestCase {
 
     protected $data;
@@ -44,7 +45,194 @@ class ImportHelpersTest extends TestCase {
 
     static $opa_valid_tables = array('ca_objects', 'ca_entities', 'ca_occurrences', 'ca_movements', 'ca_loans', 'ca_object_lots', 'ca_storage_locations', 'ca_places', 'ca_item_comments');
 
+    private $va_mock_response_AAT = array(
+            'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression:visual arts:abstraction' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+            'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)' => array(
+                    0 =>
+                            array(
+                                    'ID' =>
+                                            array(
+                                                    'type' => 'uri',
+                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                            ),
+                                    'TermPrefLabel' =>
+                                            array(
+                                                    'xml:lang' => 'en',
+                                                    'type' => 'literal',
+                                                    'value' => 'abstraction',
+                                            ),
+                                    'Parents' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
+                                            ),
+                                    'ParentsFull' =>
+                                            array(
+                                                    'type' => 'literal',
+                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                            ),
+                            )
+            ),
+    );
+    private $va_mock_response_people;
+
     protected function setUp(): void {
+
         $this->data = [
                 1 => "Verdun",
                 2 => ['Cambrai', 'Arras'],
@@ -181,15 +369,18 @@ class ImportHelpersTest extends TestCase {
         return $result;
     }
 
-
+    protected function _createAATServiceStub($ps_query) {
+        $o_service = $this->createStub(WLPlugInformationServiceAAT::class);
+        $o_service->method('lookup')
+                ->willReturn($this->va_mock_response_AAT[$ps_query]);
+        return $o_service;
+    }
     # -------------------------------------------------------
     public function testAATMatchPeople() {
         // some real-world examples
-        $o_service = new WLPlugInformationServiceAAT();
-
-        $vm_ret = caMatchAAT(
-                explode(':', 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression: visual arts:abstraction'),
-                null, null, $o_service);
+        $vs_query = 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression:visual arts:abstraction';
+        $o_service = $this->_createAATServiceStub($vs_query);
+            $vm_ret = caMatchAAT(explode(':', $vs_query), null, null, $o_service);
         $this->assertEquals('http://vocab.getty.edu/aat/300056508', $vm_ret);
     }
 

--- a/tests/helpers/ImportHelpersTest.php
+++ b/tests/helpers/ImportHelpersTest.php
@@ -60,42 +60,23 @@ class ImportHelpersTest extends TestCase {
                                                     'type' => 'literal',
                                                     'value' => 'abstraction',
                                             ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
-                                            ),
                             )
             ),
-            'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings' => array(
+            'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process:transfer method:intaglio prints:etchings' => array(
                     0 =>
                             array(
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300041365',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
+                                                    'value' => 'etchings',
                                             ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
-                                            ),
+
                             )
             ),
             'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper' => array(
@@ -104,23 +85,13 @@ class ImportHelpersTest extends TestCase {
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300189621',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
-                                            ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                                    'value' => 'works on paper',
                                             ),
                             )
             ),
@@ -130,23 +101,13 @@ class ImportHelpersTest extends TestCase {
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300108127',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
-                                            ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                                    'value' => 'Abstract',
                                             ),
                             )
             ),
@@ -156,23 +117,13 @@ class ImportHelpersTest extends TestCase {
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300069478',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
-                                            ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                                    'value' => 'computer art',
                                             ),
                             )
             ),
@@ -182,23 +133,13 @@ class ImportHelpersTest extends TestCase {
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300182574',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
-                                            ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                                    'value' => 'acrylic painting (technique)',
                                             ),
                             )
             ),
@@ -208,31 +149,19 @@ class ImportHelpersTest extends TestCase {
                                     'ID' =>
                                             array(
                                                     'type' => 'uri',
-                                                    'value' => 'http://vocab.getty.edu/aat/300056508',
+                                                    'value' => 'http://vocab.getty.edu/aat/300054216',
                                             ),
                                     'TermPrefLabel' =>
                                             array(
                                                     'xml:lang' => 'en',
                                                     'type' => 'literal',
-                                                    'value' => 'abstraction',
-                                            ),
-                                    'Parents' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), ... Associated Concepts Facet',
-                                            ),
-                                    'ParentsFull' =>
-                                            array(
-                                                    'type' => 'literal',
-                                                    'value' => '<forms of expression for visual arts>, forms of expression (artistic concept), artistic concepts, <concepts in the arts and humanities>, Associated Concepts (hierarchy name), Associated Concepts Facet',
+                                                    'value' => 'painting image-making',
                                             ),
                             )
             ),
     );
-    private $va_mock_response_people;
 
     protected function setUp(): void {
-
         $this->data = [
                 1 => "Verdun",
                 2 => ['Cambrai', 'Arras'],
@@ -378,78 +307,87 @@ class ImportHelpersTest extends TestCase {
                 ->willReturn($this->va_mock_response_AAT[$ps_query]);
         return $o_service;
     }
+
+    # -------------------------------------------------------
+    public function testAATExternal() {
+        // some real-world examples
+        $o_service = new WLPlugInformationServiceAAT();
+        $result = $o_service->lookup([], 'test');
+        $this->assertIsArray($result);
+    }
+
     # -------------------------------------------------------
     public function testAATMatchPeople() {
         // some real-world examples
         $vs_query = 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:forms of expression:forms of expression:visual arts:abstraction';
         $o_service = $this->_createAATServiceStub($vs_query);
-            $vm_ret = caMatchAAT(explode(':', $vs_query), null, null, $o_service);
+        $vm_ret = caMatchAAT(explode(':', $vs_query), null, null, $o_service);
         $this->assertEquals('http://vocab.getty.edu/aat/300056508', $vm_ret);
     }
 
     public function testAATMatchPrints() {
         // some real-world examples
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process: transfer method:intaglio prints:etchings')
-        );
+        $vs_query = 'Objects We Use:Visual Works:visual works:visual works by medium or technique:prints:prints by process or technique:prints by process:transfer method:intaglio prints:etchings';
+        $o_service = $this->_createAATServiceStub($vs_query);
+        $vm_ret = caMatchAAT(explode(':', $vs_query), null, null, $o_service);
 
         $this->assertEquals('http://vocab.getty.edu/aat/300041365', $vm_ret);
     }
 
     public function testAATMatchPaper() {
+        $vs_query = 'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper';
+        $o_service = $this->_createAATServiceStub($vs_query);
         // some real-world examples
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'Objects We Use:Visual Works:visual works:visual works by medium or technique:works on paper')
-        );
+        $vm_ret = caMatchAAT(explode(':', $vs_query), null, null, $o_service);
 
         $this->assertEquals('http://vocab.getty.edu/aat/300189621', $vm_ret);
     }
 
-    public function testAATMatchAbstractArt() {
+    public function testAATMatchAbstractArtRemoveParens() {
         // some real-world examples
 
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract'),
-                180, array('removeParensFromLabels' => true)
-        );
+        $vs_query = 'People and Culture:Styles and Periods:styles and periods by region:European:European styles and periods:modern European styles and movements:modern European fine arts styles and movements:Abstract';
+
+        $o_service = $this->_createAATServiceStub($vs_query);
+        // some real-world examples
+        $vm_ret = caMatchAAT(explode(':', $vs_query), 180, array('removeParensFromLabels' => true), $o_service);
 
         $this->assertEquals('http://vocab.getty.edu/aat/300108127', $vm_ret);
     }
 
-    public function testAATMatchComputerArt() {
+    public function testAATMatchComputerArtRemoveParens() {
         // some real-world examples
 
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art'),
-                180, array('removeParensFromLabels' => true)
+        $vs_query = 'People and Culture:Associated Concepts:concepts in the arts:artistic concepts:art genres:computer art';
+        $o_service = $this->_createAATServiceStub($vs_query);
+        $vm_ret = caMatchAAT(explode(':', $vs_query),
+                180, array('removeParensFromLabels' => true),
+                $o_service
         );
 
         $this->assertEquals('http://vocab.getty.edu/aat/300069478', $vm_ret);
     }
 
-    public function testAATMatchAcrylicPainting() {
+    public function testAATMatchAcrylicPaintingRemoveParens() {
         // some real-world examples
 
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)'),
-                180, array('removeParensFromLabels' => true)
+        $vs_query = 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting techniques:painting techniques by medium:acrylic painting (technique)';
+        $o_service = $this->_createAATServiceStub($vs_query);
+        $vm_ret = caMatchAAT(explode(':', $vs_query),
+                180, array('removeParensFromLabels' => true),
+                $o_service
         );
-
         $this->assertEquals('http://vocab.getty.edu/aat/300182574', $vm_ret);
     }
 
-    public function testAATMatchPainting() {
+    public function testAATMatchPaintingRemoveParens() {
         // some real-world examples
 
-        $vm_ret = caMatchAAT(
-                explode(':',
-                        'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)'),
-                180, array('removeParensFromLabels' => true)
+        $vs_query = 'Descriptors:Processes and Techniques:processes and techniques:processes and techniques by specific type:image-making processes and techniques:painting and painting techniques:painting (image-making)';
+        $o_service = $this->_createAATServiceStub($vs_query);
+        $vm_ret = caMatchAAT(explode(':', $vs_query),
+                180, array('removeParensFromLabels' => true),
+                $o_service
         );
 
         $this->assertEquals('http://vocab.getty.edu/aat/300054216', $vm_ret);


### PR DESCRIPTION
Refactor testing code to substitute remote API calls to AAT by mocks. It will reduce external dependency on AAT API service.

Nevertheless, I kept one of the end-to-end tests to make sure there is a test that properly tests AAT service is up and running.