### PR TITLE
PROV-2967 Normalize BCE dates correctly

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -3596,7 +3596,7 @@ class TimeExpressionParser {
 
 					for($vn_y=$vn_s; $vn_y <= $vn_e; $vn_y+= 100) {
 
-						$vn_century_num = abs(floor($vn_y/100)) + 1;
+						$vn_century_num = ($vn_y >= 0) ? abs(floor($vn_y/100)) + 1 : abs(floor($vn_y/100));
 						if ($vn_century_num == 0)  { continue; }
 						$vn_x = substr((string)$vn_century_num, strlen($vn_century_num) - 1, 1);
 

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -1553,6 +1553,8 @@ class TimeExpressionParserTest extends TestCase {
 
 		$this->assertEquals(5, sizeof($va_centuries));
 		$this->assertEquals($va_expected, array_keys($va_centuries));
+		$this->assertEquals('5th century BCE', array_shift($va_centuries));
+		$this->assertEquals('1st century BCE', array_pop($va_centuries));
 	}
 	
 	function testNormalizationCenturiesBC2AD() {

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -1524,6 +1524,53 @@ class TimeExpressionParserTest extends TestCase {
 		$this->assertEquals(10, sizeof($va_decades));
 		$this->assertEquals($va_decades_expected, $va_decades);
 	}
+	
+	function testNormalizationCenturiesAD() {
+		$o_tep = new TimeExpressionParser('1600 - 1900');
+		$va_historic = $o_tep->getHistoricTimestamps();
+
+		$va_expected = [];
+		for($vn_i = 1600; $vn_i <= 1900; $vn_i += 100) {
+			$va_expected[] = $vn_i;
+		}
+
+		$va_centuries = $o_tep->normalizeDateRange($va_historic['start'], $va_historic['end'], 'centuries');
+	
+		$this->assertEquals(4, sizeof($va_centuries));
+		$this->assertEquals($va_expected, array_keys($va_centuries));
+	}
+	
+	function testNormalizationCenturiesBC() {
+		$o_tep = new TimeExpressionParser('500 BCE - 100 BCE');
+		$va_historic = $o_tep->getHistoricTimestamps();
+
+		$va_expected = [];
+		for($vn_i = -500; $vn_i <= -100; $vn_i += 100) {
+			$va_expected[] = $vn_i;
+		}
+
+		$va_centuries = $o_tep->normalizeDateRange($va_historic['start'], $va_historic['end'], 'centuries');
+
+		$this->assertEquals(5, sizeof($va_centuries));
+		$this->assertEquals($va_expected, array_keys($va_centuries));
+	}
+	
+	function testNormalizationCenturiesBC2AD() {
+		$o_tep = new TimeExpressionParser('100 B.C. - 150 A.D.');
+		$va_historic = $o_tep->getHistoricTimestamps();
+
+		$va_expected = [];
+		for($vn_i = -100; $vn_i <= 100; $vn_i += 100) {
+			$va_expected[] = $vn_i;
+		}
+
+		$va_centuries = $o_tep->normalizeDateRange($va_historic['start'], $va_historic['end'], 'centuries');
+
+		$this->assertEquals(3, sizeof($va_centuries));
+		$this->assertEquals($va_expected, array_keys($va_centuries));
+		$this->assertEquals('1st century BCE', array_shift($va_centuries));
+		$this->assertEquals('2nd century', array_pop($va_centuries));
+	}
 
 	function testMultiWordConjunctions() {
 		$o_tep = new TimeExpressionParser();


### PR DESCRIPTION
PR corrects behavior when normalizing BCE dates to century. Previous behavior tagged on an extra century. Eg. 100 BCE - 100 AD resulted in normalization of 2nd century BCE, 1st century BCE, 1st century AD, 2nd century AD, where 2nd century BCE is not correct.

Also adds tests for century normalization, which had been omitted for some reason.