### PR TITLE
PROV-2979 add strip newlines option to data exporter

### DIFF
--- a/app/lib/Parsers/DisplayTemplateParser.php
+++ b/app/lib/Parsers/DisplayTemplateParser.php
@@ -662,7 +662,7 @@ class DisplayTemplateParser {
 						if (sizeof($va_relative_ids) && is_array($va_get_options['filterTypes'])) {
 						    $vs_rel_table_name = $t_rel_instance->tableName();
 						    $vs_rel_pk = $t_rel_instance->primaryKey();
-						    if (is_array($va_filter_types = caMakeTypeIDList($vs_rel_table_name, $va_get_options['filterTypes'])) && sizeof($va_filter_types)) {
+						    if (is_array($va_filter_types = caMakeTypeIDList($vs_rel_table_name, $va_get_options['filterTypes'], ['dontIncludeSubtypesInTypeRestriction' => true])) && sizeof($va_filter_types)) {
 						        if ($qr_types = caMakeSearchResult($vs_rel_table_name, $va_relative_ids)) {
 						            $va_filtered_ids = [];
 						            while($qr_types->nextHit()) {
@@ -805,23 +805,7 @@ class DisplayTemplateParser {
 						if (sizeof($va_relative_ids) && is_array($va_get_options['filterTypes'])) {
 						    $vs_rel_table_name = $t_rel_instance->tableName();
 						    $vs_rel_pk = $t_rel_instance->primaryKey();
-						    if (is_array($va_filter_types = caMakeTypeIDList($vs_rel_table_name, $va_get_options['filterTypes'])) && sizeof($va_filter_types)) {
-						        if ($qr_types = caMakeSearchResult($vs_rel_table_name, $va_relative_ids)) {
-						            $va_filtered_ids = [];
-						            while($qr_types->nextHit()) {
-						                if(in_array($qr_types->get("{$vs_rel_table_name}.type_id"), $va_filter_types)) {
-						                    $va_filtered_ids[] = (int)$qr_types->get("{$vs_rel_table_name}.{$vs_rel_pk}");
-						                }
-						            }
-						            $va_relative_ids = $va_filtered_ids;
-						        }
-						    }
-						}
-						
-						if (sizeof($va_relative_ids) && is_array($va_get_options['filterTypes'])) {
-						    $vs_rel_table_name = $t_rel_instance->tableName();
-						    $vs_rel_pk = $t_rel_instance->primaryKey();
-						    if (is_array($va_filter_types = caMakeTypeIDList($vs_rel_table_name, $va_get_options['filterTypes'])) && sizeof($va_filter_types)) {
+						    if (is_array($va_filter_types = caMakeTypeIDList($vs_rel_table_name, $va_get_options['filterTypes'], ['dontIncludeSubtypesInTypeRestriction' => true])) && sizeof($va_filter_types)) {
 						        if ($qr_types = caMakeSearchResult($vs_rel_table_name, $va_relative_ids)) {
 						            $va_filtered_ids = [];
 						            while($qr_types->nextHit()) {

--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -1334,7 +1334,7 @@ class SearchResult extends BaseObject {
 							    is_array($pa_options['filterTypes']) &&
 							    (sizeof($pa_options['filterTypes']) > 0)
 							) {
-							    $filter_by_types = caMakeTypeIDList($va_path_components['table_name'], $pa_options['filterTypes']);
+							    $filter_by_types = caMakeTypeIDList($va_path_components['table_name'], $pa_options['filterTypes'], ['dontIncludeSubtypesInTypeRestriction' => true]);
 						        $type_spec = join('.', [$va_path_components['table_name'], $type_id_fld]);
 							}
 							

--- a/app/models/ca_data_exporter_items.php
+++ b/app/models/ca_data_exporter_items.php
@@ -574,6 +574,16 @@ class ca_data_exporter_items extends BaseModel {
 			'description' => _t('Formatting option for Geocode attributes. Forces return of coordinates only, omitting text labels.')
 		);
 		
+		$va_settings['stripNewlines'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Remove newline characters from text values'),
+			'description' => _t('Formatting option for text attributes. Removes any newline characters in output.')
+		);
+		
 		$va_settings['_id'] = array(
 			'formatType' => FT_TEXT,
 			'displayType' => DT_FIELD,

--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1666,6 +1666,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 			throw new ApplicationException(_t("Record with ID %1 does not exist in table %2", $pn_record_id, $pn_table_num));
 		}
 
+		$vb_strip_newlines = caGetOption('stripNewlines',$pa_options, $t_exporter_item->getSetting('stripNewlines'));
+
 		// switch context to a different set of records if necessary and repeat current exporter item for all those selected records
 		// (e.g. hierarchy children or related items in another table, restricted by types or relationship types)
 		if(!$vb_ignore_context && ($vs_context = $t_exporter_item->getSetting('context'))) {
@@ -2214,6 +2216,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 
 			// if returned value is null then we skip the item
 			$this->opo_app_plugin_manager->hookExportItem(array('instance' => $t_instance, 'exporter_item_instance' => $t_exporter_item, 'export_item' => &$va_item));
+	
+			if($vb_strip_newlines) { $va_item['text'] = preg_replace("![\n\r]+!", '', $va_item['text']); }
 		}
 
 		$o_log->logInfo(_t("Extracted data for this mapping is as follows:"));


### PR DESCRIPTION
PR adds per-mapping option to data exporter to strip new line values from exported text. This is useful for compatibility with some data consumers. Eg. consumers that choke on returns in values in CSV files, even when properly escaped, like IPT.