### PR TITLE
NOJIRA Allow filterTypes option to be comma or semicolon separated list

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -1029,7 +1029,7 @@ class SearchResult extends BaseObject {
 		
 		$config = Configuration::load();
 		
-		if($pa_options['filterTypes'] && !is_array($pa_options['filterTypes'])) { $pa_options['filterTypes'] = [$pa_options['filterTypes']]; }
+		if($pa_options['filterTypes'] && !is_array($pa_options['filterTypes'])) { $pa_options['filterTypes'] = preg_split('![,;]+!',$pa_options['filterTypes']); }
 		
 		if ($vb_return_with_structure) { $pa_options['returnAsArray'] = $vb_return_as_array = true; } // returnWithStructure implies returnAsArray
 		


### PR DESCRIPTION
PR enables the SearchResult::get() filterTypes option, and consequently the display template parser filterTypes attribute, to be passed as a comma or semicolon separated list. Currently it is used as a string, which limits filtering to a single type.

filterTypes is used to control which record types are returned when pulling data from a hierarchy.