### PR TITLE
PROV-2996, PROV-2997 Representation bundle fixes

### DIFF
--- a/app/models/ca_editor_ui_screens.php
+++ b/app/models/ca_editor_ui_screens.php
@@ -1197,8 +1197,8 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 								_t('Classic') => 'CLASSIC',
 								_t('New UI with batch uploading') => 'NEW_UI'
 							],
-							'default' => '',
-							'multiple' => true,
+							'default' => 'NEW_UI',
+							'multiple' => false,
 							'label' => _t('User interface style'),
 							'description' => _t('')
 						];

--- a/install/profiles/xml/base.xml
+++ b/install/profiles/xml/base.xml
@@ -1643,12 +1643,12 @@
         <item idno="socken" enabled="1" default="0">
           <labels>
             <label locale="en_US" preferred="1">
-              <name_singular>parrish</name_singular>
-              <name_plural>parrishes</name_plural>
+              <name_singular>parish</name_singular>
+              <name_plural>parishes</name_plural>
             </label>
             <label locale="en_CA" preferred="1">
-              <name_singular>parrish</name_singular>
-              <name_plural>parrishes</name_plural>
+              <name_singular>parish</name_singular>
+              <name_plural>parishes</name_plural>
             </label>
             <label locale="sv_SE" preferred="1">
               <name_singular>socken</name_singular>

--- a/themes/default/views/bundles/ca_object_representations.php
+++ b/themes/default/views/bundles/ca_object_representations.php
@@ -178,7 +178,7 @@
 	} 
 						foreach($bundles_to_edit_proc as $f) {
 							if($f === 'type_id') { // type
-								print $t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."\n";
+								print "<div class='formLabel''>".$t_item->getDisplayLabel("ca_object_representations.{$f}")."<br/>".$t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."</div>\n";
 							} elseif($t_item->hasField($f)) { // intrinsic
 								print $t_item->htmlFormElement($f, null, ['id' => "{$id_prefix}_{$f}_{n}", 'name' => "{$id_prefix}_{$f}_{n}", 'width' => '500px', 'height' => null, 'value' => '{'.$f.'}', 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."\n";
 							} elseif($t_item->hasElement($f)) {
@@ -270,7 +270,7 @@
 					if(in_array($f, ['media'])) { continue; }
 					
 					if($f === 'type_id') { // type
-						print $t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."\n";
+						print "<div class='formLabel''>".$t_item->getDisplayLabel("ca_object_representations.{$f}")."<br/>".$t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."</div>\n";
 					} elseif($t_item->hasField($f)) { // intrinsic
 						print $t_item->htmlFormElement($f, null, ['id' => "{$id_prefix}_{$f}_{n}", 'name' => "{$id_prefix}_{$f}_{n}", 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."\n";
 					} elseif($t_item->hasElement($f)) {


### PR DESCRIPTION
PR addresses two minor issues in the media representation (ca_object_representations) bundle:

- When representation type is included in the in-line editing form it lacks a label
- Bundle mode (classic vs new) is not retained during first save of newly placed bundle