### PR TITLE
PROV-2999 Fix for distorted derivative images when using Gmagick and EXIF orientation tag is set

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1819,6 +1819,14 @@ dont_extract_embedded_media_metdata_when_length_exceeds = 2097152
 #
 allow_fetching_of_media_from_remote_urls = 0
 
+# When EXIF orientation is set on uploaded media, it must be stripped from derivatives. When using the Gmagick 
+# media processing plugin, ExifTool will be used to strip the tag if available. This is preferred as it allows
+# color profiles to be preserved, but it is relatively slow. If you don't care about color profiles set this option 
+# and the Gmagick stripImage() function will be used. It is fast, but does eliminate all embedded metadata, including
+# color profiles
+#
+dont_use_exiftool_to_strip_exif_orientation_tags = 0
+
 # If you wish to allow the linking to existing object representations in the manner other relationships
 # set the relevant directives below to 1. Using representations as records that can be targets of
 # relationships can be confusing and, well, odd for many common setups. Still, when you need this behavior

--- a/app/helpers/mediaPluginHelpers.php
+++ b/app/helpers/mediaPluginHelpers.php
@@ -503,6 +503,25 @@
 	}
 	# ------------------------------------------------------------------------------------------------
 	/**
+	 * Remove EXIF Orientation tag using ExifTool
+	 *
+	 * @param string $pfilepath file path
+	 *
+	 * @return bool True on success, false if operation failed
+	 */
+	function caExtractRemoveOrientationTagWithExifTool($filepath){
+		if(!file_exists($filepath)) { return false; }
+		if ($path_to_exif_tool = caExifToolInstalled()) {
+			caExec("{$path_to_exif_tool} -overwrite_original_in_place -P -fast -Orientation= ".caEscapeShellArg($filepath)." 2> /dev/null", $output, $return);
+
+			if($return == 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+	# ------------------------------------------------------------------------------------------------
+	/**
 	 * Perform mapping of extracted media metadata to CollectiveAccess bundles.
 	 *
 	 * @param BundlableLabelableBaseModelWithAttributes $po_instance Model instance to insert extracted metadata into

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -4307,7 +4307,7 @@ if (!$vb_batch) {
 											$vs_tmp_directory = caGetTempDirPath();
 										}
                                     	$vs_path = $vs_tmp_directory.'/'.$va_values['tmp_name'];
-                                    	$md = json_decode(file_get_contents("{$vs_path}_metadata"), true);
+                                    	$md = json_decode(@file_get_contents("{$vs_path}_metadata"), true);
                                         $vs_original_name = $md['original_filename'];
                                     } else {
                                         $vs_path = $va_values['tmp_name'];


### PR DESCRIPTION
PR resolves issue where Gmagick based media processing outputs distorted derivatives when EXIF orientation tags are set. Issue involves stripping EXIF metadata from derivatives to prevent undesired rotation by consuming applications.