### PR TITLE
PROV-3002 Update mimetype used for WAV

### DIFF
--- a/app/lib/Plugins/Media/Audio.php
+++ b/app/lib/Plugins/Media/Audio.php
@@ -70,6 +70,7 @@ class WLPlugMediaAudio Extends BaseMediaPlugin Implements IWLPlugMedia {
 		"IMPORT" => array(
 			"audio/mpeg"						=> "mp3",
 			"audio/x-aiff"						=> "aiff",
+			"audio/wav"							=> "wav",
 			"audio/x-wav"						=> "wav",
 			"audio/x-wave"						=> "wav",
 			"audio/mp4"							=> "aac",
@@ -80,7 +81,9 @@ class WLPlugMediaAudio Extends BaseMediaPlugin Implements IWLPlugMedia {
 		"EXPORT" => array(
 			"audio/mpeg"						=> "mp3",
 			"audio/x-aiff"						=> "aiff",
+			"audio/wav"							=> "wav",
 			"audio/x-wav"						=> "wav",
+			"audio/x-wave"						=> "wav",
 			"audio/mp4"							=> "aac",
 			"video/x-flv"						=> "flv",
 			"image/png"							=> "png",
@@ -115,6 +118,7 @@ class WLPlugMediaAudio Extends BaseMediaPlugin Implements IWLPlugMedia {
 			"duration" 			=> 'R',
 			"filesize" 			=> 'R',
 			"getID3_tags"		=> 'W',
+			'colorspace'		=> 'W',
 			"quality"			=> "W",		// required for JPEG compatibility
 			"bitrate"			=> 'W', 	// in kbps (ex. 64)
 			"channels"			=> 'W',		// 1 or 2, typically
@@ -130,6 +134,8 @@ class WLPlugMediaAudio Extends BaseMediaPlugin Implements IWLPlugMedia {
 		"audio/mpeg"						=> "MPEG-3",
 		"audio/x-aiff"						=> "AIFF",
 		"audio/x-wav"						=> "WAV",
+		"audio/x-wave"						=> "WAV",
+		"audio/wav"							=> "WAV",
 		"audio/mp4"							=> "AAC",
 		"image/png"							=> "PNG",
 		"image/jpeg"						=> "JPEG",
@@ -194,10 +200,10 @@ class WLPlugMediaAudio Extends BaseMediaPlugin Implements IWLPlugMedia {
 		    // Quicktime-wrapped MP3
 			$info['mime_type'] = 'audio/mpeg';
 		}
+		if (in_array(strtolower(trim($info["mime_type"])), ['audio/wave', 'audio/wav', 'audio/x-wave'], true)) {
+			$info["mime_type"] = 'audio/x-wav';
+		}
 		if (($info["mime_type"]) && isset($this->info["IMPORT"][$info["mime_type"]]) && $this->info["IMPORT"][$info["mime_type"]]) {
-			if ($info["mime_type"] === 'audio/x-wave') {
-				$info["mime_type"] = 'audio/x-wav';
-			}
 			$this->handle = $this->ohandle = $info;
 			$this->metadata = $info;	// populate with getID3 data because it's handy
 			return $info["mime_type"];


### PR DESCRIPTION
PR addresses issue raised with the migration to composer-based getID3() support for WAV files is broken. This is due to a change in reported mimetype for this particular format. Other formats (AIFF, MP3) are not affected.