### PR TITLE
PROV-2971 Make all dates display as YYYY.MM.DD 

### DIFF
--- a/app/conf/datetime.conf
+++ b/app/conf/datetime.conf
@@ -17,9 +17,14 @@ expressions = {
 # Output options for date/times
 #
 
-# Format to use for dates; valid values are (text|delimited|iso8601|yearOnly|original)	[default is text]
+# Format to use for dates; valid values are (text|delimited|iso8601|yearOnly|ymd|original)	[default is text]
 # "original" is the date as entered by the user; other values will normalize all date/time input
-# to the selected standard format
+# to the selected standard format:
+#	ymd =  year-month-day format (Ex. 1927/10/07)
+#	delimited = delimited date format (Ex. 10/7/1927)
+# 	iso8601 = ISO date format (Ex. 1927/10/07); iso8601 and ymd are similar in format, but ymd respects all formatting options (Eg. custom delimiters)
+#	yearOnly = year display only, discarding month, day and time if present
+#	text = Full text date with language-specific month name (Ex. October 7 1927) 
 dateFormat = text
 
 #

--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -2441,7 +2441,7 @@ class TimeExpressionParser {
 	 *		dateTimeConjunction (string) [default is first in lang. config]
 	 *		showADEra (true|false) [default is false]
 	 *		uncertaintyIndicator (string) [default is first in lang. config]
- 	 *		dateFormat		(text|delimited|iso8601|yearOnly)	[default is text]
+ 	 *		dateFormat		(text|delimited|iso8601|yearOnly|ymd)	[default is text]
 	 *		dateDelimiter	(string) [default is first delimiter in language config file]
 	 *		circaIndicator	(string) [default is first indicator in language config file]
 	 *		beforeQualifier	(string) [default is first indicator in language config file]
@@ -2612,7 +2612,7 @@ class TimeExpressionParser {
 				}
 			} elseif ((isset($pa_options['dateFormat']) && ($pa_options['dateFormat'] == 'yearOnly'))) { 
 				$va_range_conjunctions = $this->opo_language_settings->getList('rangeConjunctions');
-				return $va_start_pieces['year']." ".$va_range_conjunctions[0]." ".$va_end_pieces['year'];
+				return ($va_start_pieces['year'] != $va_end_pieces['year']) ? $va_start_pieces['year']." ".$va_range_conjunctions[0]." ".$va_end_pieces['year'] : $va_start_pieces['year'];
 			}
 			
 		
@@ -3241,7 +3241,7 @@ class TimeExpressionParser {
 		
 		$vs_month = null;
 		if ($pa_date_pieces['month'] > 0) {		// date with month
-			if ($pa_options['dateFormat'] == 'delimited') {
+			if (in_array((string)$pa_options['dateFormat'], ['delimited', 'ymd'], true)) {
 				$vs_month = $pa_date_pieces['month'];
 			} else {
 				$va_months = $this->getMonthList();
@@ -3279,7 +3279,12 @@ class TimeExpressionParser {
 			$vs_day .= $vs_day_suffix;
 		}
 		
-		if ($vb_month_comes_first) {
+		if($pa_options['dateFormat'] === 'ymd') {
+			$va_date[] = $vs_year;
+			if ($vs_month) { $va_date[] = sprintf("%02d", $vs_month); }
+			if ($vs_day) { $va_date[] =  sprintf("%02d", $vs_day); }
+			return join($vs_date_delimiter, $va_date);
+		} elseif ($vb_month_comes_first) {
 			if ($vs_month) { $va_date[] = (($pa_options['dateFormat'] == 'delimited') ? sprintf("%02d", $vs_month) : $vs_month); }
 			if ($vs_day) { 
 				if (

--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -753,7 +753,14 @@ class TimeExpressionParser {
 		if ($va_hook_result["expression"] != $ps_expression) {
 			$ps_expression = $va_hook_result["expression"];
 		}
-
+		
+		
+		// Convert ISO ranges
+		if (preg_match("!^([\d\-:TZ]+)/([\d\-:TZ]+)$!", trim($ps_expression), $matches)) {
+			$conjunction = array_shift($this->opo_language_settings->getList("rangeConjunctions"));
+			$ps_expression = $matches[1]." {$conjunction} ".$matches[2];
+		}
+	
 		# convert
 		$va_dict = $this->opo_datetime_settings->getAssoc("expressions");
 		$vs_lc_expression = mb_strtolower($ps_expression);
@@ -837,11 +844,11 @@ class TimeExpressionParser {
 		# convert dd-mm-yyyy dates to dd/mm/yyyy to prevent our range conjunction code below doesn't mangle it
 		$ps_expression = preg_replace("/([\d]{2})-([\d]{2})-([\d]{4})/", "$1/$2/$3", $ps_expression);
 		
-		if (preg_match("/([\d]{4})-([\d]{2})$/", $ps_expression, $va_matches)) {
+		if (preg_match("/([\d]{4})-([\d]{2})(\/|$)/", $ps_expression, $va_matches)) {
 			if (intval($va_matches[2]) > 12) {
-				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})$/", "$1-".substr($va_matches[1], 0, 2)."$2", $ps_expression);
+				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})(\/|$)/", "$1-".substr($va_matches[1], 0, 2)."$2$3", $ps_expression);
 			} else {
-				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})$/", "$1#$2", $ps_expression);
+				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})(\/|$)/", "$1#$2$3", $ps_expression);
 			}
 		}
 		

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -657,7 +657,32 @@ class TimeExpressionParserTest extends TestCase {
 
 	public function testParseISO8601Date() {
 		$o_tep = new TimeExpressionParser();
-		$vb_res = $o_tep->parse('2009-09-18 21:03');
+		$vb_res = $o_tep->parse('2009-09-18');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 1253246400);
+		$this->assertEquals($va_parse['end'], 1253332799);
+		$this->assertEquals($va_parse[0], 1253246400);
+		$this->assertEquals($va_parse[1], 1253332799);
+	}
+	
+	public function testParseISO8601DateMonthOnly() {
+		$o_tep = new TimeExpressionParser();
+		$vb_res = $o_tep->parse('2009-09');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 1251777600);
+		$this->assertEquals($va_parse['end'], 1254369599);
+		$this->assertEquals($va_parse[0], 1251777600);
+		$this->assertEquals($va_parse[1], 1254369599);
+	}
+	
+	public function testParseISO8601DateWithTime() {
+		$o_tep = new TimeExpressionParser();
+		
+		$vb_res = $o_tep->parse('2009-09-18 21:03Z');
 		$this->assertEquals($vb_res, true);
 		$va_parse = $o_tep->getUnixTimestamps();
 
@@ -665,6 +690,53 @@ class TimeExpressionParserTest extends TestCase {
 		$this->assertEquals($va_parse['end'], 1253322180);
 		$this->assertEquals($va_parse[0], 1253322180);
 		$this->assertEquals($va_parse[1], 1253322180);
+		$vb_res = $o_tep->parse('2009-09-18T21:03Z');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getUnixTimestamps();
+
+		$this->assertEquals($va_parse['start'], 1253322180);
+		$this->assertEquals($va_parse['end'], 1253322180);
+		$this->assertEquals($va_parse[0], 1253322180);
+		$this->assertEquals($va_parse[1], 1253322180);
+	}
+	
+	public function testParseISO8601DateRange() {
+		$o_tep = new TimeExpressionParser();
+	
+		$vb_res = $o_tep->parse('2009-09-18/2010-02-02');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], '2009.091800000000');
+		$this->assertEquals($va_parse['end'], '2010.020223595900');
+		$this->assertEquals($va_parse[0], '2009.091800000000');
+		$this->assertEquals($va_parse[1], '2010.020223595900');
+	}
+	
+	public function testParseISO8601DateRangeMonths() {
+		$o_tep = new TimeExpressionParser();
+		
+		$vb_res = $o_tep->parse('1952-10/1952-11');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+
+		$this->assertEquals($va_parse['start'], '1952.100100000000');
+		$this->assertEquals($va_parse['end'], '1952.113023595900');
+		$this->assertEquals($va_parse[0], '1952.100100000000');
+		$this->assertEquals($va_parse[1], '1952.113023595900');
+	}
+	
+	public function testParseISO8601DateRangeWithTime() {
+		$o_tep = new TimeExpressionParser();
+		
+		$vb_res = $o_tep->parse('2009-09-18T02:30:02Z/2010-02-02T05:35Z');
+		$this->assertEquals($vb_res, true);
+		$va_parse = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_parse['start'], '2009.091802300200');
+		$this->assertEquals($va_parse['end'], '2010.020205350000');
+		$this->assertEquals($va_parse[0], '2009.091802300200');
+		$this->assertEquals($va_parse[1], '2010.020205350000');
 	}
 
 	public function testParseNowDate() {
@@ -1425,6 +1497,31 @@ class TimeExpressionParserTest extends TestCase {
 		$o_tep->setLanguage('de_DE');
 
 		$this->assertEquals($o_tep->getText(), '6. Juni 2009 um 22:55:10');
+	}
+	
+	public function testDateTextOutputFormats() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('6/8/1984');
+		$this->assertEquals($vb_res, true);
+
+		$this->assertEquals($o_tep->getText(), 'June 8 1984');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1984/06/08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1984.06.08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '06/08/1984');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1984-06-08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1984');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'text']), 'June 8 1984');
+
+		$o_tep->setLanguage('de_DE');
+
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1984/06/08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1984.06.08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '08/06/1984');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1984-06-08');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1984');
+		$this->assertEquals($o_tep->getText(), '8. Juni 1984');
 	}
 
 	public function testMYADate() {


### PR DESCRIPTION
PR adds new year-month-day (ymd) date formatting option. This allows for the requested YYYY.MM.DD input and display format by using dateFormat=ymd in conjunction with dateDelimiter=.

The ymd format is similar to the existing iso8601 format, save the it honors date formatting options such as custom delimiters through the dateDelimiter option. The iso8601 format ignores all such options by design to ensure conformity to the standard.