### PR TITLE
PROV-2974 Add existing record policies that operate on CollectiveAccess primary key ids

### DIFF
--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -353,7 +353,11 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				_t('overwrite_on_preferred_labels') => 'overwrite_on_preferred_labels',
 				_t('merge_on_idno_and_preferred_labels') => 'merge_on_idno_and_preferred_labels',
 				_t('merge_on_idno_and_preferred_labels_with_replace') => 'merge_on_idno_and_preferred_labels_with_replace',
-				_t('overwrite_on_idno_and_preferred_labels') => 'overwrite_on_idno_and_preferred_labels'
+				_t('overwrite_on_idno_and_preferred_labels') => 'overwrite_on_idno_and_preferred_labels',
+				_t('skip_on_id') => 'skip_on_id',
+				_t('merge_on_id') => 'merge_on_id',
+				_t('merge_on_id_with_replace') => 'merge_on_id_with_replace',
+				_t('overwrite_on_id') => 'overwrite_on_id'
 			),
 			'label' => _t('Existing record policy'),
 			'description' => _t('Determines how existing records are checked for and handled by the import mapping.  Pending implementation.')
@@ -1523,7 +1527,8 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				'none', 'skip_on_idno', 'skip_on_preferred_labels',
 				'merge_on_idno', 'merge_on_preferred_labels', 'merge_on_idno_and_preferred_labels',
 				'merge_on_idno_with_replace', 'merge_on_preferred_labels_with_replace', 'merge_on_idno_and_preferred_labels_with_replace',
-			 	'overwrite_on_idno', 'overwrite_on_preferred_labels', 'overwrite_on_idno_and_preferred_labels'
+			 	'overwrite_on_idno', 'overwrite_on_preferred_labels', 'overwrite_on_idno_and_preferred_labels', 
+			 	'merge_on_id', 'merge_on_id_with_replace', 'skip_on_id', 'overwrite_on_id'
 			)
 		)) {
 			$vs_existing_record_policy = 'none';
@@ -1531,11 +1536,12 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 		
 		
 		// Analyze mapping for figure out where type, idno, preferred label and other mandatory fields are coming from
-		$vn_type_id_mapping_item_id = $vn_idno_mapping_item_id = $vn_list_mapping_list_id = null;
+		$vn_primary_key_mapping_item_id = $vn_type_id_mapping_item_id = $vn_idno_mapping_item_id = $vn_list_mapping_list_id = null;
 		$va_preferred_label_mapping_ids = $va_nonpreferred_label_mapping_ids = array();
 		$va_mandatory_field_mapping_ids = array();
 		
 		$va_mandatory_fields = $t_subject->getMandatoryFields();
+		$vs_subject_primary_key = $t_subject->primaryKey();
 		
 		foreach($va_mapping_items as $vn_item_id => $va_item) {
 			$vs_destination = $va_item['destination'];
@@ -1570,6 +1576,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					break;
 				case "{$vs_subject_table}.{$vs_idno_fld}":
 					$vn_idno_mapping_item_id = $vn_item_id;
+					break;
+				case "{$vs_subject_table}.{$vs_subject_primary_key}":
+					$vn_primary_key_mapping_item_id = $vn_item_id;
 					break;
 				case 'ca_list_items.list_id':
 				    $vn_list_mapping_list_id = $vn_item_id;
@@ -1781,6 +1790,12 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				$vs_idno = "%";
 			}
 			
+			// Primary key mapping
+			$vn_mapped_primary_key_value = null;
+			if ($vn_primary_key_mapping_item_id) {
+				$vn_mapped_primary_key_value = ca_data_importers::getValueFromSource($va_mapping_items[$vn_primary_key_mapping_item_id], $o_reader, array('otherValues' => $va_rule_set_values, 'environment' => $va_environment));
+			}
+			
 			$vb_idno_is_template = (bool)preg_match('![%]+!', $vs_idno);
 			
 			if (!$vb_idno_is_template) {
@@ -1833,10 +1848,56 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					}
 				} elseif ($vs_existing_record_policy != 'none') {
 					switch($vs_existing_record_policy) {
+						case 'merge_on_id':
+						case 'merge_on_id_with_replace':
+							$va_ids = call_user_func_array($t_subject->tableName()."::find", 
+								[[$t_subject->primaryKey() => $vn_mapped_primary_key_value],
+								['returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans]]
+							);
+							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
+								$t_subject->load($va_ids[0]);
+								if ($log_erp) { $o_log->logInfo(_t('[%1] Merged with existing record matched on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy)); }
+								break;
+							} else {
+								if ($log_erp) { $o_log->logInfo(_t('[%1] Could not match existing record on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy)); }
+							}
+							break;
+						case 'skip_on_id':
+							$va_ids = call_user_func_array($t_subject->tableName()."::find", 
+								[[$t_subject->primaryKey() => $vn_mapped_primary_key_value],
+								['returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans]]
+							);
+							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
+								if ($log_erp) { $o_log->logInfo(_t('[%1] Skipped import because of existing record matched on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy)); }
+								$this->num_records_skipped++;
+								continue(2);	// skip because idno matched
+							}
+							break;
+						case 'overwrite_on_id':
+							$va_ids = call_user_func_array($t_subject->tableName()."::find", 
+								[[$t_subject->primaryKey() => $vn_mapped_primary_key_value],
+								['returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans]]
+							);
+							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
+								$t_subject->load($va_ids[0]);
+								$t_subject->setMode(ACCESS_WRITE);
+								$t_subject->delete(true, array('hard' => true));
+								if ($t_subject->numErrors()) {
+									$this->logImportError(_t('[%1] Could not delete existing record matched on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy), $va_log_import_error_opts);
+									// Don't stop?
+								} else {
+									if ($log_erp) { $o_log->logInfo(_t('[%1] Overwrote existing record matched on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy)); }
+									$t_subject->clear();
+									break;
+								}
+							} else {
+								if ($log_erp) { $o_log->logInfo(_t('[%1] Could not match existing record on primary key %2 for %3 by policy %4', $vs_idno, $vn_mapped_primary_key_value, $t_subject->tableName(), $vs_existing_record_policy)); }
+							}
+							break;
 						case 'skip_on_idno':
 							if (!$vb_idno_is_template) {
 								$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno, 'deleted' => 0)),
+									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno)),
 									array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 								));
 								if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -1848,7 +1909,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							break;
 						case 'skip_on_preferred_labels':
 							$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values, 'deleted' => 0)),
+								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values)),
 								array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 							));
 							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -1863,7 +1924,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						case 'merge_on_idno_with_replace':
 							if (!$vb_idno_is_template) {
 								$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno, 'deleted' => 0)),
+									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno)),
 									array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 								));
 								if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -1878,7 +1939,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						case 'merge_on_preferred_labels':
 						case 'merge_on_preferred_labels_with_replace':
 							$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values, 'deleted' => 0)),
+								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values)),
 								array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 							));
 							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -1893,7 +1954,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						case 'overwrite_on_idno':
 							if (!$vb_idno_is_template && $vs_idno) {
 								$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno, 'deleted' => 0)),
+									array_merge($va_base_criteria, array($t_subject->getProperty('ID_NUMBERING_ID_FIELD') => $vs_idno)),
 									array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 								));
 								if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -1915,7 +1976,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							if ($vs_existing_record_policy == 'overwrite_on_idno') { break; }	// fall through if overwrite_on_idno_and_preferred_labels
 						case 'overwrite_on_preferred_labels':
 							$va_ids = call_user_func_array($t_subject->tableName()."::find", array(
-								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values, 'deleted' => 0)),
+								array_merge($va_base_criteria, array('preferred_labels' => $va_pref_label_values)),
 								array('returnAs' => 'ids', 'purifyWithFallback' => true, 'transaction' => $o_trans)
 							));
 							if (is_array($va_ids) && (sizeof($va_ids) > 0)) {
@@ -3343,9 +3404,11 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 												(
 													!isset($va_elements_set_for_this_record[$vs_element]) && 
 													!$va_elements_set_for_this_record[$vs_element] && 
-													in_array($vs_existing_record_policy, ['merge_on_idno_with_replace', 'merge_on_preferred_labels_with_replace', 
-																							'merge_on_idno_and_preferred_labels_with_replace']) &&
-													!$vb_force_add
+													in_array($vs_existing_record_policy, 
+														['merge_on_idno_with_replace', 'merge_on_preferred_labels_with_replace', 
+														 'merge_on_idno_and_preferred_labels_with_replace', 'merge_on_id_with_replace'
+														]
+													) && !$vb_force_add
 												)
 												||
 												$vb_force_replace


### PR DESCRIPTION
PR adds four new existing record policies to the data importer: merge_on_id, merge_on_id_with_replace, overwrite_on_id, skip_on_id

These policies merge using internal CollectiveAccess primary key id integers. They exist for those odd times when your data is using those ids.