### PR TITLE
PROV-3003 Object representation editor bundle "download all" omits files

### DIFF
--- a/app/conf/annotation_types.conf
+++ b/app/conf/annotation_types.conf
@@ -218,6 +218,7 @@ mappings = {
 	video/x-flv 					= TimeBasedVideo,
 	audio/x-aiff 					= TimeBasedAudio,
 	audio/x-wav 					= TimeBasedAudio,
+	audio/wav 						= TimeBasedAudio,
 	audio/mpeg 						= TimeBasedAudio,
 	audio/mp4 						= TimeBasedAudio,
 	application/pdf 				= Document,

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -2516,10 +2516,11 @@ class BaseEditorController extends ActionController {
 					$names_set[$vs_name]++;
 					$ext = pathinfo($vs_name, PATHINFO_EXTENSION);
 					$vs_name = pathinfo($vs_name, PATHINFO_FILENAME).'-'.$names_set[$vs_name].'.'.$ext;
+				} else {
+					$names_set[$vs_name] = 1;
 				}
 				$o_zip->addFile($vs_path, $vs_name);
 				
-				$names_set[$vs_name] = 1;
 			}
 			$o_view->setVar('zip_stream', $o_zip);
 			$o_view->setVar('archive_name', caGetMediaDownloadArchiveName($t_subject->tableName(), $vn_subject_id, ['extension' => 'zip'])); //preg_replace('![^A-Za-z0-9\.\-]+!', '_', trim($t_subject->get($t_subject->getProperty('ID_NUMBERING_ID_FIELD')), "/")).'.zip');

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -2510,8 +2510,16 @@ class BaseEditorController extends ActionController {
 		
 		if (sizeof($va_file_paths) > 1) {
 			$o_zip = new ZipStream();
+			$names_set = [];
 			foreach($va_file_paths as $vs_path => $vs_name) {
+				if (isset($names_set[$vs_name])) {
+					$names_set[$vs_name]++;
+					$ext = pathinfo($vs_name, PATHINFO_EXTENSION);
+					$vs_name = pathinfo($vs_name, PATHINFO_FILENAME).'-'.$names_set[$vs_name].'.'.$ext;
+				}
 				$o_zip->addFile($vs_path, $vs_name);
+				
+				$names_set[$vs_name] = 1;
 			}
 			$o_view->setVar('zip_stream', $o_zip);
 			$o_view->setVar('archive_name', caGetMediaDownloadArchiveName($t_subject->tableName(), $vn_subject_id, ['extension' => 'zip'])); //preg_replace('![^A-Za-z0-9\.\-]+!', '_', trim($t_subject->get($t_subject->getProperty('ID_NUMBERING_ID_FIELD')), "/")).'.zip');


### PR DESCRIPTION
PR addresses issue where the "download all" option in the ca_object_representations editor bundle will omit files from the generated downloadable ZIP archive when the file naming policy results in duplicate file name. To resolve this, a system to generate unique file names in this situation is implemented.