### PR TITLE
Add abilityto disable  mediaDirRecursiveExpensiveCheck

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2104,6 +2104,9 @@ character_set = utf-8
 	# If you are on such a server you can disable all "expensive" configuration checks here.
 dont_do_expensive_configuration_checks_in_web_ui = 0
 
+# Extremly time consuming check of file permissions  in media folder can be disabled, because it slow on otherwise fast servers.
+dont_do_media_dir_expensive_check =0
+
 # -----------------------------------
 # Configuration exporter options
 # -----------------------------------

--- a/app/lib/ConfigurationCheck.php
+++ b/app/lib/ConfigurationCheck.php
@@ -450,6 +450,7 @@ final class ConfigurationCheck {
 	# They appear in the "configuration check" screen under manage -> system configuration.
 	# -------------------------------------------------------
 	public static function mediaDirRecursiveExpensiveCheck() {
+    if ((bool)self::$opo_config->get('dont_do_media_dir_expensive_check')) { return true;}
 		$va_dirs = self::getSubdirectoriesAsArray(self::$opo_config->get("ca_media_root_dir"));
 		$i = 0;
 		foreach($va_dirs as $vs_dir){


### PR DESCRIPTION
mediaDirRecursiveExpensiveCheck can be costly on large installations (25000 folders in media), Configuration check then fails on silent timeout.
I have added config to bypass this test (with bypass disabled on default). 

