### PR TITLE
NOJIRA Set place hierarchy to default when no parent_id is set for place record

### DIFF
--- a/app/models/ca_places.php
+++ b/app/models/ca_places.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2019 Whirl-i-Gig
+ * Copyright 2008-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -493,6 +493,24 @@ class ca_places extends RepresentableBaseModel implements IBundleProvider, IHier
 		}
 		
 		return null;
+	}
+	# ------------------------------------------------------
+	/**
+	 * Override insert() to check parent_id and default to default hierarchy if none is specified.
+	 */ 
+	public function insert($pa_options=null) {
+		if((int)$this->get('parent_id') <= 0) {
+			if ($default_hierarchy_id = caGetDefaultItemID('place_hierarchies')) {
+				$root_id = ca_places::find(['hierarchy_id' => $default_hierarchy_id], ['returnAs' => 'firstId']);
+			} elseif(is_array($hierarchies = $this->getHierarchyList()) && sizeof($hierarchies)) {
+				$first_hierarchy = array_shift($hierarchies);
+				$root_id = $first_hierarchy['place_id'];
+			} else {
+				throw new ApplicationException(_t('No place hierarchies are defined'));
+			}
+			$this->set('parent_id', $root_id);
+		}
+		return parent::insert($pa_options);
 	}
 	# ------------------------------------------------------
 }


### PR DESCRIPTION
PR handles issue where ca_places record is inserted without a parent_id by automatically setting the parent_id to the root_id used for the default place hierarchy. This avoids errors in cases where places are created in the user interface outside of a hierarchical context.