### PR TITLE
PROV-3012 "Could not add parent collection to object" error thrown when saving object within collection

### DIFF
--- a/app/controllers/editor/objects/ObjectEditorController.php
+++ b/app/controllers/editor/objects/ObjectEditorController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2018 Whirl-i-Gig
+ * Copyright 2008-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -66,7 +66,12 @@ class ObjectEditorController extends BaseEditorController {
 	 *
 	 */
 	public function postSave($t_object, $pb_is_insert) {
-		if ( $this->request->config->get('ca_objects_x_collections_hierarchy_enabled') && ($vs_coll_rel_type = $this->request->config->get('ca_objects_x_collections_hierarchy_relationship_type')) && ($pn_collection_id = $this->request->getParameter('collection_id', pInteger))) {
+		if (
+			$this->request->config->get('ca_objects_x_collections_hierarchy_enabled') && 
+			($vs_coll_rel_type = $this->request->config->get('ca_objects_x_collections_hierarchy_relationship_type')) && 
+			($pn_collection_id = $this->request->getParameter('collection_id', pInteger)) &&
+			!$t_object->relationshipExists('ca_collections', $pn_collection_id, $vs_coll_rel_type)
+		) {
 			if (!($t_object->addRelationship('ca_collections', $pn_collection_id, $vs_coll_rel_type))) {
 				$this->notification->addNotification(_t("Could not add parent collection to object: %1", join("; ", $t_object->getErrors())), __NOTIFICATION_TYPE_ERROR__);
 			}

--- a/app/models/ca_places.php
+++ b/app/models/ca_places.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2019 Whirl-i-Gig
+ * Copyright 2008-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -493,6 +493,24 @@ class ca_places extends RepresentableBaseModel implements IBundleProvider, IHier
 		}
 		
 		return null;
+	}
+	# ------------------------------------------------------
+	/**
+	 * Override insert() to check parent_id and default to default hierarchy if none is specified.
+	 */ 
+	public function insert($pa_options=null) {
+		if((int)$this->get('parent_id') <= 0) {
+			if ($default_hierarchy_id = caGetDefaultItemID('place_hierarchies')) {
+				$root_id = ca_places::find(['hierarchy_id' => $default_hierarchy_id], ['returnAs' => 'firstId']);
+			} elseif(is_array($hierarchies = $this->getHierarchyList()) && sizeof($hierarchies)) {
+				$first_hierarchy = array_shift($hierarchies);
+				$root_id = $first_hierarchy['place_id'];
+			} else {
+				throw new ApplicationException(_t('No place hierarchies are defined'));
+			}
+			$this->set('parent_id', $root_id);
+		}
+		return parent::insert($pa_options);
 	}
 	# ------------------------------------------------------
 }


### PR DESCRIPTION
PR prevents false "Could not add parent collection to object" error that may be thrown when saving an object and object-collection hierarchies are enabled even though the object is linked properly the collection and saved.