### PR TITLE
PROV-3009 Add option to omit specific access_statuses values for tables

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1119,6 +1119,26 @@ ca_objects_allow_access_inheritance = 0
 ca_objects_access_inheritance_default = 1
 
 
+# The "access" intrinsic field available on all primary tables determines whether a record
+# is displayed in public user interfaces, and to what groups of users it may be displayed.
+# The "access_statuses" list determines the values may be set for the "access" intrinsic. 
+# Typically it's two values (public, not-public), with additional entries optionally added to 
+# cover specific groups or categories of user. 
+#
+# Configured access values are shared across all types of records. The "omit_access_statuses" 
+# option allows you to hide specific values on specific table and type combinations. The
+# __default__ metatype is used for any type not specifically configured. You may use both list item
+# codes and list item values to reference to the entries to be omitted. 
+#
+# By default no entries are omitted, and all types of records use the same list of access values.
+# Uncomment the configuration below to omit values for specific tables/types.
+#
+#omit_access_statuses = {
+#	ca_objects = {
+#		__default__ = [restricted_public_access]
+#		a_type_code = [1,2]
+#	}
+#}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -2525,14 +2545,3 @@ idno_element_display_format_without_label = <div class='formLabel'>^ELEMENT <spa
 
 # Log directory for external export activity
 external_export_log_directory = <ca_base_dir>/app/log
-
-
-#
-#
-#
-omit_access_statuses = {
-	ca_objects = {
-		__default__ = [restricted_public_access],
-		item = [0,1]
-	}
-}

--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2525,3 +2525,14 @@ idno_element_display_format_without_label = <div class='formLabel'>^ELEMENT <spa
 
 # Log directory for external export activity
 external_export_log_directory = <ca_base_dir>/app/log
+
+
+#
+#
+#
+omit_access_statuses = {
+	ca_objects = {
+		__default__ = [restricted_public_access],
+		item = [0,1]
+	}
+}

--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1643,6 +1643,37 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 		
 		$pa_options['disabledOptions'] = $va_disabled_options;
 		
+		// For "access_statuses" list we enforce per-table/type option visibility restrictions
+		// here using specification in app.conf "omit_access_statuses" setting
+		//
+		if (
+			($t_list->get('ca_lists.list_code') === 'access_statuses') && 
+			($omit_table = caGetOption('table', $pa_options, null))			// table to omit values for
+		) {
+			$omit_type = caGetOption('type', $pa_options, null);			// optional type to omit values for
+			$config = Configuration::load();
+			$omit_map = $config->getAssoc('omit_access_statuses');
+			
+			if (isset($omit_map[$omit_table]) && ($omit_map = $omit_map[$omit_table])) {
+				if ($omit_type && is_array($omit_map[$omit_type])) { 
+					$omit_map = $omit_map[$omit_type];						// type specific policy
+				} else {
+					$omit_map = $omit_map['__default__'];					// defaulr (all type) policy
+				}
+				
+				if (is_array($omit_map)) {
+					foreach($omit_map as $i => $value) {
+						if(!strlen(trim($value))) { continue; }
+						if (!is_numeric($value)) { 
+							$value = caGetListItemValueForIdno('access_statuses', $value); 	// convert status identifiers to integer code values
+							if(!strlen(trim($value))) { continue; }
+						}
+						unset($va_options[(int)$value]);
+					}
+				}
+			}
+		}
+		
 		if (($max_columns = caGetOption('maxColumns', $pa_options, 1, ['castTo' => 'integer'])) < 1) { $max_columns = 1; }
 		switch($vs_render_as) {
 			case 'radio_buttons':

--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1658,7 +1658,7 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 				if ($omit_type && is_array($omit_map[$omit_type])) { 
 					$omit_map = $omit_map[$omit_type];						// type specific policy
 				} else {
-					$omit_map = $omit_map['__default__'];					// defaulr (all type) policy
+					$omit_map = $omit_map['__default__'];					// default (all type) policy
 				}
 				
 				if (is_array($omit_map)) {


### PR DESCRIPTION
PR adds configuration option in app.conf to control visibility/availability of selected access_statuses list values in "access" control for a given table/type combinations.

This will allow variations of the access list to be used in different types of records, while still maintaining the access_statuses list as a single definitive source of valid access values.