### PR TITLE
PROV-3019 Add support for domPDF 0.8.6

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1798,13 +1798,13 @@ dont_use_graphicsmagick_to_identify_pdfs = 0
 #
 dont_use_zendpdf_to_identify_pdfs = 1
 
-# CollectiveAccess supports three methods for generating PDF output for download and printing: dompdf (slower; built-in), 
-# wkhtmltopdf (faster; requires additional software installation) and phantomjs (faster; requires additional software installation). 
-# By default it will favor using wkhtmltopdf if available, falling back to phantomjs and then to dompdf which is always available. 
+# CollectiveAccess supports two methods for generating PDF output for download and printing: dompdf (slower; built-in), 
+# and wkhtmltopdf (faster; requires additional software installation). 
+# By default it will favor using wkhtmltopdf if available, falling back to dompdf which is always available. 
 #
 # You can override the build in preference and force the use of a specific PDF generator by uncommenting and setting this 
 # option to one of the following:
-#		wkhtmltopdf, phantomjs, dompdf 
+#		wkhtmltopdf, dompdf 
 # use_pdf_renderer = wkhtmltopdf
 
 # Only media than can be identified by a plugin may be uploaded. If you want to be able to upload any file

--- a/app/lib/Plugins/PDFRenderer/domPDF.php
+++ b/app/lib/Plugins/PDFRenderer/domPDF.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2014-2019 Whirl-i-Gig
+ * Copyright 2014-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -60,6 +60,7 @@ class WLPlugPDFRendererdomPDF Extends BasePDFRendererPlugIn Implements IWLPlugPD
 		
 		$options = new Options();
 		$options->set('isRemoteEnabled', TRUE);
+		$options->set('chroot', __CA_BASE_DIR__);
 		$options->set('logOutputFile', __CA_APP_DIR__.'/tmp/log.htm');
     	$options->set('tempDir', __CA_APP_DIR__.'/tmp');
 		$this->renderer = new DOMPDF($options);
@@ -119,8 +120,8 @@ class WLPlugPDFRendererdomPDF Extends BasePDFRendererPlugIn Implements IWLPlugPD
 	 *
 	 * @return bool True on success, false if parameters are invalid
 	 */
-	public function setPage($ps_size, $ps_orientation, $ps_margin_top=0, $ps_margin_right=0, $ps_margin_bottom=0, $ps_margin_left=0) {
-		$this->renderer->set_paper($ps_size, $ps_orientation);
+	public function setPage($size, $orientation, $margin_top=0, $margin_right=0, $margin_bottom=0, $margin_left=0) {
+		$this->renderer->set_paper($size, $orientation);
 		
 		return true;
 	}
@@ -131,19 +132,25 @@ class WLPlugPDFRendererdomPDF Extends BasePDFRendererPlugIn Implements IWLPlugPD
 	 * @return array - status info array; 'available' key determines if the plugin should be loaded or not
 	 */
 	public function checkStatus() {
-		$va_status = parent::checkStatus();
+		$status = parent::checkStatus();
 		
-		if (!($vb_wkhtmltopdf = caWkhtmltopdfInstalled())) {
-			$va_status['available'] = true;
+		$config = Configuration::load();
+		$use = $config->get('use_pdf_renderer');
+		
+		$wkhtmltopdf = ((!strlen($use) || (strtolower($use) === 'wkhtmltopdf')) && caWkhtmltopdfInstalled());
+		$dompdf = (!strlen($use) || (strtolower($use) === 'dompdf'));
+		
+		if (!$wkhtmltopdf) {
+			$status['available'] = $dompdf;
 		} else {
-			$va_status['available'] = false;
-			if ($vb_wkhtmltopdf) {
-				$va_status['unused'] = true;
-				$va_status['warnings'][] = _t("Didn't load because wkhtmltopdf is available and preferred");
+			$status['available'] = false;
+			if ($wkhtmltopdf) {
+				$status['unused'] = true;
+				$status['warnings'][] = _t("Didn't load because wkhtmltopdf is available and preferred");
 			} 
 		}
 		
-		return $va_status;
+		return $status;
 	}
 	# ------------------------------------------------
 }

--- a/app/lib/Plugins/PDFRenderer/wkhtmltopdf.php
+++ b/app/lib/Plugins/PDFRenderer/wkhtmltopdf.php
@@ -91,27 +91,27 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 	/**
 	 * Render HTML formatted string as a PDF
 	 *
-	 * @param string $ps_content A fully-formed HTML document to render as a PDF
-	 * @param array $pa_options Options include:
+	 * @param string $content A fully-formed HTML document to render as a PDF
+	 * @param array $options Options include:
 	 *		stream = Output the rendered PDF directly to the response [Default=false]
 	 *		filename = The filename to set the PDF to when streams [Default=output.pdf]
 	 *
 	 * @return string The rendered PDF content
 	 * @seealso wkhtmltopdf::renderFile()
 	 */
-	public function render($ps_content, $pa_options=null) {
+	public function render($content, $options=null) {
 	    // Force backtrack limit high to allow regex on very large strings
 	    // If we don't do this preg_replace will fail silently on large PDFs
 	    ini_set('pcre.backtrack_limit', '100000000');
 	    
 		// Extract header and footer
-		$vs_header = preg_match("/<!--BEGIN HEADER-->(.*)<!--END HEADER-->/s", $ps_content, $va_matches) ? $va_matches[1] : '';
-		$vs_footer = preg_match("/<!--BEGIN FOOTER-->(.*)<!--END FOOTER-->/s", $ps_content, $va_matches) ? $va_matches[1] : '';
+		$vs_header = preg_match("/<!--BEGIN HEADER-->(.*)<!--END HEADER-->/s", $content, $va_matches) ? $va_matches[1] : '';
+		$vs_footer = preg_match("/<!--BEGIN FOOTER-->(.*)<!--END FOOTER-->/s", $content, $va_matches) ? $va_matches[1] : '';
 		
-		$ps_content = preg_replace("/<!--BEGIN HEADER-->(.*)<!--END HEADER-->/s", "", $ps_content);
-		$ps_content = preg_replace("/<!--BEGIN FOOTER-->(.*)<!--END FOOTER-->/s", "", $ps_content);
+		$content = preg_replace("/<!--BEGIN HEADER-->(.*)<!--END HEADER-->/s", "", $content);
+		$content = preg_replace("/<!--BEGIN FOOTER-->(.*)<!--END FOOTER-->/s", "", $content);
 		
-		file_put_contents($vs_content_path = caMakeGetFilePath("wkhtmltopdf", "html"), $ps_content); 
+		file_put_contents($vs_content_path = caMakeGetFilePath("wkhtmltopdf", "html"), $content); 
 		file_put_contents($vs_header_path = caMakeGetFilePath("wkhtmltopdf", "html"), $vs_header); 
 		file_put_contents($vs_footer_path = caMakeGetFilePath("wkhtmltopdf", "html"), $vs_footer); 
 		$vs_output_path = caMakeGetFilePath("wkhtmltopdf", "pdf", ['useAppTmpDir' => true]);
@@ -119,10 +119,10 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 		caExec($this->ops_wkhtmltopdf_path." --enable-local-file-access  --disable-smart-shrinking --dpi 96 --encoding UTF-8 --margin-top {$this->ops_margin_top} --margin-bottom {$this->ops_margin_bottom} --margin-left {$this->ops_margin_left} --margin-right {$this->ops_margin_right} --page-size {$this->ops_page_size} --orientation {$this->ops_page_orientation} page ".caEscapeShellArg($vs_content_path)." --header-html {$vs_header_path} --footer-html {$vs_footer_path} {$vs_output_path}", $va_output, $vn_return);	
 		
 		$vs_pdf_content = file_get_contents($vs_output_path);
-		if (caGetOption('stream', $pa_options, false)) {
+		if (caGetOption('stream', $options, false)) {
 			header("Cache-Control: private");
    			header("Content-type: application/pdf");
-			header("Content-Disposition: attachment; filename=".caGetOption('filename', $pa_options, 'output.pdf'));
+			header("Content-Disposition: attachment; filename=".caGetOption('filename', $options, 'output.pdf'));
 			print $vs_pdf_content;
 		}
 		
@@ -137,18 +137,18 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 	/**
 	 * Render HTML file as a PDF
 	 *
-	 * @param string $ps_file_path Path to fully-formed HTML file to render as a PDF
-	 * @param array $pa_options Options include:
+	 * @param string $file_path Path to fully-formed HTML file to render as a PDF
+	 * @param array $options Options include:
 	 *		stream = Output the rendered PDF directly to the response [Default=false]
 	 *		filename = The filename to set the PDF to when streams [Default=export_results.pdf]
 	 *
 	 * @return string The rendered PDF content
 	 * @seealso wkhtmltopdf::render()
 	 */
-	public function renderFile($ps_file_path, $pa_options=null) {
-		if(!file_exists($ps_file_path)) { return false; }
-		$vs_content = file_get_contents($ps_file_path);	
-		return $this->render($vs_content, $pa_options);
+	public function renderFile($file_path, $options=null) {
+		if(!file_exists($file_path)) { return false; }
+		$vs_content = file_get_contents($file_path);	
+		return $this->render($vs_content, $options);
 	}
 	# ------------------------------------------------
 	/**
@@ -159,17 +159,17 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 	 *
 	 * @return bool True on success, false if parameters are invalid
 	 */
-	public function setPage($ps_size, $ps_orientation, $ps_margin_top=0, $ps_margin_right=0, $ps_margin_bottom=0, $ps_margin_left=0) {
-		if (!PDFRenderer::isValidPageSize($ps_size) || !PDFRenderer::isValidOrientation($ps_orientation)) {
+	public function setPage($size, $orientation, $margin_top=0, $margin_right=0, $margin_bottom=0, $margin_left=0) {
+		if (!PDFRenderer::isValidPageSize($size) || !PDFRenderer::isValidOrientation($orientation)) {
 			return false;
 		}
-		$this->ops_page_size = $ps_size;
-		$this->ops_page_orientation = $ps_orientation;
+		$this->ops_page_size = $size;
+		$this->ops_page_orientation = $orientation;
 		
-		$this->ops_margin_top = caConvertMeasurement($ps_margin_top, 'mm').'mm';
-		$this->ops_margin_right = caConvertMeasurement($ps_margin_right, 'mm').'mm';
-		$this->ops_margin_bottom = caConvertMeasurement($ps_margin_bottom, 'mm').'mm';
-		$this->ops_margin_left = caConvertMeasurement($ps_margin_left, 'mm').'mm';
+		$this->ops_margin_top = caConvertMeasurement($margin_top, 'mm').'mm';
+		$this->ops_margin_right = caConvertMeasurement($margin_right, 'mm').'mm';
+		$this->ops_margin_bottom = caConvertMeasurement($margin_bottom, 'mm').'mm';
+		$this->ops_margin_left = caConvertMeasurement($margin_left, 'mm').'mm';
 		
 		return true;
 	}
@@ -180,10 +180,13 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 	 * @return array - status info array; 'available' key determines if the plugin should be loaded or not
 	 */
 	public function checkStatus() {
-		$va_status = parent::checkStatus();
-		$va_status['available'] = caWkhtmltopdfInstalled();
+		$config = Configuration::load();
+		$use = $config->get('use_pdf_renderer');
+
+		$status = parent::checkStatus();
+		$status['available'] = (!strlen($use) || (strtolower($use) === 'wkhtmltopdf')) && caWkhtmltopdfInstalled();
 		
-		return $va_status;
+		return $status;
 	}
 	# ------------------------------------------------
 }


### PR DESCRIPTION
PR Implements support for changes implemented on domPDF 0.8.6. 

With domPDF 0.8.6 generation of PDFs that reference external resources such as images and CSS files (basically 99.9% of PDF templates in CA) fail due to newly imposed security restrictions. The PR sets options to allow locally hosted resources to continue to be loaded.

PR also fixes non-functional app.conf use_pdf_renderer option.