### PR TITLE
PROV-3018 Allow ingest of media representations via service-specific urls

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1476,6 +1476,7 @@ ca_item_tags_lookup_sort = _natural
 # -----------------------------------
 ca_objects_default_bundle_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</ifdef>
 ca_entities_default_bundle_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</ifdef>
+ca_collections_default_bundle_display_template = <l>^ca_collections.preferred_labels.name</l> (^relationship_typename)
 ca_places_default_bundle_display_template = <l>^ca_places.preferred_labels.name</l> (^relationship_typename)
 ca_occurrences_default_bundle_display_template = <l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)
 ca_object_lots_default_bundle_display_template = <l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)
@@ -1491,6 +1492,7 @@ ca_list_items_default_bundle_display_template = <l>^ca_list_items.preferred_labe
 ca_objects_default_editor_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l></ifdef>
 ca_entities_default_editor_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l></ifdef>
 ca_places_default_editor_display_template = <l>^ca_places.preferred_labels.name</l>
+ca_collections_default_editor_display_template = <l>^ca_collections.preferred_labels.name</l>
 ca_occurrences_default_editor_display_template = <l>^ca_occurrences.preferred_labels.name</l>
 ca_object_lots_default_editor_display_template = <l>^ca_object_lots.preferred_labels.name</l>
 ca_storage_locations_default_editor_display_template = <l>^ca_storage_locations.hierarchy.preferred_labels.name</l>
@@ -1798,13 +1800,13 @@ dont_use_graphicsmagick_to_identify_pdfs = 0
 #
 dont_use_zendpdf_to_identify_pdfs = 1
 
-# CollectiveAccess supports three methods for generating PDF output for download and printing: dompdf (slower; built-in), 
-# wkhtmltopdf (faster; requires additional software installation) and phantomjs (faster; requires additional software installation). 
-# By default it will favor using wkhtmltopdf if available, falling back to phantomjs and then to dompdf which is always available. 
+# CollectiveAccess supports two methods for generating PDF output for download and printing: dompdf (slower; built-in), 
+# and wkhtmltopdf (faster; requires additional software installation). 
+# By default it will favor using wkhtmltopdf if available, falling back to dompdf which is always available. 
 #
 # You can override the build in preference and force the use of a specific PDF generator by uncommenting and setting this 
 # option to one of the following:
-#		wkhtmltopdf, phantomjs, dompdf 
+#		wkhtmltopdf, dompdf 
 # use_pdf_renderer = wkhtmltopdf
 
 # Only media than can be identified by a plugin may be uploaded. If you want to be able to upload any file

--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -1540,22 +1540,6 @@ function caProcessRefineryRelatedMultiple($po_refinery_instance, &$pa_item, $pa_
 	}
 	# ---------------------------------------------------------------------
 	/**
-	 *
-	 */
-	function caValidateGoogleSheetsUrl($url) {
-		if (!is_array($parsed_url = parse_url(urldecode($url)))) { return null; }
- 			
-		$tmp = explode('/', $parsed_url['path']);
-		array_pop($tmp); $tmp[] = 'export';
-		$path = join("/", $tmp);
-		$transformed_url = $parsed_url['scheme']."://".$parsed_url['host'].$path."?format=xlsx";
-		if (!isUrl($transformed_url) || !preg_match('!^https://(docs|drive).google.com/(spreadsheets|file)/d/!', $transformed_url)) {
-			return null;
-		}
-		return $transformed_url;
-	}
-	# ---------------------------------------------------------------------
-	/**
 	 * Return list of key values to try when looking for "preferred labels" option in splitter opts.
 	 */
 	function caGetPreferredLabelNameKeyList() { 

--- a/app/helpers/preload.php
+++ b/app/helpers/preload.php
@@ -91,8 +91,13 @@ spl_autoload_register(function ($class) {
         if(require(__CA_MODELS_DIR__."/{$class}.php")) { return true; }
     }
     
+    // strip namespaces if present
+    if(strpos($class, '\\') !== false) {
+    	$class = array_pop(explode('\\', $class));
+    }
+    
     // search common locations for class
-    $paths = [__CA_LIB_DIR__, __CA_LIB_DIR__.'/Utils', __CA_LIB_DIR__.'/Parsers', __CA_LIB_DIR__.'/Media'];
+    $paths = [__CA_LIB_DIR__, __CA_LIB_DIR__.'/Utils', __CA_LIB_DIR__.'/Parsers', __CA_LIB_DIR__.'/Media', __CA_LIB_DIR__.'/Exceptions'];
     foreach($paths as $path) {
         if(file_exists("{$path}/{$class}.php")) {
             if(require("{$path}/{$class}.php")) { return true; }   

--- a/app/lib/ApplicationError.php
+++ b/app/lib/ApplicationError.php
@@ -431,4 +431,3 @@ class ApplicationError {
 		return false;
 	}
 }
-?>

--- a/app/lib/Controller/AppController.php
+++ b/app/lib/Controller/AppController.php
@@ -36,7 +36,7 @@
  
 include_once(__CA_LIB_DIR__."/Controller/Request/RequestHTTP.php");
 include_once(__CA_LIB_DIR__."/Controller/RequestDispatcher.php");
-include_once(__CA_LIB_DIR__."/Controller/ApplicationException.php");
+include_once(__CA_LIB_DIR__."/Exceptions/ApplicationException.php");
 
 global $g_app_controller;
 $g_app_controller = null;

--- a/app/lib/Exceptions/UrlFetchException.php
+++ b/app/lib/Exceptions/UrlFetchException.php
@@ -1,13 +1,13 @@
 <?php
 /** ---------------------------------------------------------------------
- * app/lib/Plugins/WLPlug.php :
+ * app/lib/Exceptions/UrlFetchException.php :
  * ----------------------------------------------------------------------
  * CollectiveAccess
  * Open-source collections management software
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2003-2008 Whirl-i-Gig
+ * Copyright 2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -15,42 +15,22 @@
  * the terms of the provided license as published by Whirl-i-Gig
  *
  * CollectiveAccess is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * This source code is free and modifiable under the terms of 
+ * This source code is free and modifiable under the terms of
  * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
  * the "license.txt" file for details, or visit the CollectiveAccess web site at
  * http://www.CollectiveAccess.org
  *
  * @package CollectiveAccess
- * @subpackage LibraryPlugins
+ * @subpackage Core
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
  *
  * ----------------------------------------------------------------------
  */
- 
- /**
-  *
-  */
 
-class WLPlug extends BaseObject {
-	# ------------------------------------------------------------------------
-	var $error_output = false;
-	var $description = '';
-	
-	# ------------------------------------------------------------------------
-	public function getDescription() {
-		return isset($this->description) ? $this->description : '';
-	}
-	# ------------------------------------------------------------------------
-	public function checkStatus() {
-		return array(
-			'description' => $this->getDescription(),
-			'errors' => [],
-			'warnings' => [],
-			'available' => false
-		);
-	}
-	# ------------------------------------------------------------------------
-}
+/**
+ *
+ */
+	class UrlFetchException extends Exception {} 

--- a/app/lib/MediaUrl.php
+++ b/app/lib/MediaUrl.php
@@ -1,0 +1,108 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/MediaUrl.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Media
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+namespace CA;
+
+ /**
+  *
+  */
+require_once(__CA_LIB_DIR__.'/Plugins/PluginConsumer.php');
+
+class MediaUrl extends \CA\Plugins\PluginConsumer {
+	# ----------------------------------------------------------
+	# Properties
+	# ----------------------------------------------------------
+	
+	
+	# ----------------------------------------------------------
+	# Methods
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
+	public function __construct($no_cache=false) { 
+		if (!self::$plugin_path) { self::$plugin_path = __CA_LIB_DIR__.'/Plugins/MediaUrl'; }
+		self::$exclusion_list = ['BaseMediaUrlPlugin.php'];
+		
+		self::$name = 'MediaUrl';
+		self::$plugin_prefix = '\\CA\\MediaUrl\\Plugins\\';
+	}
+	
+	# ----------------------------------------------------------
+	/**
+	 * Validate url
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		format = Suggest preferred format to plugins that can return different formats for the same resource (Eg. GoogleDrive). The format is only a preference and may be ignored. [Default is NULL]
+	 *		limit = Limit processing to a specific plugin or list of plugins. Note that the name of the default file URL handler is "_File". [Default is null; all plugins are used]
+	 *
+	 * @return array|bool False if no plugin can process the url, or an array of information about the URL on success.
+	 */
+	function validate($url, $options=null) {
+		$plugin_names = $this->getPluginNames($options);
+		foreach ($plugin_names as $plugin_name) {
+			if (!($plugin_info = $this->getPlugin($plugin_name))) { continue; }
+			if ($f = $plugin_info['INSTANCE']->parse($url, $options)) {
+				return $f;
+			}
+		}
+		return false;
+	}
+	# ----------------------------------------------------------
+	/**
+	 * Fetch contents of URL
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		format = Suggest preferred format to plugins that can return different formats for the same resource (Eg. GoogleDrive). The format is only a preference and may be ignored. [Default is NULL]
+	 *		limit = Limit processing to a specific plugin or list of plugins. Note that the name of the default file URL handler is "_File". [Default is null; all plugins are used]
+	 *		returnAsString = Return fetched content as string rather than in a file. [Default is false]
+	 *
+	 * @return bool|array|string False is no plugin can process the url, an array of data including the path to a file  containing the URL contents on success, or a string with file content is the returnAsString option is set.
+	 */
+	function fetch($url, $options=null) {
+		$plugin_names = $this->getPluginNames();
+		foreach ($plugin_names as $plugin_name) {
+			if (!($plugin_info = $this->getPlugin($plugin_name))) { continue; }
+			
+			try {
+				if ($f = $plugin_info['INSTANCE']->fetch($url, $options)) {
+					return $f;
+				}
+			} catch (\UrlFetchException $e) {
+				return false;
+			}
+		}
+		return false;
+	}
+	# ------------------------------------------------
+}

--- a/app/lib/Plugins/Media/Office.php
+++ b/app/lib/Plugins/Media/Office.php
@@ -324,7 +324,17 @@ class WLPlugMediaOffice Extends BaseMediaPlugin Implements IWLPlugMedia {
 		if (in_array(pathinfo(strtolower($ps_filepath), PATHINFO_EXTENSION), ['xls', 'xlsx'])) {
 			$va_excel_types = ['Excel2007' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'Excel5' => 'application/vnd.ms-excel', 'Excel2003XML' => 'application/vnd.ms-excel'];
 			foreach ($va_excel_types as $vs_type => $vs_mimetype) {
-				$o_reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($vs_type);
+				switch($vs_type) {
+					case 'Excel2007':
+						$o_reader = new \PhpOffice\PhpSpreadsheet\Reader\Xlsx();
+						break;
+					case 'Excel5':
+						$o_reader = new \PhpOffice\PhpSpreadsheet\Reader\Xls();
+						break;
+					case 'Excel2003XML':
+						$o_reader = new \PhpOffice\PhpSpreadsheet\Reader\Xml();
+						break;
+				}
 				if ($o_reader->canRead($ps_filepath)) {
 					return $vs_mimetype;
 				}

--- a/app/lib/Plugins/MediaUrl/BaseMediaUrlPlugin.php
+++ b/app/lib/Plugins/MediaUrl/BaseMediaUrlPlugin.php
@@ -1,13 +1,13 @@
 <?php
 /** ---------------------------------------------------------------------
- * app/lib/Plugins/WLPlug.php :
+ * app/lib/Plugins/MediaUrlParser/BaseMediaUrlParserPlugin.php :
  * ----------------------------------------------------------------------
  * CollectiveAccess
  * Open-source collections management software
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2003-2008 Whirl-i-Gig
+ * Copyright 2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -24,33 +24,40 @@
  * http://www.CollectiveAccess.org
  *
  * @package CollectiveAccess
- * @subpackage LibraryPlugins
+ * @subpackage Media
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
  *
  * ----------------------------------------------------------------------
  */
+namespace CA\MediaUrl\Plugins;
  
  /**
   *
   */
 
-class WLPlug extends BaseObject {
-	# ------------------------------------------------------------------------
-	var $error_output = false;
-	var $description = '';
+include_once(__CA_LIB_DIR__."/Plugins/WLPlug.php");
+
+class BaseMediaUrlPlugin extends \WLPlug  {
+	# ------------------------------------------------
+	/**
+	 * 
+	 */
+	protected $info = [];
 	
-	# ------------------------------------------------------------------------
-	public function getDescription() {
-		return isset($this->description) ? $this->description : '';
+	
+	# ------------------------------------------------
+	public function __construct() {
+		parent::__construct();
 	}
-	# ------------------------------------------------------------------------
-	public function checkStatus() {
-		return array(
-			'description' => $this->getDescription(),
-			'errors' => [],
-			'warnings' => [],
-			'available' => false
-		);
-	}
-	# ------------------------------------------------------------------------
+	# ------------------------------------------------
+	/** 
+	 * Announce what kinds of media this plug-in supports for import and export
+	 */
+	public function register() {
+		$this->opo_config = Configuration::load();
+		
+		$this->info["INSTANCE"] = $this;
+		return $this->info;
+	}	
+	# ------------------------------------------------
 }

--- a/app/lib/Plugins/MediaUrl/GoogleDrive.php
+++ b/app/lib/Plugins/MediaUrl/GoogleDrive.php
@@ -1,0 +1,139 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Plugins/MediaUrlParser/GoogleDrive.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage MediaUrlParser
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+namespace CA\MediaUrl\Plugins;
+ 
+ /**
+  *
+  */
+  require_once(__CA_LIB_DIR__.'/Plugins/MediaUrl/BaseMediaUrlPlugin.php');
+ 
+class GoogleDrive Extends BaseMediaUrlPlugin {	
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	private static $mimetypes = [
+		'pdf' => ['application/pdf'],
+		'xlsx' => ['application/msexcel', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+		'docx' => ['application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+	];
+	
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function __construct() {
+		$this->description = _t('Parses GoogleDrive URLs');
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function register() {
+		$this->info["INSTANCE"] = $this;
+		return $this->info;
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function checkStatus() {
+		$status = parent::checkStatus();
+		$status['available'] = is_array($this->register()); 
+		return $status;
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to parse GoogleDrive URL. If valid, transform url for to allow download as PDF
+	 * or user-specified format. Supported formats are PDF, Microsoft Excel (xlsx) and Microsoft Word (docx). 
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		format = Preferred format to grab GoogleDrive resource in, if possible. May be ignored is format is not possible for resource. Valid values are pdf, xlsx, docx. [Default is pdf]
+	 *
+	 * @return bool|array False if url is not valid, array with information about the url if valid.
+	 */
+	public function parse(string $url, array $options=null) {
+		if (!is_array($parsed_url = parse_url(urldecode($url)))) { return null; }
+ 		
+ 		$format = caGetOption('format', $options, 'pdf', ['validValues' => ['pdf', 'xlsx', 'docx']]);
+		$tmp = explode('/', $parsed_url['path']);
+		array_pop($tmp); $tmp[] = 'export';
+		$path = join("/", $tmp);
+		$transformed_url = $parsed_url['scheme']."://".$parsed_url['host'].$path."?format={$format}";
+		if (!isUrl($transformed_url) || !preg_match('!^https://(docs|drive).google.com/(spreadsheets|file)/d/!', $transformed_url)) {
+			return false;
+		}
+		
+		// Get doc title
+ 		$content = file_get_contents($url);
+ 		$filename = preg_match('!<meta property="og:title" content="([^"]+)">!', $content, $m) ? preg_replace('![^A-Za-z0-9\.\-_]+!', '_', $m[1]) : 'document';
+ 
+		return ['url' => $transformed_url, 'originalUrl' => $url, 'format' => $format, 'plugin' => 'GoogleDrive', 'originalFilename' => "{$filename}.{$format}"];
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to fetch content from a GoogleDrive URL, transforming GoogleDoc content to a PDF or other user-specified format (xlsx or docx).
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		filename = File name to use for fetched file. If omitted a random name is generated. [Default is null]
+	 *		extension = Extension to use for fetched file. If omitted ".bin" is used as the extension. [Default is null]
+	 *		format = Preferred format to grab GoogleDrive resource in, if possible. May be ignored is format is not possible for resource. Valid values are pdf, xlsx, docx. [Default is pdf]
+	 *		returnAsString = Return fetched content as string rather than in a file. [Default is false]
+	 *
+	 * @throws UrlFetchException Thrown if fetch URL fails.
+	 * @return bool|array|string False if url is not valid, array with path to file with content and format if successful, string with content if returnAsString option is set.
+	 */
+	public function fetch(string $url, array $options=null) {
+		if ($p = $this->parse($url, $options)) {
+ 			$format = caGetOption('format', $options, 'pdf', ['validValues' => ['pdf', 'xlsx', 'docx']]);
+			if($dest = caGetOption('filename', $options, null)) {
+				$dest .= '.'.caGetOption('extension', $options, '.bin');
+			}
+			
+			$tmp_file = caFetchFileFromUrl($p['url'], $dest, ['mimetype' => self::$mimetypes[$format]]);
+			
+			if (caGetOption('returnAsString', $options, false)) {
+				$content = file_get_contents($tmp_file);
+				unlink($tmp_file);
+				return $content;
+			}
+			
+			if(!$dest) { rename($tmp_file, $tmp_file .= '.'.$format); }
+			
+			return array_merge($p, ['file' => $tmp_file, 'format' => $format]);
+		}
+		return false;
+	}
+	# ------------------------------------------------
+}

--- a/app/lib/Plugins/MediaUrl/InternetArchive.php
+++ b/app/lib/Plugins/MediaUrl/InternetArchive.php
@@ -1,0 +1,133 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Plugins/MediaUrlParser/InternetArchive.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage MediaUrlParser
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+namespace CA\MediaUrl\Plugins;
+ 
+ /**
+  *
+  */
+  require_once(__CA_LIB_DIR__.'/Plugins/MediaUrl/BaseMediaUrlPlugin.php');
+ 
+class InternetArchive Extends BaseMediaUrlPlugin {	
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function __construct() {
+		$this->description = _t('Parses InternetArchive URLs');
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function register() {
+		$this->info["INSTANCE"] = $this;
+		return $this->info;
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function checkStatus() {
+		$status = parent::checkStatus();
+		$status['available'] = is_array($this->register()); 
+		return $status;
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to parse InternetArchive URL. If valid, transform url for to allow download as PDF
+	 * or user-specified format. Supported formats are PDF, Microsoft Excel (xlsx) and Microsoft Word (docx). 
+	 *
+	 * @param string $url
+	 * @param array $options No options are currently supported.
+	 *
+	 * @return bool|array False if url is not valid, array with information about the url if valid.
+	 */
+	public function parse(string $url, array $options=null) {
+		if (!is_array($parsed_url = parse_url(urldecode($url)))) { return null; }
+		
+		//Ex. We have an item whose url is https://archive.org/details/CTC_1988_08_17
+		//We would generally pull the mp3 file directly using a url like: http://www.archive.org/download/CTC_1988_08_17/CTC_1988_08_17c_44-1.mp3
+ 		
+ 		//<meta property="og:video" content="https://archive.org/download/CTC_1988_08_17/CTC_1988_08_17a_44-1.mp3">
+ 		
+ 		if(!preg_match('!\.archive\.org$!', $parsed_url['host']) && !preg_match('!^archive\.org$!', $parsed_url['host'])) { return false; }
+ 		
+ 		// Is straight download URL?
+ 		if (preg_match('!^/download/[A-Za-z0-9_\-\.]+/([A-Za-z0-9_\-\.]+)!', $parsed_url['path'])) {
+ 			return ['url' => $url, 'originalUrl' => $url, 'plugin' => 'InternetArchive'];
+ 		}
+ 		
+ 		// Is detail URL?
+ 		if (preg_match('!^/details/[A-Za-z0-9_\-\.]+!', $parsed_url['path'], $m)) {
+ 			$content = file_get_contents($url);
+ 			if(preg_match('!<meta property="og:video" content="([^"]+)">!', $content, $m)) {
+ 				return ['url' => $m[1], 'originalUrl' => $url, 'plugin' => 'InternetArchive', 'originalFilename' => pathInfo($m[1], PATHINFO_BASENAME)];
+ 			}
+ 		}
+ 		
+		return false;
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to fetch content from a InternetArchive URL, transforming content to a PDF or other user-specified format (xlsx or docx).
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		filename = File name to use for fetched file. If omitted a random name is generated. [Default is null]
+	 *		extension = Extension to use for fetched file. If omitted ".bin" is used as the extension. [Default is null]
+	 *		returnAsString = Return fetched content as string rather than in a file. [Default is false]
+	 *
+	 * @throws UrlFetchException Thrown if fetch URL fails.
+	 * @return bool|array|string False if url is not valid, array with path to file with content and format if successful, string with content if returnAsString option is set.
+	 */
+	public function fetch(string $url, array $options=null) {
+		if ($p = $this->parse($url, $options)) {
+			if($dest = caGetOption('filename', $options, null)) {
+				$dest .= '.'.caGetOption('extension', $options, '.bin');
+			}
+			
+			$tmp_file = caFetchFileFromUrl($p['url'], $dest);
+			
+			if (caGetOption('returnAsString', $options, false)) {
+				$content = file_get_contents($tmp_file);
+				unlink($tmp_file);
+				return $content;
+			}
+			
+			if(!$dest) { rename($tmp_file, $tmp_file .= '.'.$format); }
+			
+			return array_merge($p, ['file' => $tmp_file]);
+		}
+		return false;
+	}
+	# ------------------------------------------------
+}

--- a/app/lib/Plugins/MediaUrl/_File.php
+++ b/app/lib/Plugins/MediaUrl/_File.php
@@ -1,0 +1,111 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Plugins/MediaUrlParser/_File.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage MediaUrl
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+namespace CA\MediaUrl\Plugins;
+ 
+ /**
+  *
+  */
+  require_once(__CA_LIB_DIR__.'/Plugins/MediaUrl/BaseMediaUrlPlugin.php');
+ 
+class _File Extends BaseMediaUrlPlugin {	
+	# ------------------------------------------------
+	
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function __construct() {
+		$this->description = _t('Parses file URLs');
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function register() {
+		$this->info["INSTANCE"] = $this;
+		return $this->info;
+	}
+	# ------------------------------------------------
+	/**
+	 *
+	 */
+	public function checkStatus() {
+		$status = parent::checkStatus();
+		$status['available'] = is_array($this->register()); 
+		return $status;
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to parse URL as binary file. This should only fail if the URL returns an error status.
+	 *
+	 * @param string $url
+	 * @param array $options No options are currently supported.
+	 *
+	 * @return bool|array False if url is not valid, array with information about the url if valid.
+	 */
+	public function parse(string $url, array $options=null) {
+		if (!isUrl($url)) { return false; }
+		return ['url' => $url, 'originalUrl' => $url, 'format' => pathinfo($url, PATHINFO_EXTENSION), 'plugin' => 'File', 'originalFilename' => pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_BASENAME)];
+	}
+	# ------------------------------------------------
+	/**
+	 * Attempt to fetch content from a URL as a binary file. This should only fail if the URL returns an error status.
+	 *
+	 * @param string $url
+	 * @param array $options Options include:
+	 *		filename = File name to use for fetched file. If omitted a random name is generated. [Default is null]
+	 *		extension = Extension to use for fetched file. If omitted ".bin" is used as the extension. [Default is null]
+	 *		returnAsString = Return fetched content as string rather than in a file. [Default is false]
+	 *
+	 * @throws UrlFetchException Thrown if fetch URL fails.
+	 * @return bool|array|string False if url is not valid, array with path to file with content and format if successful, string with content if returnAsString option is set.
+	 */
+	public function fetch(string $url, array $options=null) {
+		if ($p = $this->parse($url, $options)) {
+ 			if($dest = caGetOption('filename', $options, null)) {
+				$dest .= '.'.caGetOption('extension', $options, '.bin');
+			}
+			
+			$tmp_file = caFetchFileFromUrl($p['url'], $dest);
+			
+			if (caGetOption('returnAsString', $options, false)) {
+				$content = file_get_contents($tmp_file);
+				unlink($tmp_file);
+				return $content;
+			}
+			
+			return array_merge($p, ['file' => $tmp_file, 'format' => pathinfo($url, PATHINFO_EXTENSION)]);
+		}
+		return false;
+	}
+	# ------------------------------------------------
+}

--- a/app/lib/Plugins/PluginConsumer.php
+++ b/app/lib/Plugins/PluginConsumer.php
@@ -1,0 +1,154 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Plugins/PluginConsumer.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Media
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+namespace CA\Plugins;
+
+class PluginConsumer extends \BaseObject {
+	# ----------------------------------------------------------
+	/**
+	 *
+	 */
+	public $DEBUG = false;
+	
+	/**
+	 * Must be set by sub-class
+	 */
+	public static $name;
+	
+	/**
+	 * Must be set by sub-class
+	 */
+	public static $plugin_prefix;
+	
+	
+	/**
+	 * Must be set by sub-class
+	 */
+	protected static $plugin_path;
+	
+	/**
+	 *
+	 */
+	protected static $plugin_names;
+	
+	/**
+	 *
+	 */
+	protected static $plugin_cache = [];
+	
+	/**
+	 *
+	 */
+	protected static $exclusion_list = [];
+	
+	/**
+	 *
+	 */
+	protected static $unregistered_plugin_cache = [];
+	
+	
+	
+	# ----------------------------------------------------------
+	/**
+	 * Get list of available plugin names.
+	 *
+	 * @param array $options Options include:
+	 *		limit = Return only specified plugins if valid. [Default is null; return all available plugins]
+	 *
+	 * @return array 
+	 */
+	public function getPluginNames(array $options=null) {		
+		$limit = caGetOption('limit', $options, [], ['castTo' => 'array']);
+		if (is_array(self::$plugin_names) && (sizeof($limit) === 0)) { return self::$plugin_names; }
+		
+		self::$plugin_names = [];
+		$dir = opendir(self::$plugin_path);
+		if (!$dir) { throw new ApplicationException(_t('Cannot open plugin directory %1', self::$plugin_path)); }
+	
+		$vb_binary_file_plugin_installed = false;
+		while (($plugin = readdir($dir)) !== false) {
+			if ((in_array($plugin, self::$exclusion_list, true)) || ((sizeof($limit) > 0) && !in_array(preg_replace('!\.php$!', '', $plugin), $limit, true))) { continue; }
+			if (preg_match("/^([A-Za-z_]+[A-Za-z0-9_]*).php$/", $plugin, $m)) {
+				self::$plugin_names[] = $m[1];
+			}
+		}
+		
+		sort(self::$plugin_names);
+		
+		return self::$plugin_names;
+	}
+	# ----------------------------------------------------------
+	/**
+	 * Get instance of plugin.
+	 *
+	 * @param string $plugin_name 
+	 *
+	 * return WLPlug Plugin instance, or null if plugin name is invalid.
+	 */
+	public function getPlugin(string $plugin_name) {
+		if (!($p = $this->getUnregisteredPlugin($plugin_name))) { return null; }
+		
+		# register the plugin's capabilities
+		if ($vo_instance = $p->register()) {
+			if ($this->DEBUG) {	print "[DEBUG:{self::$name}] LOADED {$plugin_name}<br>\n"; }
+			return self::$plugin_cache[$plugin_name] = $vo_instance;
+		} else {
+			if ($this->DEBUG) {	print "[DEBUG:{self::$name}] DID NOT LOAD {$plugin_name}<br>\n"; }
+			self::$plugin_cache[$plugin_name] = false;
+			return null;
+		}
+	}
+	# ----------------------------------------------------------
+	/**
+	 * Instantiate plugin.
+	 *
+	 * @param string $plugin_name 
+	 *
+	 * @return Plugin instance, or null if plugin name is invalid.
+	 */
+	private function getUnregisteredPlugin(string $plugin_name) {
+		if(!in_array($plugin_name, $this->getPluginNames())) { return null; }
+		
+		$plugin_dir = self::$plugin_path;
+		
+		# load the plugin
+		if (!class_exists(self::$plugin_prefix.$plugin_name)) { 
+			if(!@require_once("{$plugin_dir}/{$plugin_name}.php")) { return null; }
+		}
+		$plugin_class = self::$plugin_prefix.$plugin_name;
+		$p = new $plugin_class();
+		
+		self::$unregistered_plugin_cache[$plugin_name] = $p;
+		
+		return $p;
+	}
+	# ----------------------------------------------------------
+}

--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -175,7 +175,9 @@
 				
 				if (isset($va_info['INPUT']['FETCHED_FROM']) && ($vs_fetched_from_url = $va_info['INPUT']['FETCHED_FROM'])) {
 					$va_tmp['fetched_from'] = $vs_fetched_from_url;
+					$va_tmp['fetched_original_url'] = $va_info['INPUT']['FETCHED_ORIGINAL_URL'];
 					$va_tmp['fetched_on'] = (int)$va_info['INPUT']['FETCHED_ON'];
+					$va_tmp['fetched_by'] = $va_info['INPUT']['FETCHED_BY'];
 				}
 			
 				$va_tmp['num_multifiles'] = $t_rep->numFiles($vn_rep_id);
@@ -1292,8 +1294,10 @@
 							'md5' => $vs_md5 ? "{$vs_md5}" : "",
 							'typename' => $va_rep_type_list[$va_rep['type_id']]['name_singular'],
 							'fetched_from' => $va_rep['fetched_from'],
-							'fetched_on' => date('c', $va_rep['fetched_on']),
-							'fetched' => $va_rep['fetched_from'] ? _t("<h3>Fetched from:</h3> URL %1 on %2", '<a href="'.$va_rep['fetched_from'].'" target="_ext" title="'.$va_rep['fetched_from'].'">'.$va_rep['fetched_from'].'</a>', date('c', $va_rep['fetched_on'])) : ""
+							'fetched_original_url' => caGetOption('fetched_original_url', $va_rep, null),
+							'fetched_by' => caGetOption('fetched_by', $va_rep, null),
+							'fetched_on' => $va_rep['fetched_on'] ? date('c', $va_rep['fetched_on']): null,
+							'fetched' => $va_rep['fetched_from'] ? _t("<h3>Fetched from:</h3> URL %1 on %2 using %3 URL handler", '<a href="'.$va_rep['fetched_from'].'" target="_ext" title="'.$va_rep['fetched_from'].'">'.$va_rep['fetched_from'].'</a>', date('c', $va_rep['fetched_on']), caGetOption('fetched_by', $va_rep, 'default')) : ""
 						);
 					
 						if (is_array($bundle_data[$va_rep['representation_id']])) {

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -1738,6 +1738,8 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
  				
 			if (isset($va_info['INPUT']['FETCHED_FROM']) && ($vs_fetched_from_url = $va_info['INPUT']['FETCHED_FROM'])) {
 				$va_tmp['fetched_from'] = $vs_fetched_from_url;
+				$va_tmp['fetched_original_url'] = caGetOption('FETCHED_ORIGINAL_URL', $va_info['INPUT'], null);
+				$va_tmp['fetched_by'] = caGetOption('FETCHED_BY', $va_info['INPUT'], null);
 				$va_tmp['fetched_on'] = (int)$va_info['INPUT']['FETCHED_ON'];
 			}
  			

--- a/app/models/ca_representation_annotations.php
+++ b/app/models/ca_representation_annotations.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2013 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -653,6 +653,8 @@ class ca_representation_annotations extends BundlableLabelableBaseModelWithAttri
 			if (isset($va_info['INPUT']['FETCHED_FROM']) && ($vs_fetched_from_url = $va_info['INPUT']['FETCHED_FROM'])) {
 				$va_tmp['fetched_from'] = $vs_fetched_from_url;
 				$va_tmp['fetched_on'] = (int)$va_info['INPUT']['FETCHED_ON'];
+				$va_tmp['fetched_by'] = caGetOption('FETCHED_BY', $va_info['INPUT'], null);
+				$va_tmp['fetched_original_url'] = caGetOption('FETCHED_ORIGINAL_URL', $va_info['INPUT'], null);
 			}
  			
  			//$va_tmp['num_multifiles'] = $t_rep->numFiles($this->get('representation_id'));

--- a/app/models/ca_set_items.php
+++ b/app/models/ca_set_items.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2016 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -397,6 +397,8 @@ class ca_set_items extends BundlableLabelableBaseModelWithAttributes {
 			if (isset($va_info['INPUT']['FETCHED_FROM']) && ($vs_fetched_from_url = $va_info['INPUT']['FETCHED_FROM'])) {
 				$va_tmp['fetched_from'] = $vs_fetched_from_url;
 				$va_tmp['fetched_on'] = (int)$va_info['INPUT']['FETCHED_ON'];
+				$va_tmp['fetched_by'] = caGetOption('FETCHED_BY', $va_info['INPUT'], null);
+				$va_tmp['fetched_original_url'] = caGetOption('FETCHED_ORIGINAL_URL', $va_info['INPUT'], null);
 			}
  			
  			$va_reps[] = $va_tmp;

--- a/app/models/ca_site_pages.php
+++ b/app/models/ca_site_pages.php
@@ -699,8 +699,10 @@ class ca_site_pages extends BundlableLabelableBaseModelWithAttributes {
                     'versions' => join("; ", $va_m['versions']),
                     'page_id' => $va_m['page_id'],
                     'fetched_from' => $va_m['fetched_from'],
-                    'fetched_on' => $va_m['fetched_on'] ? date('c', $va_m['fetched_on']) : null,
-                    'fetched' => $va_m['fetched_from'] ? _t("<h3>Fetched from:</h3> URL %1 on %2", '<a href="'.$va_m['fetched_from'].'" target="_ext" title="'.$va_m['fetched_from'].'">'.$va_m['fetched_from'].'</a>', date('c', $va_m['fetched_on'])): ""
+					'fetched_original_url' => $va_m['fetched_original_url'],
+					'fetched_by' => $va_m['fetched_by'],
+					'fetched_on' => $va_m['fetched_on'] ? date('c', $va_m['fetched_on']) : null,
+                    'fetched' => $va_m['fetched_from'] ? _t("<h3>Fetched from:</h3> URL %1 on %2 uing %3 URL handler", '<a href="'.$va_m['fetched_from'].'" target="_ext" title="'.$va_m['fetched_from'].'">'.$va_m['fetched_from'].'</a>', date('c', $va_m['fetched_on']), caGetOption('fetched_by', $va_rep, 'default')): ""
                 );
         }
         return $va_initial_values;

--- a/app/models/ca_user_representation_annotations.php
+++ b/app/models/ca_user_representation_annotations.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015 Whirl-i-Gig
+ * Copyright 2015-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -631,6 +631,8 @@ class ca_user_representation_annotations extends BundlableLabelableBaseModelWith
 			if (isset($va_info['INPUT']['FETCHED_FROM']) && ($vs_fetched_from_url = $va_info['INPUT']['FETCHED_FROM'])) {
 				$va_tmp['fetched_from'] = $vs_fetched_from_url;
 				$va_tmp['fetched_on'] = (int)$va_info['INPUT']['FETCHED_ON'];
+				$va_tmp['fetched_by'] = caGetOption('FETCHED_BY', $va_info['INPUT'], null);
+				$va_tmp['fetched_original_url'] = caGetOption('FETCHED_ORIGINAL_URL', $va_info['INPUT'], null);
 			}
  			
  			//$va_tmp['num_multifiles'] = $t_rep->numFiles($this->get('representation_id'));

--- a/themes/default/views/bundles/ca_object_representations.php
+++ b/themes/default/views/bundles/ca_object_representations.php
@@ -177,6 +177,11 @@
 						<div class='formLabel'><?= _t('Relationship type: %1', $t_item_rel->getRelationshipTypesAsHTMLSelect($rel_dir, $left_sub_type_id, $right_sub_type_id, array('id' => '{fieldNamePrefix}rel_type_id_{n}', 'name' => '{fieldNamePrefix}rel_type_id_{n}', 'value' => '{rel_type_id}'), $settings)); ?></div>
 <?php
 	} 
+	if ($allow_fetching_from_urls) { 
+?>
+						<div class='formLabel'><?= _t('Fetch media from URL'); ?><br/><?php print caHTMLTextInput("{fieldNamePrefix}media_url_{n}", array('id' => '{fieldNamePrefix}media_url_{n}', 'class' => 'urlBg uploadInput'), array('width' => '500px')); ?></div>			
+<?php 
+	} 
 						foreach($bundles_to_edit_proc as $f) {
 							if($f === 'type_id') { // type
 								print "<div class='formLabel''>".$t_item->getDisplayLabel("ca_object_representations.{$f}")."<br/>".$t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."</div>\n";

--- a/themes/default/views/bundles/ca_object_representations.php
+++ b/themes/default/views/bundles/ca_object_representations.php
@@ -62,6 +62,7 @@
 	$loaded_sort_direction 	= $this->getVar('sortDirection');
 	
 	$rep_count = $t_subject->getRepresentationCount($settings);
+	$allow_fetching_from_urls = $this->request->getAppConfig()->get('allow_fetching_of_media_from_remote_urls');
 	
 	$errors = $failed_inserts = [];
 	
@@ -256,6 +257,11 @@
 					</div>
 				</div>
 				<div class="mediaUploadEditArea">
+	
+<?php if ($allow_fetching_from_urls) { ?>
+				<div class='formLabel'><?= _t('Fetch media from URL'); ?><br/><?php print caHTMLTextInput("{fieldNamePrefix}media_url_{n}", array('id' => '{fieldNamePrefix}media_url_{n}', 'class' => 'urlBg uploadInput'), array('width' => '500px')); ?></div>
+				
+<?php } ?>				
 <?php
     if($t_item_rel->hasField('type_id') && (sizeof($rel_types) > 1)) {
 ?>
@@ -270,7 +276,7 @@
 					if(in_array($f, ['media'])) { continue; }
 					
 					if($f === 'type_id') { // type
-						print "<div class='formLabel''>".$t_item->getDisplayLabel("ca_object_representations.{$f}")."<br/>".$t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."</div>\n";
+						print "<div class='formLabel'>".$t_item->getDisplayLabel("ca_object_representations.{$f}")."<br/>".$t_item->getTypeListAsHTMLFormElement("{$id_prefix}_{$f}_{n}", ['id' => "{$id_prefix}_{$f}_{n}", 'value' => '{'.$f.'}'], ['restrictToTypes' => caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null), 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."</div>\n";
 					} elseif($t_item->hasField($f)) { // intrinsic
 						print $t_item->htmlFormElement($f, null, ['id' => "{$id_prefix}_{$f}_{n}", 'name' => "{$id_prefix}_{$f}_{n}", 'width' => '500px', 'height' => null, 'textAreaTagName' => 'textentry', 'no_tooltips' => true])."\n";
 					} elseif($t_item->hasElement($f)) {


### PR DESCRIPTION
PR adds facility to allow ingest of media using various types of urls, from standard resource urls to service-specific urls for GoogleDrive, Internet Archive. Is pluggable to simplify expansion in the future to services such as YouTube and Vimeo.