### PR TITLE
PROV-3022 Use correct path when attempting to run ImageMagick

### DIFF
--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -315,7 +315,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 	 * Returns base path to ImageMagick installation
 	 */
 	public function getBasePath() {
-		return caMediaPluginImageMagickInstalled();
+		return pathInfo(caMediaPluginImageMagickInstalled(), PATHINFO_DIRNAME);
 	}
 	# ------------------------------------------------
 	# Tell WebLib what kinds of media this plug-in supports


### PR DESCRIPTION
PR addresses regression that breaks support for media processing using ImageMagick command-line binaries.