### PR TITLE
PROV-2922 Add ability to create a placeholder for object representation record

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1505,6 +1505,7 @@ Filesize: ^ca_object_representations.media_filesize<br/>
 <ifdef code='ca_object_representations.media_colorspace'>Colorspace: ^ca_object_representations.media_bitdepth ^ca_object_representations.media_colorspace<br/></ifdef>
 <ifdef code='ca_object_representations.original_filename'>File name: ^ca_object_representations.original_filename<br/></ifdef>
 <ifdef code='ca_object_representations.page_count'>Pages: ^ca_object_representations.page_count<br/></ifdef>
+<ifdef code='ca_object_representations.preview_count'>Previews: ^ca_object_representations.preview_count<br/></ifdef>
 Access: ^ca_object_representations.access<br/>
 Status: ^ca_object_representations.status<br/>"
 
@@ -2099,6 +2100,14 @@ maximum_download_file_count =
 
 downloaded_file_naming = original_name
 #ca_objects_downloaded_file_naming = "Meow_^ca_object_representations.original_filename"
+
+# Formatting of download file name for media archives (multiple files bound together in a ZIP file)
+# 
+# Set to 'idno' to name the archive using the identifier of the source record. You may also set 
+# this to a display template evaluated relative to the source record. Ex. When downloading an
+# archive of media from an object, setting this to "DOWNLOAD_^ca_object.preferred_labels.name" will
+# name the archive with the preferred label of the objet prefixed with the word "DOWNLOAD"
+downloaded_media_archive_file_naming = idno
 
 # -----------------------------------
 # Task queue set up (deferred processing of uploaded media)

--- a/app/conf/media_display.conf
+++ b/app/conf/media_display.conf
@@ -10,7 +10,7 @@ media_overlay = {
 		
 		viewer = TileViewer,
 		#use_universal_viewer_for_image_list_length_at_least = 3,
-		use_mirador_for_image_list_length_at_least = 3,
+		#use_mirador_for_image_list_length_at_least = 3,
 		viewer_for_multipage_images = Mirador
 	},
 	video = {

--- a/app/conf/media_processing.conf
+++ b/app/conf/media_processing.conf
@@ -811,7 +811,9 @@ ca_object_representations = {
 				#	QUEUE_WHEN_FILE_LARGER_THAN = <queue_threshold_in_bytes>
 				#},
 				original 	= {
-					RULE = rule_video, VOLUME = quicktime
+					RULE = rule_video, VOLUME = quicktime,
+					#SKIP_WHEN_FILE_LARGER_THAN = 500000,
+					#REPLACE_WITH = page
 				}
 			},
 			MEDIA_VIEW_DEFAULT_VERSION = h264_hi,
@@ -949,7 +951,9 @@ ca_object_representations = {
 				#	QUEUE_WHEN_FILE_LARGER_THAN = <queue_threshold_in_bytes>
 				#},
 				original 	= {
-					RULE = rule_video, VOLUME = quicktime
+					RULE = rule_video, VOLUME = quicktime,
+					#SKIP_WHEN_FILE_LARGER_THAN = 500000,
+					#REPLACE_WITH_VERSION = large
 				}
 			},
 			MEDIA_VIEW_DEFAULT_VERSION = original,

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1194,7 +1194,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 				$vs_buf .= "{$vs_watch}\n";
 				TooltipManager::add("#caWatchItemButton", _t('Watch/Unwatch this record'));
 
-				if ($po_view->request->user->canDoAction("can_change_type_{$vs_table_name}")) {
+				if ($po_view->request->user->canDoAction("can_change_type_{$vs_table_name}") && (sizeof($t_item->getTypeList()) > 1)) {
 
 					$vs_buf .= "<div id='inspectorChangeType' class='inspectorActionButton'><div id='inspectorChangeTypeButton'><a href='#' onclick='caTypeChangePanel.showPanel(); return false;'>".caNavIcon(__CA_NAV_ICON_CHANGE__, '20px', array('title' => _t('Change type')))."</a></div></div>\n";
 
@@ -4962,15 +4962,16 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 	 */
 	function caGetMediaDownloadArchiveName($table, $id, $options=null) {
 		$config = Configuration::load();
-		switch($mode = $config->get(["{$table}_downloaded_media_archive_file_naming", "downloaded_media_archive_file_naming","{$table}_downloaded_file_naming", 'downloaded_file_naming'])) {
+		switch($mode = $config->get(["{$table}_downloaded_media_archive_file_naming", 'downloaded_media_archive_file_naming', "{$table}_downloaded_file_naming", 'downloaded_file_naming'])) {
 			case 'idno':
-				$filename = $data['idno'].(strlen($data['index']) ? '_'.$data['index'] : '').'.'.$data['extension'];
-				break;
+				// Noop - fall through	
 			default:
-				if (strpos($mode, "^") == false) { // use default templte
+				if (strpos($mode, "^") === false) { // use default template
 					$mode = "^{$table}.idno";
 				}
-				$filename = caProcessTemplateForIDs($mode, $table, [$id]);
+				if (!($filename = caProcessTemplateForIDs($mode, $table, [$id]))) {
+					$filename = 'export';
+				}
 				$ext = caGetOption('extension', $options, 'zip');
 				
 				if(!preg_match("!\.{$ext}$!i", $filename)) {

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -1967,12 +1967,12 @@ class BaseEditorController extends ActionController {
 				throw new ApplicationException(_t('Cannot view media'));
 			}
 
-			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('value_blob', 'original', 'MIMETYPE')))) {
+			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('value_blob', 'INPUT', 'MIMETYPE')))) {
 				throw new ApplicationException(_t('Invalid viewer'));
 			}
 
 			$va_display_info = caGetMediaDisplayInfo('media_overlay', $vs_mimetype);
-			if(($t_instance->numFiles() > 1) && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
+			if(($t_instance->numFiles() > 1) && (caGetMediaClass($vs_mimetype) === 'image') && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
 				$va_display_info['viewer'] = $vs_viewer_name = $multipage_viewer;
 				unset($va_display_info['use_mirador_for_image_list_length_at_least']);
 				unset($va_display_info['use_universal_viewer_for_image_list_length_at_least']);
@@ -1996,7 +1996,7 @@ class BaseEditorController extends ActionController {
 			require_once(__CA_MODELS_DIR__."/ca_object_representations.php");
 			$t_instance = new ca_object_representations($pn_representation_id);
 			
-			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
 				throw new ApplicationException(_t('Invalid viewer'));
 			}
 			
@@ -2019,7 +2019,7 @@ class BaseEditorController extends ActionController {
 				}
 			}
 			
-			if(($t_instance->numFiles() > 1) && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
+			if(($t_instance->numFiles() > 1) && (caGetMediaClass($vs_mimetype) === 'image') && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
 				$va_display_info['viewer'] = $vs_viewer_name = $multipage_viewer;
 				unset($va_display_info['use_mirador_for_image_list_length_at_least']);
 				unset($va_display_info['use_universal_viewer_for_image_list_length_at_least']);
@@ -2046,7 +2046,7 @@ class BaseEditorController extends ActionController {
 			require_once(__CA_MODELS_DIR__."/ca_site_page_media.php");
 			$t_instance = new ca_site_page_media($pn_media_id);
 			
-			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+			if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
 				throw new ApplicationException(_t('Invalid viewer'));
 			}
 			
@@ -2093,7 +2093,7 @@ class BaseEditorController extends ActionController {
 			case 'representation':
 				$t_instance = new ca_object_representations($va_identifier['id']);
 				
-				if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+				if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
 					throw new ApplicationException(_t('Invalid viewer'));
 				}
 				
@@ -2116,7 +2116,7 @@ class BaseEditorController extends ActionController {
 					}
 				}
 				
-				if(($t_instance->numFiles() > 1) && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
+				if(($t_instance->numFiles() > 1) && (caGetMediaClass($vs_mimetype) === 'image') && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
 					$va_display_info['viewer'] = $vs_viewer_name = $multipage_viewer;
 					unset($va_display_info['use_mirador_for_image_list_length_at_least']);
 					unset($va_display_info['use_universal_viewer_for_image_list_length_at_least']);
@@ -2132,12 +2132,12 @@ class BaseEditorController extends ActionController {
 				$t_subject = Datamodel::getInstanceByTableNum($t_attr->get('table_num'), true);
 				$t_subject->load($t_attr->get('row_id'));
 				
-				if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('value_blob', 'original', 'MIMETYPE')))) {
+				if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('value_blob', 'INPUT', 'MIMETYPE')))) {
 					throw new ApplicationException(_t('Invalid viewer'));
 				}
 				
 				$va_display_info = caGetMediaDisplayInfo('media_overlay', $vs_mimetype);
-				if(($t_instance->numFiles() > 1) && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
+				if(($t_instance->numFiles() > 1) && (caGetMediaClass($vs_mimetype) === 'image') && ($multipage_viewer = caGetOption('viewer_for_multipage_images', $va_display_info, null))) {
 					$va_display_info['viewer'] = $vs_viewer_name = $multipage_viewer;
 					unset($va_display_info['use_mirador_for_image_list_length_at_least']);
 					unset($va_display_info['use_universal_viewer_for_image_list_length_at_least']);
@@ -2178,7 +2178,7 @@ class BaseEditorController extends ActionController {
 		switch($va_identifier['type']) {
 			case 'representation':
                 $t_instance = new ca_object_representations($va_identifier['id']);
-                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
                     throw new ApplicationException(_t('Invalid viewer'));
                 }
                 $this->response->addContent($vs_viewer_name::searchViewerData($this->request, $ps_identifier, ['request' => $this->request, 't_subject' => $t_subject, 't_instance' => $t_instance, 'display' => $va_display_info]));
@@ -2186,7 +2186,7 @@ class BaseEditorController extends ActionController {
                 break;
 			case 'attribute':
                 $t_instance = new ca_object_representations($va_identifier['id']);
-                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
                     throw new ApplicationException(_t('Invalid viewer'));
                 }
                 $this->response->addContent($vs_viewer_name::searchViewerData($this->request, $ps_identifier, ['request' => $this->request, 't_subject' => $t_subject, 't_instance' => $t_instance, 'display' => $va_display_info]));
@@ -2216,7 +2216,7 @@ class BaseEditorController extends ActionController {
 		switch($va_identifier['type']) {
 			case 'representation':
                 $t_instance = new ca_object_representations($va_identifier['id']);
-                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
                     throw new ApplicationException(_t('Invalid viewer'));
                 }
                 $this->response->addContent($vs_viewer_name::autocomplete($this->request, $ps_identifier, ['request' => $this->request, 't_subject' => $t_subject, 't_instance' => $t_instance, 'display' => $va_display_info]));
@@ -2224,7 +2224,7 @@ class BaseEditorController extends ActionController {
                 break;
 			case 'attribute':
                 $t_instance = new ca_object_representations($va_identifier['id']);
-                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'original', 'MIMETYPE')))) {
+                if (!($vs_viewer_name = MediaViewerManager::getViewerForMimetype("media_overlay", $vs_mimetype = $t_instance->getMediaInfo('media', 'INPUT', 'MIMETYPE')))) {
                     throw new ApplicationException(_t('Invalid viewer'));
                 }
                 $this->response->addContent($vs_viewer_name::autocomplete($this->request, $ps_identifier, ['request' => $this->request, 't_subject' => $t_subject, 't_instance' => $t_instance, 'display' => $va_display_info]));
@@ -2462,7 +2462,7 @@ class BaseEditorController extends ActionController {
 				    $va_reps = $t_subject->getRepresentations([$ps_version]);
 				    break;
 			}
-			$vs_idno = $t_subject->get('idno');
+			$vs_idno = $t_subject->get($t_subject->getProperty('ID_NUMBERING_ID_FIELD'));
 	
 			$vb_download_for_record = false;
 			foreach($va_reps as $vn_representation_id => $va_rep) {

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -3560,6 +3560,14 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 		$va_media_info = $this->get($ps_field, array('returnWithStructure' => true));
 		if (!is_array($va_media_info) || !is_array($va_media_info = array_shift($va_media_info))) { return null; }
 		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
+		
 		$vi = $this->_MEDIA_VOLUMES->getVolumeInformation($va_media_info[$ps_version]["VOLUME"]);
 		if (!is_array($vi)) { return null; }
 		if (is_array($vi["mirrors"])) {
@@ -3579,6 +3587,14 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	public function getMediaMirrorStatus($ps_field, $ps_version, $mirror="") {
 		$va_media_info = $this->get($ps_field, array('returnWithStructure' => true));
 		if (!is_array($va_media_info) || !is_array($va_media_info = array_shift($va_media_info))) { return null; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
 		
 		$vi = $this->_MEDIA_VOLUMES->getVolumeInformation($va_media_info[$ps_version]["VOLUME"]);
 		if (!is_array($vi)) {
@@ -3603,6 +3619,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 		
 		$va_media_info = $this->get($ps_field, array('returnWithStructure' => true));
 		if (!is_array($va_media_info) || !is_array($va_media_info = array_shift($va_media_info))) { return null; }
+
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
 		
 		$va_volume_info = $this->_MEDIA_VOLUMES->getVolumeInformation($va_media_info[$ps_version]["VOLUME"]);
 		if (!is_array($va_volume_info)) { return null; }
@@ -3676,6 +3699,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	public function getMediaUrl($ps_field, $ps_version, $pn_page=1, $pa_options=null) {
 		$va_media_info = $this->getMediaInfo($ps_field);
 		if (!is_array($va_media_info)) { return null; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
 
 		#
 		# Use icon
@@ -3747,6 +3777,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	public function getMediaPath($ps_field, $ps_version, $pn_page=1) {
 		$va_media_info = $this->getMediaInfo($ps_field);
 		if (!is_array($va_media_info)) { return null; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
 
 		#
 		# Use icon
@@ -3799,6 +3836,14 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	public function getMediaTag($ps_field, $ps_version, $pa_options=null) {
         if(!$pa_options) { $pa_options = []; }
 		if (!is_array($va_media_info = $this->getMediaInfo($ps_field))) { return null; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
 		if (!is_array($va_media_info[$ps_version])) { return null; }
 
         if ($alt_text_template = Configuration::load()->get($this->tableName()."_alt_text_template")) { 
@@ -3853,6 +3898,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	public function &getMediaInfo($ps_field, $ps_version=null, $ps_property=null) {
 		$va_media_info = self::get($ps_field, array('returnWithStructure' => true, 'USE_MEDIA_FIELD_VALUES' => true));
 		if (!is_array($va_media_info) || !is_array($va_media_info = array_shift($va_media_info))) { return null; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
 		
 		#
 		# Use icon
@@ -3916,6 +3968,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	 */
 	public function getMediaInputTypeForVersion($ps_field, $ps_version) {
 		if ($va_media_info = $this->getMediaInfo($ps_field)) {
+			#
+			# Was this version skipped?
+			#
+			if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+				$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+			}
+		
 			$o_media_proc_settings = new MediaProcessingSettings($this, $ps_field);
 			if($vs_media_type = $o_media_proc_settings->canAccept($va_media_info["INPUT"]["MIMETYPE"])) {
 				$va_media_type_info = $o_media_proc_settings->getMediaTypeInfo($vs_media_type);
@@ -4458,11 +4517,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 						}
 					
 						$queue 				= $va_default_queue_settings['QUEUE'];
-						$queue_threshold 	= isset($version_info[$v]['QUEUE_WHEN_FILE_LARGER_THAN']) ? intval($version_info[$v]['QUEUE_WHEN_FILE_LARGER_THAN']) : (int)$va_default_queue_settings['QUEUE_WHEN_FILE_LARGER_THAN'];
+						$queue_threshold 	= caGetOption('QUEUE_WHEN_FILE_LARGER_THAN', $version_info[$v], (int)$va_default_queue_settings['QUEUE_WHEN_FILE_LARGER_THAN']);
 						$rule 				= isset($version_info[$v]['RULE']) ? $version_info[$v]['RULE'] : '';
 						$volume 			= isset($version_info[$v]['VOLUME']) ? $version_info[$v]['VOLUME'] : '';
 
 						$basis				= isset($version_info[$v]['BASIS']) ? $version_info[$v]['BASIS'] : '';
+						
+						$skip_threshold 	= caGetOption('SKIP_WHEN_FILE_LARGER_THAN', $version_info[$v], null);
 
 						if (isset($media_desc[$basis]) && isset($media_desc[$basis]['FILENAME'])) {
 							if (!isset($va_media_objects[$basis])) {
@@ -4540,7 +4601,26 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 								return false;
 							}
 
-							if ((bool)$version_info[$v]["USE_EXTERNAL_URL_WHEN_AVAILABLE"]) { 
+							$media_desc[$v] = array(
+								"VOLUME" => $volume,
+								"MIMETYPE" => $output_mimetype,
+								"WIDTH" => $m->get("width"),
+								"HEIGHT" => $m->get("height"),
+								"PROPERTIES" => $m->getProperties(),
+								"EXTENSION" => $ext,
+							);
+						
+							if (
+								(!is_null($skip_threshold) && ((int)$skip_threshold < (int)$media_desc["INPUT"]["FILESIZE"]))
+								||
+								(is_null($skip_threshold) && isset($version_info[$v]['REPLACE_WITH_VERSION']) && in_array($version_info[$v]['REPLACE_WITH_VERSION'], $va_versions, true))
+							) {
+								$media_desc[$v]['SKIP'] = 1;
+								
+								$alt_version_list = array_filter(array_keys($media_desc), function($x) use ($v) { return ($x !== $v); });
+								$replace_with_version = caGetOption('REPLACE_WITH_VERSION', $version_info[$v], array_pop($alt_version_list), ['validValues' => $va_versions]);
+								$media_desc[$v]['REPLACE_WITH_VERSION'] = $replace_with_version ? $replace_with_version : $va_versions[0];
+							} else if ((bool)$version_info[$v]["USE_EXTERNAL_URL_WHEN_AVAILABLE"]) { 
 								$filepath = $this->_SET_FILES[$ps_field]['tmp_name'];
 							
 								if ($pa_options['delete_old_media']) {
@@ -4550,20 +4630,14 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 									);
 								}
 														
-								$media_desc[$v] = array(
-									"VOLUME" => $volume,
-									"MIMETYPE" => $output_mimetype,
-									"WIDTH" => $m->get("width"),
-									"HEIGHT" => $m->get("height"),
-									"PROPERTIES" => $m->getProperties(),
+								$media_desc[$v] = array_merge($media_desc[$v], [
 									"EXTERNAL_URL" => $media_desc['INPUT']['FETCHED_FROM'],
 									"FILENAME" => null,
 									"HASH" => null,
 									"MAGIC" => null,
-									"EXTENSION" => $ext,
 									"MD5" => md5_file($filepath),
 									"FILE_LAST_MODIFIED" => filemtime($filepath)
-								);
+								]);
 							} else {
 								$magic = rand(0,99999);
 								$filepath = $vi["absolutePath"]."/".$dirhash."/".$magic."_".$this->_genMediaName($ps_field)."_".$v.".".$ext;
@@ -4637,19 +4711,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 									}
 								}
 							
-								$media_desc[$v] = array(
-									"VOLUME" => $volume,
-									"MIMETYPE" => $output_mimetype,
-									"WIDTH" => $m->get("width"),
-									"HEIGHT" => $m->get("height"),
-									"PROPERTIES" => $m->getProperties(),
+								$media_desc[$v] = array_merge($media_desc[$v], [
 									"FILENAME" => $this->_genMediaName($ps_field)."_".$v.".".$ext,
 									"HASH" => $dirhash,
 									"MAGIC" => $magic,
-									"EXTENSION" => $ext,
 									"MD5" => md5_file($filepath),
 									"FILE_LAST_MODIFIED" => filemtime($filepath)
-								);
+								]);
 							}
 						} else {
 							$m->set("version", $v);

--- a/app/lib/Media/MediaInfoCoder.php
+++ b/app/lib/Media/MediaInfoCoder.php
@@ -92,6 +92,13 @@ class MediaInfoCoder {
 		if (!($va_media_info = $this->opa_media_info) && !($va_media_info = caGetOption('data', $pa_options, null))) { return false; }	
 		
 		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
+		#
 		# Use icon
 		#
 		if ($ps_version && (!$ps_key || (in_array(strtoupper($ps_key), array('WIDTH', 'HEIGHT'))))) {
@@ -140,6 +147,13 @@ class MediaInfoCoder {
 		$vn_page = 1;
 		if (is_array($pa_options) && (isset($pa_options["page"])) && ($pa_options["page"] > 1)) {
 			$vn_page = $pa_options["page"];
+		}
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
 		}
 		
 		#
@@ -192,6 +206,13 @@ class MediaInfoCoder {
 		$vn_page = 1;
 		if (is_array($pa_options) && (isset($pa_options["page"])) && ($pa_options["page"] > 1)) {
 			$vn_page = $pa_options["page"];
+		}
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
 		}
 		
 		#
@@ -261,6 +282,13 @@ class MediaInfoCoder {
 		if (!isset($pa_options["page"]) || ($pa_options["page"] < 1)) { $pa_options["page"] = 1; }
 		
 		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
+		#
 		# Use icon
 		#
 		if (isset($va_media_info[$ps_version]) && isset($va_media_info[$ps_version]['USE_ICON']) && ($vs_icon_code = $va_media_info[$ps_version]['USE_ICON'])) {
@@ -320,6 +348,13 @@ class MediaInfoCoder {
 	public function mediaIsMirrored($ps_version, $pa_options=null) {
 		if (!($va_media_info = $this->opa_media_info) && !($va_media_info = caGetOption('data', $pa_options, null))) { return false; }
 		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
+		
 		$va_volume_info = $this->opo_volume_info->getVolumeInformation($va_media_info[$ps_version]["VOLUME"]);
 		if (!is_array($va_volume_info)) {
 			return false;
@@ -336,6 +371,13 @@ class MediaInfoCoder {
 	 */
 	public function getMediaMirrorStatus($ps_version, $ps_mirror=null, $pa_options=null) {
 		if (!($va_media_info = $this->opa_media_info) && !($va_media_info = caGetOption('data', $pa_options, null))) { return false; }
+		
+		#
+		# Was this version skipped?
+		#
+		if (isset($va_media_info[$ps_version]["SKIP"]) && $va_media_info[$ps_version]["SKIP"]) {
+			$ps_version = $va_media_info[$ps_version]["REPLACE_WITH_VERSION"];
+		}
 		
 		$va_volume_info = $this->opo_volume_info->getVolumeInformation($va_media_info[$ps_version]["VOLUME"]);
 		if (!is_array($va_volume_info)) {

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -2388,7 +2388,18 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 				break;
 			case 'page_count':
 			case 'preview_count':
-				return $this->numFiles($row_id);
+				if (($qr = caMakeSearchResult('ca_object_representations', [$row_id])) && $qr->nextHit()) {
+					$mimetype = $qr->getMediaInfo('media', 'INPUT', 'MIMETYPE');
+					$class = caGetMediaClass($mimetype);
+					
+					if (($bundle_name === 'page_count') && in_array($class, ['document', 'image'])) {
+						return $this->numFiles($row_id);
+					}
+					if (($bundle_name === 'preview_count') && in_array($class, ['audio', 'video'])) {
+						return $this->numFiles($row_id);
+					}
+				}
+				return null;
 				break;
 			case 'media_dimensions':
 			case 'media_duration':


### PR DESCRIPTION
PR adds ability to process uploaded media without retaining the original file. Two new per-version media_processing.conf settings are added:

- SKIP_WHEN_FILE_LARGER_THAN skips processing of a version when the uploaded file is greater than the number of bytes specified here
- REPLACE_WITH_VERSION remaps all calls to the version to another extant version. 

When SKIP_WHEN_FILE_LARGER_THAN is used REPLACE_WITH_VERSION is only honored if the size of the uploaded file exceeds the stated limit. When REPLACE_WITH_VERSION is used without SKIP_WHEN_FILE_LARGER_THAN the version is always skipped and remapped.