### PR TITLE
PROV-2984 Implement configurable summary download names

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2348,6 +2348,29 @@ ca_objects_standard_results_export_formats = [xlsx, csv, tab, docx]
 #
 #ca_sets_export_file_naming = "Export from ^ca_sets.preferred_labels.name"
 
+#
+# Formatting of download file name for summary PDFs generated from the record editor. 
+# Can be set to a display template evaluated relative to the record being summarized. 
+# This means you can use any record metadata in the file name. If not set, the download 
+# will default to the using the template defined by the @filename setting in the summary
+# print template.
+#
+ca_objects_summary_file_naming = "^ca_objects.idno"
+ca_object_lots_summary_file_naming = "^ca_object_lots.idno_stub"
+ca_entities_summary_file_naming = "^ca_entities.idno"
+ca_places_summary_file_naming = "^ca_places.idno"
+ca_occurrences_summary_file_naming = "^ca_occurrences.idno"
+ca_collections_summary_file_naming = "^ca_collections.idno"
+ca_lists_summary_file_naming = "^ca_lists.list_code"
+ca_list_items_summary_file_naming = "^ca_list_items.idno"
+ca_loans_summary_file_naming = "^ca_loans.idno"
+ca_movements_summary_file_naming = "^ca_movements.idno"
+ca_object_representations_summary_file_naming = "^ca_object_representations.idno"
+ca_representation_annotations_summary_file_naming = "Annotation_for_^ca_object_representations.idno"
+ca_storage_locations_summary_file_naming = "^ca_storage_locations.idno"
+ca_tours_summary_file_naming = "^ca_tours.tour_code"
+ca_tour_stops_summary_file_naming = "^ca_tour_stops.idno"
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -897,7 +897,13 @@ class BaseEditorController extends ActionController {
 
                     $o_pdf->setPage(caGetOption('pageSize', $va_template_info, 'letter'), caGetOption('pageOrientation', $va_template_info, 'portrait'), caGetOption('marginTop', $va_template_info, '0mm'), caGetOption('marginRight', $va_template_info, '0mm'), caGetOption('marginBottom', $va_template_info, '0mm'), caGetOption('marginLeft', $va_template_info, '0mm'));
             
-                    $o_pdf->render($vs_content, array('stream'=> true, 'append' => $media_to_append, 'filename' => ($vs_filename = $this->view->getVar('filename')) ? $vs_filename : caGetOption('filename', $va_template_info, 'print_summary.pdf')));
+            		if (!$filename_template = $this->request->config->get($t_subject->tableName().'_summary_file_naming')) {
+            			$filename_template = $this->view->getVar('filename') ? $filename_template : caGetOption('filename', $va_template_info, 'print_summary');
+            		}
+            		if (!($filename = caProcessTemplateForIDs($filename_template, $t_subject->tableName(), [$vn_subject_id]))) {
+            			$filename = 'print_summary';
+            		}
+                    $o_pdf->render($vs_content, ['stream'=> true, 'append' => $media_to_append, 'filename' => "{$filename}.pdf"]);
 
                     $vb_printed_properly = true;
                     break;


### PR DESCRIPTION
PR implements template-based file names for downloaded summary PDFs in the object editor. Previously the download name was a generic name based upon the template used to generate the summary.