### PR TITLE
PROV-2975 Allow identifiers to be used for setSpecs

### DIFF
--- a/app/conf/oai_provider.conf
+++ b/app/conf/oai_provider.conf
@@ -17,6 +17,9 @@ providers = {
 		# Used for ListSets verb
 		setFacet = collection_facet,
 		
+		# When facet is for related table or type, use identifiers rather than record ids
+		useIdentifiersForSets = 0,
+		
 		# Query
 		query = *,
 		

--- a/app/lib/Service/OAIPMHService.php
+++ b/app/lib/Service/OAIPMHService.php
@@ -378,6 +378,65 @@ class OAIPMHService extends BaseService {
 	}
 	# -------------------------------------------------------
 	/**
+	 *
+	 */
+	private function useIdnoForFacet($facet_name, $facet) {
+		$o_browse = caGetBrowseInstance($this->table);
+		if (!is_array($facet_info = $o_browse->getInfoForFacet($facet_name))) { return null; }
+		
+		switch($facet_info['type']) {
+			case 'authority':
+				if (!($t_instance = Datamodel::getInstance($facet_info['table'], true))) {
+					$this->throwError(self::OAI_ERR_NO_SET_HIERARCHY, _t('Invalid set facet'));
+				}
+				if((bool)$this->opa_provider_info['useIdentifiersForSets']) {
+					return $t_instance->getFieldValuesForIDs(array_map(function($v) { return $v['id']; }, $facet), [Datamodel::getTableProperty($this->table, 'ID_NUMBERING_ID_FIELD')]);
+				}
+				break;
+			case 'fieldList':
+				$t_instance = Datamodel::getInstance($this->table, true);
+				if((bool)$this->opa_provider_info['useIdentifiersForSets'] && ($facet_info['field'] === 'type_id')) {
+					return array_map(function($v) { return $v['idno']; }, $t_instance->getTypeList());
+				}
+				break;
+		}
+		
+		return false;
+	}
+	# -------------------------------------------------------
+	/**
+	 *
+	 */
+	private function getIdForIdno($facet_name, $idno) {
+		if(!(bool)$this->opa_provider_info['useIdentifiersForSets']) { return null; }
+		
+		$o_browse = caGetBrowseInstance($this->table);
+		if (!is_array($facet_info = $o_browse->getInfoForFacet($facet_name))) { print "blah"; return null; }
+		
+		switch($facet_info['type']) {
+			case 'authority':
+				$t = $facet_info['table'];
+				if(!Datamodel::tableExists($t)) { 
+					$this->throwError(self::OAI_ERR_NO_RECORDS_MATCH, _t('Invalid set facet'));
+				}
+				if ($id = $t::find([Datamodel::getTableProperty($t, 'ID_NUMBERING_ID_FIELD') => $idno], ['returnAs' => 'firstId'])) {
+					return $id;
+				} else {
+					$this->throwError(self::OAI_ERR_NO_RECORDS_MATCH, _t('Invalid set'));
+					return;
+				}
+				break;
+			case 'fieldList':
+				if($facet_info['field'] === 'type_id') {
+					$t_instance = Datamodel::getInstance($this->table, true);
+					return $t_instance->getTypeIDForCode($idno);
+				}
+				break;
+		}
+		return null;
+	}
+	# -------------------------------------------------------
+	/**
 	 * Responds to ListSets OAI verb
 	 */
 	private function listSets($oaiData) {
@@ -395,13 +454,16 @@ class OAIPMHService extends BaseService {
 			$o_browse->execute(array('no_cache' => $vb_dont_cache, 'showDeleted' => $vb_show_deleted, 'checkAccess' => $vb_dont_enforce_access_settings ? null : $va_access_values));
 			$va_facet = $o_browse->getFacet($vs_facet_name,array('checkAccess' => ($vb_dont_enforce_access_settings ? null : $va_access_values)));
 	
+			
+			$idnos = $this->useIdnoForFacet($vs_facet_name, $va_facet);
+
 			 if (is_array($va_facet)) {
 				$listSets = $oaiData->createElement('ListSets');
 				$oaiData->documentElement->appendChild($listSets);
 				foreach($va_facet as $vn_id => $va_info) {
 						$elements = array(
-								'setSpec' => $va_info['id'],
-								'setName' => caEscapeForXml($va_info['label'])
+							'setSpec' => is_array($idnos) ? $idnos[$va_info['id']] : $va_info['id'],
+							'setName' => caEscapeForXml($va_info['label'])
 						);
 						$this->createElementWithChildren($this->oaiData, $listSets, 'set', $elements);
 				}
@@ -505,6 +567,10 @@ class OAIPMHService extends BaseService {
 			}
 			
 			if ($this->opa_provider_info['setFacet'] && $set) {
+				if (!empty($id = $this->getIdForIdno($this->opa_provider_info['setFacet'], $set))) {
+					$set = $id;
+				}
+				
 				$o_browse->addCriteria($this->opa_provider_info['setFacet'], $set);
 			}
 			$o_browse->execute(array('showDeleted' => $vb_show_deleted, 'no_cache' => $vb_dont_cache, 'limitToModifiedOn' => $vs_range, 'checkAccess' => $vb_dont_enforce_access_settings ? null : $va_access_values, 'dontFilterByACL' => $this->opa_provider_info['dontFilterByACL']));
@@ -567,7 +633,7 @@ class OAIPMHService extends BaseService {
 							'datestamp' => self::unixToUtc($va_deleted_timestamps[$vn_id]['timestamp'] ? $va_deleted_timestamps[$vn_id]['timestamp'] : $va_timestamps[$vn_id]['timestamp'])	
 						);
 					
-						if ($verb == 'ListIdentifiers') {
+						if ($verb == 'ListIdentifiers') {å
 							$header = $this->createElementWithChildren($oaiData, $verbElement, 'header', $headerData);
 							$header->setAttribute("status", "deleted");
 						} else {

--- a/app/lib/Service/OAIPMHService.php
+++ b/app/lib/Service/OAIPMHService.php
@@ -633,7 +633,7 @@ class OAIPMHService extends BaseService {
 							'datestamp' => self::unixToUtc($va_deleted_timestamps[$vn_id]['timestamp'] ? $va_deleted_timestamps[$vn_id]['timestamp'] : $va_timestamps[$vn_id]['timestamp'])	
 						);
 					
-						if ($verb == 'ListIdentifiers') {å
+						if ($verb == 'ListIdentifiers') {
 							$header = $this->createElementWithChildren($oaiData, $verbElement, 'header', $headerData);
 							$header->setAttribute("status", "deleted");
 						} else {


### PR DESCRIPTION
PR adds OAI provider option to use identifiers (Eg. ca_collections.idno) as setSpec values when sets are using relationships or type browse facets. Currently preferred labels and row ids are used. Identifiers are required by some consumers such as EBSCO.