### PR TITLE
PROV-2989 Fix regression that would cause authority lookups to fail to save in editing UI

### DIFF
--- a/app/lib/Attributes/Values/AuthorityAttributeValue.php
+++ b/app/lib/Attributes/Values/AuthorityAttributeValue.php
@@ -250,7 +250,7 @@ abstract class AuthorityAttributeValue extends AttributeValue {
 		$o_view->setVar('settings', $va_settings);
 		$o_view->setVar('element_info', $pa_element_info);
 		$o_view->setVar('class', $vs_class);
-		$o_view->setVar('forSearch', caGetOptions('forSearch', $pa_options, false));
+		$o_view->setVar('forSearch', caGetOption('forSearch', $pa_options, false));
 		
 		$o_view->setVar('allowQuickadd', (strpos($pa_options['request']->getController(), 'Interstitial') === false));
 


### PR DESCRIPTION
PR fixes regression incurred when adding support for authority lookups in advanced search forms. The regression would cause authority lookups to fail in the editor UI.