### PR TITLE
PROV-3035 Extend SimpleService to only return records created or modified after a specific change log log_id

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -6349,7 +6349,7 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 			}
 			
 			if ($t = Datamodel::getInstance($t_attr->get('table_num'), true)) {
-				$va_subject_config = $t->getProperty('LOG_CHANGES_USING_AS_SUBJECT');
+				$va_subject_config = null;
 				$vs_subject_tablename = $t->tableName();
 			}
 		} else {

--- a/app/models/ca_change_log.php
+++ b/app/models/ca_change_log.php
@@ -345,10 +345,28 @@ class ca_change_log extends BaseModel {
 				ORDER BY cl.log_id
 				{$vs_limit_sql}
 			", [$pn_from_datetime]);
+		}  elseif (caGetOption('includeSubjectEntries', $pa_options, false)) {		// pull based upon log_id with subject log entries included
+			if(sizeof($va_only_tables)) {
+				$vs_table_filter_sql = 'AND (cl.logged_table_num IN (' . join(',', $va_only_tables) . ') OR clsub.subject_table_num IN (' . join(',', $va_only_tables) . '))';
+			} elseif(sizeof($va_ignore_tables)) {
+				$vs_table_filter_sql = 'AND (cl.logged_table_num NOT IN (' . join(',', $va_ignore_tables) . ') OR clsub.subject_table_num NOT IN (' . join(',', $va_ignore_tables) . '))';
+			}
+			$qr_results = $o_db->query("
+				SELECT * FROM ca_change_log cl, ca_change_log_snapshots cls, ca_change_log_subjects clsub
+				WHERE cl.log_id = cls.log_id AND cl.log_id>=? AND cl.log_id = clsub.log_id
+				{$vs_table_filter_sql}
+				ORDER BY cl.log_id
+				{$vs_limit_sql}
+			", [$pn_from]);
 		} else {							// pull based upon log_id
+			if(sizeof($va_only_tables)) {
+				$vs_table_filter_sql = 'AND cl.logged_table_num IN (' . join(',', $va_only_tables) . ')';
+			} elseif(sizeof($va_ignore_tables)) {
+				$vs_table_filter_sql = 'AND cl.logged_table_num NOT IN (' . join(',', $va_ignore_tables) . ')';
+			}
 			$qr_results = $o_db->query("
 				SELECT * FROM ca_change_log cl, ca_change_log_snapshots cls
-				WHERE cl.log_id = cls.log_id AND cl.log_id >= ?
+				WHERE cl.log_id = cls.log_id AND cl.log_id>=?
 				{$vs_table_filter_sql}
 				ORDER BY cl.log_id
 				{$vs_limit_sql}


### PR DESCRIPTION
PR extends SimpleService "search" API to take optional log_id and change log mode. When set, the service will only return search matches that have appear in the log with the specified mode(s) after the log_id.

This extension enables creation of simple "changed since the last time" services.