### PR TITLE
PROV-3038 Make blank_label_text configurable on a per-table basis

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -645,9 +645,14 @@ require_preferred_label_for_ca_tour_stops = 0
 # if this option is set to "No label" blank preferred labels will be 
 # automatically set to [No label]
 #
+# The "blank_label_text" directive will set text for all records
+# You can set blank label text for a specific table in the form <table name>_blank_label_text
+# Ex. ca_objects_blank_label_text = BLANK TITLE
+#
 # Omit or leave blank this option to use the default placeholder of "BLANK"
 #
 #blank_label_text = No label
+#ca_objects_blank_label_text  = No label
 
 
 # -----------------------------------

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1053,7 +1053,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 								$vs_label = $vs_idno;
 								$vb_show_idno = false;
 							} else {
-								$vs_label =  '['.caGetBlankLabelText().']';
+								$vs_label =  '['.caGetBlankLabelText($vs_table_name).']';
 							}
 							break;
 					}
@@ -2069,7 +2069,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 
 		if (!($vs_label = $t_set->getLabelForDisplay())) {
 			if (!($vs_label = $t_set->get('set_code'))) {
-				$vs_label = '['.caGetBlankLabelText().']';
+				$vs_label = '['.caGetBlankLabelText('ca_sets').']';
 			}
 		}
 
@@ -4844,16 +4844,26 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 	 * "blank_label_text" option. If the option is not set the default value of
 	 * "[BLANK]" will be returned.
 	 *
+	 * @param mixed $table Table name of number blank label is to be applied to. If set 
+	 *						table-specific text is set with fallback to general "blank_label_text"
+	 *
 	 * @return string
 	 */
-	$g_blank_label_text = null;
-	function caGetBlankLabelText() {
-		global $g_blank_label_text;
-		if ($g_blank_label_text) { return $g_blank_label_text; }
+	function caGetBlankLabelText($table=null) {
+		if (MemoryCache::contains('blank_label_text_'.$table)) { return MemoryCache::fetch('blank_label_text_'.$table); }
 		$config = Configuration::load();
-		if ($label_text = $config->get('blank_label_text')) {
+		
+		$d = [];
+		if (($table) && ($t = Datamodel::getInstance($table, true))) {
+			$d[] = $t->tableName().'_blank_label_text';
+		}
+
+		$d[] = 'blank_label_text';
+		
+		if ($label_text = $config->get($d)) {
 		    if(is_array($label_text)) { $label_text = join(' ', $label_text); }
-			return $g_blank_label_text = _t($label_text);
+		    MemoryCache::save('blank_label_text_'.$table, $l = _t($label_text));
+			return $l;
 		}
 		return $g_blank_label_text = _t('BLANK');
 	}

--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -1134,7 +1134,7 @@
 							        $vs_name = pathinfo($vs_item, PATHINFO_FILENAME);
 							    }
 							    
-								if(!isset($va_val['preferred_labels']) || !strlen($va_val['preferred_labels'])) { $va_val['preferred_labels'] = $vs_name ? $vs_name : '['.caGetBlankLabelText().']'; }
+								if(!isset($va_val['preferred_labels']) || !strlen($va_val['preferred_labels'])) { $va_val['preferred_labels'] = $vs_name ? $vs_name : '['.caGetBlankLabelText('ca_object_representations').']'; }
 					
 								if ($va_val['media']['media'] || $vs_item) {
 									// Search for files in import directory (or subdirectory of import directory specified by mediaPrefix)

--- a/app/lib/ApplicationChangeLog.php
+++ b/app/lib/ApplicationChangeLog.php
@@ -274,7 +274,7 @@ require_once(__CA_LIB_DIR__."/Db.php");
 	private function _getChangeLogFromRawData($pa_data, $pn_table_num, $options=null) {
 		//print "<pre>".print_r($pa_data, true)."</pre>\n";	
 		$va_log_output = array();
-		$vs_blank_placeholder = caGetBlankLabelText();
+		$vs_blank_placeholder = caGetBlankLabelText($pn_table_num);
 		$o_tep = new TimeExpressionParser();
 		
 		if (!$options) { $options = []; }

--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -3980,7 +3980,7 @@
 									if ($va_criteria[$vn_val]) { continue; }		// skip items that are used as browse critera - don't want to browse on something you're already browsing on
 									$vn_child_count = isset($va_list_child_count_cache[$vn_val]) ? $va_list_child_count_cache[$vn_val] : 0;
 									
-									if (!($vs_label = html_entity_decode($va_list_label_cache[$vn_val]))) { $vs_label = '['.caGetBlankLabelText().']'; }
+									if (!($vs_label = html_entity_decode($va_list_label_cache[$vn_val]))) { $vs_label = '['.caGetBlankLabelText('ca_list_items').']'; }
 									if (is_array($va_facet_info['relabel']) && isset($va_facet_info['relabel'][$vs_label])) {
 									    $vs_label = $va_facet_info['relabel'][$vs_label];
 									}
@@ -4049,7 +4049,7 @@
 										
 											$va_facet_list[$vn_ancestor_id] = array(
 												'id' => $vn_ancestor_id,
-												'label' => ($vs_label = $qr_ancestors->get('ca_list_items.preferred_labels.name_plural')) ? $vs_label : '['.caGetBlankLabelText().']',
+												'label' => ($vs_label = $qr_ancestors->get('ca_list_items.preferred_labels.name_plural')) ? $vs_label : '['.caGetBlankLabelText('ca_list_items').']',
 												'parent_id' => $vn_parent_id,
 												'hierarchy_id' => $qr_ancestors->get('list_id'),
 												'child_count' => 1,
@@ -4637,7 +4637,7 @@
                                         if ($vb_check_ancestor_access && !in_array($qr_ancestors->get('access'), $pa_options['checkAccess'])) { continue; }
                                         $va_values[$vn_ancestor_id] = array(
                                             'id' => $vn_ancestor_id,
-                                            'label' => ($vs_label = $qr_ancestors->get('ca_list_items.preferred_labels.name_plural')) ? $vs_label : '['.caGetBlankLabelText().']',
+                                            'label' => ($vs_label = $qr_ancestors->get('ca_list_items.preferred_labels.name_plural')) ? $vs_label : '['.caGetBlankLabelText('ca_list_items').']',
                                             'parent_id' => $qr_ancestors->get('ca_list_items.parent_id'),
                                             'child_count' => 1
                                         );

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -3884,7 +3884,7 @@ if (!$vb_batch) {
 									}
 								} else {
 									$this->editLabel($va_label['label_id'],
-										array($this->getLabelDisplayField() => '['.caGetBlankLabelText().']'),
+										array($this->getLabelDisplayField() => '['.caGetBlankLabelText($table).']'),
 										$vn_label_locale_id,
 										$vn_label_type_id,
 										true, array('queueIndexing' => true)
@@ -3934,7 +3934,7 @@ if (!$vb_batch) {
 									foreach($va_labels_for_this_locale as $vn_id => $va_labels_by_locale) {
 						 				foreach($va_labels_by_locale as $vn_locale_id => $va_labels) {
 						 					foreach($va_labels as $vn_i => $va_label) {
-						 						if(isset($va_label[$this->getLabelDisplayField()]) && ($va_label[$this->getLabelDisplayField()] == '['.caGetBlankLabelText().']')) {
+						 						if(isset($va_label[$this->getLabelDisplayField()]) && ($va_label[$this->getLabelDisplayField()] == '['.caGetBlankLabelText($table).']')) {
 						 							$this->removeLabel($va_label['label_id'], array('queueIndexing' => true));
 						 						}
 						 					}
@@ -4025,7 +4025,7 @@ if (!$vb_batch) {
 									}
 								} else {
 									$this->editLabel($va_label['label_id'],
-										array($this->getLabelDisplayField() => '['.caGetBlankLabelText().']'),
+										array($this->getLabelDisplayField() => '['.caGetBlankLabelText($table).']'),
 										$vn_label_locale_id,
 										$vn_label_type_id,
 										false, array('queueIndexing' => true)
@@ -4198,7 +4198,12 @@ if (!$vb_batch) {
 											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
 											
 											$t_importer = new ca_data_importers();
-											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
+											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, [
+												'logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 
+												'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 
+												'transaction' => $this->getTransaction()],
+												'environment' => ['original_filename' => $vs_original_name, '/original_filename' => $vs_original_name]
+											]); 
 										}
 									}
 									
@@ -4375,7 +4380,12 @@ if (!$vb_batch) {
 											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
 											
 											$t_importer = new ca_data_importers();
-											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, ['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 'transaction' => $this->getTransaction()]]); 
+											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, [
+												'logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 
+												'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 
+												'transaction' => $this->getTransaction()],
+												'environment' => ['original_filename' => $vs_original_name, '/original_filename' => $vs_original_name]
+											]); 
 										}
                                     }
                                 }

--- a/app/lib/Media/MediaViewers/Diva.php
+++ b/app/lib/Media/MediaViewers/Diva.php
@@ -152,7 +152,7 @@
         
                             foreach($va_reps as $va_rep) {
                                 $pa_data['resources'][] = [
-                                    'title' => str_replace("[".caGetBlankLabelText()."]", "", $va_labels[$va_rep['representation_id']]),
+                                    'title' => str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $va_labels[$va_rep['representation_id']]),
                                     'representation_id' => $va_rep['representation_id'],
                                     'preview_url' => $va_rep['urls']['small'],
                                     'url' => $va_rep['urls'][$vs_display_version],

--- a/app/lib/Media/MediaViewers/Mirador.php
+++ b/app/lib/Media/MediaViewers/Mirador.php
@@ -154,7 +154,7 @@
                             foreach($va_reps as $va_rep) {
                                 if (is_array($access_values) && sizeof($access_values) && !in_array($va_rep['access'], $access_values)) { continue; }
                                 $pa_data['resources'][] = [
-                                    'title' => str_replace("[".caGetBlankLabelText()."]", "", $va_labels[$va_rep['representation_id']]),
+                                    'title' => str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $va_labels[$va_rep['representation_id']]),
                                     'representation_id' => $va_rep['representation_id'],
                                     'preview_url' => $va_rep['urls']['small'],
                                     'url' => $va_rep['urls'][$vs_display_version],

--- a/app/lib/Media/MediaViewers/UniversalViewer.php
+++ b/app/lib/Media/MediaViewers/UniversalViewer.php
@@ -103,7 +103,7 @@
 						foreach($va_reps as $va_rep) {
 						    if (is_array($access_values) && sizeof($access_values) && !in_array($va_rep['access'], $access_values)) { continue; }
 							$pa_data['resources'][] = [
-								'title' => str_replace("[".caGetBlankLabelText()."]", "", $va_labels[$va_rep['representation_id']]),
+								'title' => str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $va_labels[$va_rep['representation_id']]),
 								'representation_id' => $va_rep['representation_id'],
 								'preview_url' => $va_rep['urls']['small'],
 								'url' => $va_rep['urls'][$vs_display_version],

--- a/app/lib/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch.php
@@ -958,11 +958,11 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 								//$vs_term = preg_replace("%((?<!\d)[".$this->ops_search_tokenizer_regex."]+|[".$this->ops_search_tokenizer_regex."]+(?!\d))%u", '', $vs_raw_term);
 								$vs_term = join(' ', $this->_tokenize($vs_raw_term, true));
 	
-								if ($vs_access_point && (mb_strtoupper($vs_raw_term) == '['.caGetBlankLabelText().']')) {
+								if ($vs_access_point && (mb_strtoupper($vs_raw_term) == '['.caGetBlankLabelText($pn_subject_tablenum).']')) {
 									$t_ap = Datamodel::getInstanceByTableNum($va_access_point_info['table_num'], true);
 									if (is_a($t_ap, 'BaseLabel')) {	// labels have the literal text "[blank]" indexed to "blank" to indicate blank-ness 
 										$vb_is_blank_search = false;
-										$vs_term = caGetBlankLabelText();
+										$vs_term = caGetBlankLabelText($pn_subject_tablenum);
 									} else {
 										$vb_is_blank_search = true;
 										$vs_table_num = $va_access_point_info['table_num'];

--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -588,7 +588,7 @@
 				}
 			
 				if ($t_rep->getPreferredLabelCount() == 0) {
-					$vs_label = (isset($pa_values['name']) && $pa_values['name']) ? $pa_values['name'] : '['.caGetBlankLabelText().']';
+					$vs_label = (isset($pa_values['name']) && $pa_values['name']) ? $pa_values['name'] : '['.caGetBlankLabelText('ca_object_representations').']';
 			
 					$t_rep->addLabel(array('name' => $vs_label), $pn_locale_id, null, true);
 					if ($t_rep->numErrors()) {

--- a/app/lib/Search/SearchEngine.php
+++ b/app/lib/Search/SearchEngine.php
@@ -140,7 +140,7 @@ class SearchEngine extends SearchBase {
 		}
 		
 		$ps_search = preg_replace('![\|]([A-Za-z0-9_,;]+[:]{1})!', "/$1", $ps_search);	// allow | to be used in lieu of / as the relationship type separator, as "/" is problematic to encode in GET requests
-		$ps_search = preg_replace('/(?!")\['.caGetBlankLabelText().'\](?!")/i', '"['.caGetBlankLabelText().']"', $ps_search); // the special [BLANK] search term, which returns records that have *no* content in a specific fields, has to be quoted in order to protect the square brackets from the parser.
+		$ps_search = preg_replace('/(?!")\['.caGetBlankLabelText($this->ops_tablename).'\](?!")/i', '"['.caGetBlankLabelText($this->ops_tablename).']"', $ps_search); // the special [BLANK] search term, which returns records that have *no* content in a specific fields, has to be quoted in order to protect the square brackets from the parser.
 		$ps_search = preg_replace('/(?!")\['._t('SET').'\](?!")/i', '"['._t('SET').']"', $ps_search); // the special [SET] search term, which returns records that have *any* content in a specific fields, has to be quoted in order to protect the square brackets from the parser.
 		
 		if(!is_array($pa_options)) { $pa_options = array(); }

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -3274,7 +3274,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 													&&
 													(sizeof(array_filter($t_subject->getSecondaryLabelDisplayFields(), function($v) use ($va_element_content) { return isset($va_element_content[$v]) && strlen($va_element_content[$v]); })) == 0)
 												) { 
-													$va_element_content[$vs_disp_field] = '['.caGetBlankLabelText().']'; 
+													$va_element_content[$vs_disp_field] = '['.caGetBlankLabelText($vn_table_num).']'; 
 												}
 												
 												if ($vb_skip_if_data_present && ($t_subject->getLabelCount(true, $vn_locale_id) > 0)) { continue(2); }
@@ -3517,7 +3517,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						            $vs_rel_label_display_fld = $t_rel->getLabelDisplayField();
 						        }
 						
-						        $vs_name = '['.caGetBlankLabelText().']';
+						        $vs_name = '['.caGetBlankLabelText($vs_table_name).']';
 						        if(isset($va_element_data['preferred_labels'][$vs_rel_label_display_fld]) ) { $vs_name = $va_element_data['preferred_labels'][$vs_rel_label_display_fld]; }
 						        elseif(isset($va_element_data['preferred_labels']) ) { $vs_name = $va_element_data['preferred_labels']; }
 						        elseif(isset($va_element_data[$vs_rel_label_display_fld][$vs_rel_label_display_fld]) ) { $vs_name = $va_element_data[$vs_rel_label_display_fld][$vs_rel_label_display_fld]; }

--- a/app/models/ca_item_comments.php
+++ b/app/models/ca_item_comments.php
@@ -621,7 +621,7 @@ class ca_item_comments extends BaseModel {
             $label = _t('Item has been deleted'); 
         }
         if(!$label) {
-            $label = '['.caGetBlankLabelText().']';
+            $label = '['.caGetBlankLabelText('ca_item_comments').']';
         }
         
         $res = ['table_num' => $table_num, 'id' => $row_id, 'label' => $label, 'idno' => $idno, 'notes' => $notes];

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -908,7 +908,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 			return false;
 		}
 		
-		if (!$ps_title) { $ps_title = '['.caGetBlankLabelText().']'; }
+		if (!$ps_title) { $ps_title = '['.caGetBlankLabelText('ca_object_representations').']'; }
 		$t_annotation->addLabel(array('name' => $ps_title), $pn_locale_id, null, true);
 		if ($t_annotation->numErrors()) {
 			$this->errors = $t_annotation->errors;

--- a/app/models/ca_sets.php
+++ b/app/models/ca_sets.php
@@ -1218,7 +1218,7 @@ class ca_sets extends BundlableLabelableBaseModelWithAttributes implements IBund
 			if(!$g_ui_locale_id) { $g_ui_locale_id = 1; }
 
 			$t_item->addLabel(array(
-				'caption' => '['.caGetBlankLabelText().']',
+				'caption' => '['.caGetBlankLabelText('ca_set_items').']',
 			), $g_ui_locale_id);
 			
 			if ($t_item->numErrors()) {

--- a/themes/default/views/mediaViewers/DivaManifest.php
+++ b/themes/default/views/mediaViewers/DivaManifest.php
@@ -39,7 +39,7 @@
 	
 	$vs_display_version = caGetOption('display_version', $va_display, 'tilepic');
 	
-	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText()."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText()."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
+	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText($t_subject->tableName())."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
 	
 	$va_metadata = [
     	["label" => "Title", "value" => $vs_title]

--- a/themes/default/views/mediaViewers/MiradorManifest.php
+++ b/themes/default/views/mediaViewers/MiradorManifest.php
@@ -39,7 +39,7 @@
 	
 	$vs_display_version = caGetOption('display_version', $va_display, 'tilepic');
 	
-	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText()."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText()."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
+	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText($t_subject->tableName())."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
 	
 	$va_metadata = [
     	["label" => "Title", "value" => $vs_title]

--- a/themes/default/views/mediaViewers/UniversalViewerManifest.php
+++ b/themes/default/views/mediaViewers/UniversalViewerManifest.php
@@ -39,7 +39,7 @@
 	
 	$vs_display_version = caGetOption('display_version', $va_display, 'tilepic');
 	
-	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText()."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText()."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
+	$vs_title = ($t_instance && ($vs_rep_title = str_replace("[".caGetBlankLabelText('ca_object_representations')."]", "", $t_instance->get('preferred_labels')))) ? $vs_rep_title : (($vs_subject_title = str_replace("[".caGetBlankLabelText($t_subject->tableName())."]", "", $t_subject->get('preferred_labels'))) ? $vs_subject_title : "???");
 	
 	$va_metadata = [
     	["label" => "Title", "value" => $vs_title]


### PR DESCRIPTION
PR extends existing blank label text feature to be settable on a per-table basis.

The app.conf "blank_label_text" directive sets default test to use for preferred labels when no text is set.

Currently this single setting is used for all types of records.Additional configuration directives should be added allowing configuration on a per-table basis with fallback to the universal setting. Format of table-specific directives should be <table>_blank_label_text. For example, "ca_objects_blank_label_text"