### PR TITLE
PROV-3027 Add configuration option for setting default in list reconfigured with omit_access_statuses

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1140,7 +1140,12 @@ ca_objects_access_inheritance_default = 1
 #
 #omit_access_statuses = {
 #	ca_objects = {
-#		__default__ = [restricted_public_access]
+#		# Set omit list + new list default
+#		__default__ = {
+#			omit = [restricted_public_access],
+#			default = not_publish
+#		},
+#		# Just set omit list
 #		a_type_code = [1,2]
 #	}
 #}

--- a/app/helpers/listHelpers.php
+++ b/app/helpers/listHelpers.php
@@ -284,20 +284,36 @@ require_once(__CA_MODELS_DIR__.'/ca_list_items.php');
 	 *
 	 * @return string|null
 	 */
-	$g_list_item_ids_for_values = [];
 	function caGetListItemIDForValue($ps_list_code, $ps_value, $pa_options=null) {
-		global $g_list_item_ids_for_values;
+		return array_shift(array_keys(caGetListItemForValue($ps_list_code, $ps_value, $pa_options)));
+	}
+	# ---------------------------------------
+	/**
+	 * Get list item info for value. Can be useful when handling access/status values
+	 * @param string $ps_list_code Code of the list
+	 * @param string $ps_value item_value of the list item in question
+	 * @param array $pa_options Options for ca_lists::getItemFromListByItemValue() plus:
+	 *		transaction = transaction to execute queries within. [Default=null]
+	 *      noCache = Don't use cache. [Default is false]
+	 *      dontCache = Synonym for noCache
+	 *      checkAccess = Array of access values to filter returned values on. If omitted no filtering is performed. [Default is null]
+	 *
+	 * @return array|null
+	 */
+	$g_list_items_for_values = [];
+	function caGetListItemForValue($ps_list_code, $ps_value, $pa_options=null) {
+		global $g_list_items_for_values;
 		$vs_cache_key = caMakeCacheKeyFromOptions($pa_options, "{$ps_list_code}/{$ps_value}");
 		
 		if(!caGetOption(['noCache', 'dontCache'], $pa_options, false)) {
-		    if(isset($g_list_item_ids_for_values[$vs_cache_key])) { return $g_list_item_ids_for_values[$vs_cache_key]; }
+		    if(isset($g_list_items_for_values[$vs_cache_key])) { return $g_list_items_for_values[$vs_cache_key]; }
         }
         
 		$t_list = new ca_lists();
 		if ($o_trans = caGetOption('transaction', $pa_options, null)) { $t_list->setTransaction($o_trans); }
 		
 		if ($va_item = $t_list->getItemFromListByItemValue($ps_list_code, $ps_value, $pa_options)) {
-			return $g_list_item_ids_for_values[$vs_cache_key] = array_shift(array_keys($va_item));
+			return $g_list_items_for_values[$vs_cache_key] = $va_item;
 		}
 		return null;
 	}

--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1662,6 +1662,13 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 				}
 				
 				if (is_array($omit_map)) {
+					$v = array_shift(caExtractValuesByUserLocale(caGetListItemForValue('access_statuses', $pa_options['value'])));
+					$value_idno = $v['idno'];
+					$default_value = caGetOption('default', $omit_map, null);
+					if(is_array($omit_map['omit'])) { $omit_map = $omit_map['omit']; }
+					if (!in_array($value_idno, $omit_map, true)) {
+						$pa_options['value']= caGetListItemValueForIdno('access_statuses', $default_value);
+					}
 					foreach($omit_map as $i => $value) {
 						if(!strlen(trim($value))) { continue; }
 						if (!is_numeric($value)) { 


### PR DESCRIPTION
PR extends configuration format for app.conf omit_access_statuses directive to allow for additional options, and adds new configuration option to set default value in reconfigured list. This default overrides any set for the overall list, and is useful when the overall list default has bee omitted.