### PR TITLE
PROV-3043 Add per-rule config options

### DIFF
--- a/app/plugins/prepopulate/conf/prepopulate.conf
+++ b/app/plugins/prepopulate/conf/prepopulate.conf
@@ -19,6 +19,11 @@ prepopulate_rules = {
 		# can be overwrite, or addIfEmpty
 		# See the 'target' setting below and http://docs.collectiveaccess.org/wiki/Prepopulate
 		mode = addIfEmpty,
+		
+		# Set which events this run runs on here. Values can be "edit" and/or "save".
+		# This will override prepopulate_fields_on_save and prepopulate_fields_on_edit.
+		# Omit this to use prepopulate_fields_on_edit and prepopulate_fields_on_edit values.
+		useFor = [edit, save],
 
 		# What's the prepopulate target?
 		# This can be an intrinsic field, labels or an attribute.

--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -57,15 +57,15 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 	}
 	# --------------------------------------------------------------------------------------------
 	public function hookSaveItem(&$pa_params) {
-		if($this->opo_plugin_config->get('prepopulate_fields_on_save')) {
-			$this->prepopulateFields($pa_params['instance']);
+		if($this->opo_plugin_config->get('enabled')) {
+			$this->prepopulateFields($pa_params['instance'], ['hook' => 'save']);
 		}
 		return true;
 	}
 	# --------------------------------------------------------------------------------------------
 	public function hookEditItem(&$pa_params) {
-		if($this->opo_plugin_config->get('prepopulate_fields_on_edit')) {
-			$this->prepopulateFields($pa_params['instance']);
+		if ($this->opo_plugin_config->get('enabled')) {
+			$this->prepopulateFields($pa_params['instance'], ['hook' => 'edit']);
 		}
 		return true;
 	}
@@ -104,6 +104,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 	 * @param BundlableLabelableBaseModelWithAttributes $t_instance The table instance to prepopulate
 	 * @param array $pa_options Options array. Available options are:
 	 * 		prepopulateConfig = override path to prepopulate.conf, e.g. for testing purposes
+	 *		hook = indicates what triggered application: "save" or "edit"
 	 * @return bool success or not
 	 */
 	public function prepopulateFields(&$t_instance, $pa_options=null) {
@@ -111,10 +112,11 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		if($vs_prepopulate_cfg = caGetOption('prepopulateConfig', $pa_options, null)) {
 			$this->opo_plugin_config = Configuration::load($vs_prepopulate_cfg);
 		}
+		
+		$hook = caGetOption('hook', $pa_options, null);
 
-		if(!(bool)$this->opo_plugin_config->get('prepopulate_fields_on_save') && !(bool)$this->opo_plugin_config->get('prepopulate_fields_on_load')) {
-			return false;
-		}
+		$default_prepop_on_save  = (bool)$this->opo_plugin_config->get('prepopulate_fields_on_save');
+		$default_prepop_on_edit  = (bool)$this->opo_plugin_config->get('prepopulate_fields_on_edit');
 
 		$va_rules = $this->opo_plugin_config->get('prepopulate_rules');
 		if(!$va_rules || (!is_array($va_rules)) || (sizeof($va_rules)<1)) { return false; }
@@ -136,6 +138,16 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		$va_expression_vars = array(); // we only process those if and when we need them
 		foreach($va_rules as $vs_rule_key => $va_rule) {
 			if($t_instance->tableName() != $va_rule['table']) { continue; }
+			$useFor = caGetOption('useFor', $va_rule, null);
+			if ($useFor && !is_array($useFor)) { $useFor = [$useFor]; }
+			$useFor = is_array($useFor) ? array_map(function($v) { return strtolower($v); }, $useFor) : null;
+			
+			if (is_array($useFor) && !in_array($hook, $useFor, true)) { 
+				continue; 
+			} elseif(!$useFor) {
+				if (($hook === 'edit') && !$default_prepop_on_edit) { continue; }
+				if (($hook === 'save') && !$default_prepop_on_save) { continue; }
+			}
 
 			$vs_mode = strtolower(caGetOption('mode', $va_rule, 'merge'));
 			
@@ -335,9 +347,8 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 							}
 						}
 					} else {
-						if(sizeof($va_attributes)>1) {
-							Debug::msg("[prepopulateFields()] partial containers with multiple values are not supported");
-							continue;
+						if((sizeof($va_attributes)>1) && ($vs_mode !== 'addifempty')) {
+							$t_instance->removeAttributes($va_parts[1]);
 						}
 						switch($vs_mode) {
 							case 'overwrite': // always replace first value we find


### PR DESCRIPTION
PR adds per-rule configuration options to override existing global trigger options. This allows different rules to run on different triggers (Eg edit or save). Previously all rules share the same trigger configuration using the global prepopulate_fields_on_edit or prepopulate_fields_on_save options in prepopulate.conf.