### PR TITLE
Do not translate empty text

### DIFF
--- a/app/models/ca_editor_ui_screens.php
+++ b/app/models/ca_editor_ui_screens.php
@@ -1200,7 +1200,7 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 							'default' => 'NEW_UI',
 							'multiple' => false,
 							'label' => _t('User interface style'),
-							'description' => _t('')
+							'description' => ''
 						];
 						
 						$va_additional_settings['showBundlesForEditing'] = [


### PR DESCRIPTION
gettext
app/models/ca_editor_ui_screens.php:1203: warning: Empty msgid.  It is reserved by GNU gettext: gettext("") returns the header entry with                                                         meta information, not the empty string.