### PR TITLE
NOJIRA Fixes for locales and attribute settings in the installer / configuration exporter.

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -3937,7 +3937,7 @@ function caFileIsIncludable($ps_file) {
 		$vs_display_value = trim(preg_replace('![^\p{L}0-9 ]+!u', ' ', $ps_text));
 
 		// Move articles to end of string
-		$va_articles = caGetArticlesForLocale($ps_locale);
+		$va_articles = caGetArticlesForLocale($ps_locale) ?: [];
 
 		foreach($va_articles as $vs_article) {
 			if (preg_match('!^('.$vs_article.')[ ]+!i', $vs_display_value, $va_matches)) {

--- a/app/lib/ConfigurationExporter.php
+++ b/app/lib/ConfigurationExporter.php
@@ -455,6 +455,10 @@ final class ConfigurationExporter {
 							// we export all settings (not just non-default) when we're running diff exports ..
 							// otherwise we only care about non default ones
 							if($this->opn_modified_after || ($vs_value != $va_available_settings[$vs_setting]["default"])) {
+								if ($vs_setting === 'restrictToTypes'){
+									$t_item = new ca_list_items($vs_value);
+									$vs_value = $t_item->get('idno');
+								}
 								$vo_setting = $this->opo_dom->createElement("setting", caEscapeForXML($vs_value));
 								$vo_setting->setAttribute("name", $vs_setting);
 								$vo_settings->appendChild($vo_setting);
@@ -1015,7 +1019,7 @@ final class ConfigurationExporter {
 					}
 
 					if (is_array($va_types) && (sizeof($va_types) > 0)) {
-						$vo_screen->setAttribute("typeRestrictions", join(",", $va_types));
+						$vo_screen->setAttribute("typeRestrictions", join(",", array_unique($va_types)));
 						$vo_screen->setAttribute("includeSubtypes", $vb_include_subtypes ? 1 : 0);
 					}
 				}
@@ -1036,7 +1040,7 @@ final class ConfigurationExporter {
 							if($va_type_restrictions && !is_array($va_type_restrictions)) { $va_type_restrictions = [$va_type_restrictions]; }
 							
 							if (is_array($va_type_restrictions) && (sizeof($va_type_restrictions) > 0)) {
-								$vo_placement->setAttribute("typeRestrictions", join(",", caMakeTypeList($vs_type, $va_type_restrictions)));
+								$vo_placement->setAttribute("typeRestrictions", join(",", array_unique(caMakeTypeList($vs_type, $va_type_restrictions))));
 							}
 						}
 						if (isset($va_placement['settings']['bundleTypeRestrictionsIncludeSubtypes']) && (bool)$va_placement['settings']['bundleTypeRestrictionsIncludeSubtypes']) {


### PR DESCRIPTION
* Detect default cataloguing locale when running the installer.
* Support restrictToTypes settings for authority attributes in the Installer / profile export
  * Previously these were being exported as the ids of the list items.
* Locale codes in the installer are now generated based on the dialect as well if it's set.
* Don't throw warnings if locale settings don't exist for a particular locale but you want to still use it for cataloguing.