### PR TITLE
NOJIRA Clean up tmp files generated for previews of single page images

### DIFF
--- a/app/lib/Media.php
+++ b/app/lib/Media.php
@@ -714,8 +714,8 @@ class Media extends BaseObject {
 	 */
 	public function __destruct() {
 		// Clean up tmp files
-		if(is_array($tmp_files)) {
-			foreach($tmp_files as $f) {
+		if(is_array($this->tmp_files)) {
+			foreach($this->tmp_files as $f) {
 				@unlink($f);
 			}
 		}

--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -978,27 +978,34 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		}
 
 		$output_file_prefix = tempnam($tmp_dir, 'caMultipagePreview');
-
+		@unlink($output_file_prefix);
+		
 		$files = [];
 		$i = 1;
 		
 		$this->handle->setimageindex(0);
+		$num_previews = 0;
 		do {
 			if ($i > 1) { $this->handle->nextImage(); }
-			
-			$this->handle->writeImage($output_file_prefix.sprintf("_%05d", $i).".jpg");
-			$files[$i] = $output_file_prefix.sprintf("_%05d", $i).'.jpg';
-			
-			$i++;
+			$num_previews++;
 		} while($this->handle->hasnextimage());
 		
 		$this->handle->setimageindex(0);
 		
-		@unlink($output_file_prefix);
-		
-		if(sizeof($files) === 1) { return false; }
-		return $files;
-
+		if ($num_previews > 1) {
+			$i = 0;
+			do {
+				if ($i > 1) { $this->handle->nextImage(); }
+			
+				$this->handle->writeImage($output_file_prefix.sprintf("_%05d", $i).".jpg");
+				$files[$i] = $output_file_prefix.sprintf("_%05d", $i).'.jpg';
+			
+				$i++;
+			} while($this->handle->hasnextimage());
+			$this->handle->setimageindex(0);
+			return $files;
+		}
+		return false;
 	}
 	# ------------------------------------------------
 	public function joinArchiveContents($pa_files, $pa_options = array()) {


### PR DESCRIPTION
PR bypasses unnecessary creation of extra previews for non-multipage images and avoids cleanup issues with generated tmp files.