### PR TITLE
NOJIRA Resolve broken month date expressions

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -756,7 +756,7 @@ class TimeExpressionParser {
 		
 		
 		// Convert ISO ranges
-		if (preg_match("!^([\d\-:TZ]+)/([\d\-:TZ]+)$!", trim($ps_expression), $matches)) {
+		if (preg_match("!^([\d\-:TZ]{3,20})/([\d\-:TZ]{3,20})$!", trim($ps_expression), $matches)) {
 			$conjunction = array_shift($this->opo_language_settings->getList("rangeConjunctions"));
 			$ps_expression = $matches[1]." {$conjunction} ".$matches[2];
 		}

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -7730,3 +7730,14 @@ div.mediaMetadataActionButton a, div.mediaMetadataActionButton span a {
 p.abbreviatedPath, div.abbreviatedPath, span.abbreviatedPath {
 	cursor: help;
 }
+
+.bundleLabelError code, .notification-error-box code {
+    font-family: monospace, serif;
+    font-size: 1em;
+    padding: 2px;
+    margin: 1px;
+    border: 1px solid #ddd;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+    white-space: nowrap;
+}


### PR DESCRIPTION
PR addresses recent regression that would cause dates in month-year delimited format to not parse in some cases.