### PR TITLE
NOJIRA Add support for returning list of attribute value_ids 

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -2446,7 +2446,7 @@ class SearchResult extends BaseObject {
 			}
 		}
 		
-		if (!$pa_options['returnAllLocales']) { $va_return_values = caExtractValuesByUserLocale($va_return_values); } 	
+		if (!$pa_options['returnAllLocales'] && !$vb_return_value_id) { $va_return_values = caExtractValuesByUserLocale($va_return_values); } 	
 		if ($pa_options['returnWithStructure']) { 
 			return is_array($va_return_values) ? $va_return_values : []; 
 		}


### PR DESCRIPTION
PR fixes issue when using SearchResult::get() with a .value_id expression (Eg. "ca_objects.my_attribute.value_id") to return the internal value_id value. Currently only value_id for the first found value is returned, even when returnAsArray is set. This change allows a full list of value_ids to be returned.