### PR TITLE
PROV-3053 Option to configure currency used for "$"

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3593,7 +3593,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 			if (!($vs_user_currency = $po_request->user ? $po_request->user->getPreference('currency') : 'USD')) {
 				$vs_user_currency = 'USD';
 			}
-			$vs_user_currency = caGetCurrencySymbol($vs_user_currency);
+			$vs_user_currency = caGetCurrencySymbol($vs_user_currency, $va_tmp[1]);
 
 			// Parse out tags and optional sub-elements from template
 			//		we have to pull each sub-element separately

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -2693,15 +2693,22 @@ function caFileIsIncludable($ps_file) {
 	 * Get symbol for currency if available. "USD" will return "$", for example, while
 	 * "CAD" will return "CAD"
 	 *
-	 * @param $ps_value string Currency specifier (Ex. USD, EUR, CAD)
+	 * @param $value string Currency specifier (Ex. USD, EUR, CAD)
+	 * @param $element_code_or_id Metadata element code or element_id. If provided currency symbol settings from the element will be used. If omitted only global (app.conf) settingd will be used. [Default is null]
 	 *
 	 * @return string Symbol (Ex. $, £, ¥) or currency specifier if no symbol is available
 	 */
-	function caGetCurrencySymbol($ps_value) {
+	function caGetCurrencySymbol($value, $element_code_or_id=null) {
 		$o_config = Configuration::load();
-		$vs_dollars_are_this = strtolower($o_config->get('default_dollar_currency'));
-		switch(strtolower($ps_value)) {
-			case $vs_dollars_are_this:
+		
+		$dollars_are_this = null;
+		if($element_code_or_id && ($t_element = ca_metadata_elements::getInstance($element_code_or_id))) {
+			$dollars_are_this = strtolower($t_element->getSetting('dollarCurrency'));
+		}
+		if (!$dollars_are_this) { $dollars_are_this = strtolower($o_config->get('default_dollar_currency')); }
+		
+		switch(strtolower($value)) {
+			case $dollars_are_this:
 				return '$';
 			case 'eur':
 				return '€';
@@ -2710,7 +2717,7 @@ function caFileIsIncludable($ps_file) {
 			case 'jpy':
 				return '¥';
 		}
-		return $ps_value;
+		return $value;
 	}
 	# ----------------------------------------
 	/**

--- a/app/lib/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/Attributes/Values/CurrencyAttributeValue.php
@@ -42,9 +42,6 @@
 
  	global $_ca_attribute_settings;
  	
- 	$o_config = Configuration::load();
- 	$default_dollar_currency = $o_config->get('default_dollar_currency');
- 	
  	$_ca_attribute_settings['CurrencyAttributeValue'] = array(		// global
 		'minValue' => array(
 			'formatType' => FT_NUMBER,
@@ -81,8 +78,9 @@
 		'dollarCurrency' => array(
 			'formatType' => FT_TEXT,
 			'displayType' => DT_SELECT,
-			'default' => $default_dollar_currency,
+			'default' => '',
 			'options' => [
+				_t('System default') => '',
 				_t('US Dollar (USD)') => 'USD',
 				_t('Canadian Dollar (CDN)') => 'CDN',
 				_t('Australian Dollar (AUD)') => 'AUD'


### PR DESCRIPTION
PR adds per-metadata element option controlling which currency is referred to by the "$" symbol.