### PR TITLE
PROV-3054 Convert checklist layout to CSS grid to avoid max-columns render errors in Chrome

### DIFF
--- a/app/models/ca_lists.php
+++ b/app/models/ca_lists.php
@@ -1744,7 +1744,10 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 				break;
 			case 'checklist':
 				if (!sizeof($va_options)) { return ''; }	// return empty string if list has no values
-				$vs_buf = ($max_columns > 1) ? "<div style=\"column-count: {$max_columns};\">\n" : "<div>\n";
+				
+				$p = floor(100/$max_columns);
+				$vs_buf = ($max_columns > 1) ? "<div class='checklist' style='grid-template-columns: ".str_repeat(" {$p}%", $max_columns).";'>\n" : "<div>\n";
+			
 				foreach($va_options as $vm_value => $vs_label) {
 					$va_attributes = array('value' => $vm_value);
 					if (isset($va_disabled_options[$vm_value]) && $va_disabled_options[$vm_value]) {
@@ -1757,8 +1760,7 @@ class ca_lists extends BundlableLabelableBaseModelWithAttributes {
 						$va_attributes['checked'] = '1';
 					}
 					
-					$vs_buf .= caHTMLCheckboxInput($ps_name.'_'.$vm_value, $va_attributes, $pa_options)." {$vs_label}<br/>\n";
-					
+					$vs_buf .= "<div class='checklistItem'>".caHTMLCheckboxInput($ps_name.'_'.$vm_value, $va_attributes, $pa_options)." ".str_replace('&nbsp;', '', $vs_label)."</div>\n";				
 				}
 				$vs_buf .= "</div>";
 				return $vs_buf;

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -7576,8 +7576,14 @@ div.changeLogSearchResultsPagination {
 }
 
 div.checklist {
+    display: grid;
+}
+
+div.checklistItem {
     font-weight: normal;
-    line-height: 2em;
+    margin-right: 10px;
+    width: 100px;
+    
 }
 
 /* Statistics dashboard */


### PR DESCRIPTION
PR addresses layout issue in editor when using "list" elements with checklist render mode. Current layout uses CSS max-columns. When used in Chrome and the number of checklist items is less than the maximum number of rows, the layout is incorrectly broken onto two lines.

This PR modifies checklists to use a CSS grid layout, which does not suffer from these problems.