### PR TITLE
NOJIRA Adjust priv requirements for statistics

### DIFF
--- a/app/conf/access_restrictions.conf
+++ b/app/conf/access_restrictions.conf
@@ -1447,7 +1447,7 @@ access_restrictions = {
 	},
     /AuthController = {
     	default = {
-    		actions = { can_use_json_browse_service }
+    		actions = { can_use_json_find_service, can_use_json_item_service, can_use_json_browse_service, can_use_json_model_service, can_use_xml_config_updater, can_use_json_simple_service, can_use_json_replication_service, can_view_system_statistics }
     	}
     },
     /SimpleController = {
@@ -1460,10 +1460,9 @@ access_restrictions = {
 			actions = { can_use_json_replication_service }
 		}
 	},
-	
     /StatisticsController = {
 		default = {
-			actions = { can_use_json_simple_service }
+			actions = { can_view_system_statistics }
 		}
 	},
 

--- a/app/conf/search_query_builder.conf
+++ b/app/conf/search_query_builder.conf
@@ -1,0 +1,128 @@
+#
+# Search Query Builder configuration
+#
+
+# Whether or not to display the query builder button, and include the relevant JavaScript on the search form page.
+query_builder_enabled = 1
+
+# Global config for the query builder.  See http://querybuilder.js.org/#usage for available settings.
+query_builder_global_options = {}
+
+# Operators to provide per filter input type.  Note that `contains`, `not_contains`, `ends_with`, `not_ends_with` are
+# omitted from `string`, only because they are not supported by the search engine.  The query builder and the query
+# translator both correctly handle these operators.
+query_builder_operators = {
+	select = [ equal, not_equal, is_empty, is_not_empty ],
+	string = [ equal, not_equal, begins_with, not_begins_with, is_empty, is_not_empty ],
+	integer = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
+	double = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
+	date = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
+	time = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
+	datetime = [ equal, not_equal, between, not_between, is_empty, is_not_empty ]
+}
+
+# Whether or not to display the query builder per table.  Both this and `query_builder_enabled` must be `1` to display
+# the query builder for a given table.
+query_builder_enabled_ca_objects = 1
+query_builder_enabled_ca_object_lots = 1
+query_builder_enabled_ca_entities = 1
+query_builder_enabled_ca_places = 1
+query_builder_enabled_ca_collections = 1
+query_builder_enabled_ca_occurrences = 1
+query_builder_enabled_ca_storage_locations = 1
+query_builder_enabled_ca_loans = 1
+
+# Per-table list of filter names to move to the top of the query builder's list, in the order given.  Filters can come
+# from intrinsic fields, attributes or search access points.
+query_builder_priority_ca_objects = [
+	ca_objects.idno,
+	ca_object_labels.name,
+	ca_objects.type_id,
+	ca_objects.status,
+	_fulltext
+]
+
+query_builder_priority_ca_object_lots = [
+	ca_object_lots.idno_stub,
+	ca_object_lots.type_id,
+	ca_object_lot_labels.name,
+	ca_object_lots.status,
+	_fulltext
+]
+
+query_builder_priority_ca_entities = [
+	ca_entities.idno,
+	ca_entities.type_id,
+	ca_entity_labels.displayname,
+	ca_entity_labels.forename,
+	ca_entity_labels.other_forenames,
+	ca_entity_labels.middlename,
+	ca_entity_labels.surname,
+	ca_entity_labels.prefix,
+	ca_entity_labels.suffix,
+	ca_entities.status,
+	_fulltext
+]
+
+query_builder_priority_ca_places = [
+	ca_places.idno,
+	ca_place_labels.name,
+	ca_places.type_id,
+	ca_places.status,
+	_fulltext
+]
+
+query_builder_priority_ca_collections = [
+	ca_collections.idno,
+	ca_collection_labels.name,
+	ca_collections.type_id,
+	ca_collections.status,
+	_fulltext
+]
+
+query_builder_priority_ca_occurrences = [
+	ca_object_lots.idno,
+	ca_occurrence_labels.name,
+	ca_object_lots.type_id,
+	ca_object_lots.status,
+	_fulltext
+]
+
+query_builder_priority_ca_storage_locations = [
+	ca_storage_locations.idno,
+	ca_storage_location_labels.name,
+	ca_storage_locations.type_id,
+	ca_storage_locations.status,
+	_fulltext
+]
+
+query_builder_priority_ca_loans = [
+	ca_loans.idno,
+	ca_loan_labels.name,
+	ca_loans.type_id,
+	ca_loans.status,
+	_fulltext
+]
+
+# Per-table list of filter names to exclude from the query builder.  Filters can come from intrinsic fields, attributes
+# or search access points.
+query_builder_exclude_ca_objects = []
+query_builder_exclude_ca_object_lots = []
+query_builder_exclude_ca_entities = []
+query_builder_exclude_ca_places = []
+query_builder_exclude_ca_collections = []
+query_builder_exclude_ca_occurrences = []
+query_builder_exclude_ca_storage_locations = []
+query_builder_exclude_ca_loans = []
+
+query_builder_icons = {
+	add_group = fa fa-plus-circle,
+	add_rule = fa fa-plus-circle,
+	remove_group = fa fa-times-circle,
+	remove_rule = fa fa-times-circle,
+	error = fa fa-exclamation-triangle
+}
+
+query_builder_plugins = {
+	#sortable = { icon = fa fa-arrows}
+}

--- a/app/conf/user_actions.conf
+++ b/app/conf/user_actions.conf
@@ -169,6 +169,10 @@ user_actions = {
 				label = _("Use advanced search forms"),
 				description = _("Allow user to use advanced search forms")
 			},
+			can_use_searchbuilder = {
+				label = _("Use search builder "),
+				description = _("Allow user to use search builder interface")
+			},
 			can_create_ca_bundle_displays = {
 				label = _("Create displays"),
 				description = _("Allow user to create their custom data display formats")


### PR DESCRIPTION
PR adjusts privileged required for two service API calls:

• Statistics service now requires can_view_system_statistics; previously required can_use_json_simple_service.
• Auth service is now available if user has any service priv. Previously auth was only possible if user had can_use_json_browse_service priv.