### PR TITLE
Vagrant configuration for Ubuntu Focal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /app/tmp/*
 app/conf/local/*
 setup.php
-/media/*
+/media*
 !/media/.htaccess
 !/media/README.md
 .DS_Store
@@ -14,7 +14,7 @@ build
 *.sublime-*
 *.swp
 *.po~
-.vagrant/
+.vagrant*
 /import/*
 /vendor/*
 /app/lib/core/Parsers/dompdf/lib/fonts/*fm.php

--- a/Vagrantfile.focal
+++ b/Vagrantfile.focal
@@ -1,0 +1,121 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/focal64"
+
+  # Uncomment this line to skip box update check
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  
+  # Providence server port
+  config.vm.network "forwarded_port", guest: 80, host: 9090
+  
+  # Pawtucket2 server port
+  config.vm.network "forwarded_port", guest: 88, host: 9999
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  #
+  config.vm.provider "virtualbox" do |v|
+    v.memory = "2048"
+    v.cpus = 2
+    v.name = "ca-focal64"
+  end
+
+  config.vm.synced_folder "./", "/vagrant",
+    id: "vagrant-root",
+    owner: "www-data",
+    group: "www-data",
+    mount_options: ["dmode=775,fmode=664"]
+
+  # Mount pawtucket2 in case it exists
+  pawtucket2_source="../pawtucket2"
+  if File.directory?(File.expand_path(pawtucket2_source))
+    config.vm.synced_folder pawtucket2_source, "/pawtucket2",
+		id: "pawtucket2-root",
+		owner: "www-data",
+		group: "www-data",
+		mount_options: ["dmode=775,fmode=664"]
+  end
+
+
+  # provision via shell script
+  #
+  config.vm.provision "shell", inline: <<-SHELL
+    # Fix for https://bugs.launchpad.net/ubuntu/+source/livecd-rootfs/+bug/1561250
+    if ! grep -q "ubuntu-focal" /etc/hosts; then
+        echo "127.0.0.1 ubuntu-focal" >> /etc/hosts
+    fi
+    setup_php="/vagrant/setup.php"
+    # Install dependencies
+    sudo apt-get install -y software-properties-common
+    sudo LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+    apt-get update
+    # uncomment the line below if you want to upgrade every time you provision
+    # (which can take a while if there was a kernel update since you pulled the box)
+    # apt-get -q -y -o Dpkg::Options::=--force-confold upgrade
+    if [[ -e /var/lock/vagrant-provision ]]; then
+        exit;
+    fi
+    echo "mysql-server mysql-server/root_password password root" | sudo debconf-set-selections
+    echo "mysql-server mysql-server/root_password_again password root" | sudo debconf-set-selections
+    apt-get -y install mysql-client mysql-server
+    apt-get -q -y -o Dpkg::Options::=--force-confold install curl apache2
+    apt-get -q -y -o Dpkg::Options::=--force-confold install php7.4 libapache2-mod-php7.4 php7.4-curl php7.4-mysql
+    apt-get -q -y -o Dpkg::Options::=--force-confold install php7.4-xml php7.4-zip php7.4-gd 
+    apt-get -q -y -o Dpkg::Options::=--force-confold install php7.4-redis php7.4-json php7.4-imap
+    apt-get -q -y -o Dpkg::Options::=--force-confold install php7.4-xdebug
+    apt-get -q -y -o Dpkg::Options::=--force-confold install htop screen vim apachetop vnstat git
+    apt-get -q -y -o Dpkg::Options::=--force-confold install ffmpeg graphicsmagick python3-pdfminer
+    apt-get -q -y -o Dpkg::Options::=--force-confold install ghostscript dcraw poppler-utils mediainfo exiftool phantomjs
+    systemctl stop apt-daily.service
+
+    # slooooow setup with gmagick and libreoffice. if you want a shiny media processing setup, uncomment the following lines
+    #
+    # apt-get -q -y -o Dpkg::Options::=--force-confold install libreoffice abiword
+    # apt-get -q -y -o Dpkg::Options::=--force-confold install php5-dev php-pear libgraphicsmagick1-dev
+    # pecl install gmagick-1.1.7RC3
+    # cat << EOF > /etc/php5/mods-available/gmagick.ini
+      # extension=gmagick.so
+      # EOF
+    #
+    # ln -s /etc/php5/mods-available/gmagick.ini /etc/php5/apache2/conf.d/20-gmagick.ini
+
+    # Create database
+    echo "Creating database..."
+    echo "CREATE DATABASE IF NOT EXISTS collectiveaccess" | mysql -u root --password=root
+    sed -i "s/memory\_limit\ \=\ 128M/memory\_limit\ \=\ 512M/g" /etc/php/7.4/apache2/php.ini
+    sed -i "s/post\_max\_size\ \=\ 8M/post\_max\_size\ \=\ 64M/g" /etc/php/7.4/apache2/php.ini
+    sed -i "s/upload\_max\_filesize \=\ 2M/upload\_max\_filesize\ \=\ 64M/g" /etc/php/7.4/apache2/php.ini
+    if ! [ -L /var/www/html ]; then
+      rm -rf /var/www/html
+      ln -fs /vagrant /var/www/html
+    fi
+
+    echo "Configuring CollectiveAccess..."
+    if [[ ! -f /vagrant/setup.php ]]; then
+      cp /vagrant/setup.php-dist /vagrant/setup.php
+      sed -i "s/my_database_user/root/g" ${setup_php}
+      sed -i "s/my_database_password/root/g" ${setup_php}
+      sed -i "s/name_of_my_database/collectiveaccess/g" ${setup_php}
+      sed -i "s/INSTALLS\_\_\'\, false/INSTALLS\_\_\'\, true/g" ${setup_php}
+    fi
+    if ! [ -f /vagrant/app/conf/local/external_applications.conf ]; then
+      cp /vagrant/app/conf/external_applications.conf /vagrant/app/conf/local/external_applications.conf
+    sed -i "s/pdf2txt\.py/pdf2txt/g" /vagrant/app/conf/local/external_applications.conf
+    sed -i "s/\/usr\/local\/bin\/phantomjs/\/usr\/bin\/phantomjs/g" /vagrant/app/conf/local/external_applications.conf
+    fi
+    service apache2 restart
+    service mysql restart
+    touch /var/lock/vagrant-provision
+
+    # Configure xdebug
+    cp /vagrant/support/scripts/xdebug.ini /etc/php/7.4/apache2/conf.d/20-xdebug.ini
+
+  SHELL
+end

--- a/support/scripts/xdebug.ini
+++ b/support/scripts/xdebug.ini
@@ -1,0 +1,11 @@
+zend_extension=xdebug.so
+[xdebug]
+xdebug.remote_port=9000
+xdebug.remote_enable=1
+xdebug.remote_mode=req
+xdebug.remote_connect_back=true
+xdebug.remote_autostart=on
+xdebug.remote_host=10.0.2.2
+; xdebug.remote_host=
+xdebug.remote_connect_back=0
+xdebug.idekey=PHPSTORM


### PR DESCRIPTION
Add a new vagrant configuration for Ubuntu Focal, including updates
to external applications, upgrade php to 7.4 and support for xdebug.

It will listen on URL http://localhost:9090 for `providence` and on http://localhost:9999 for `pawtucket2` in case it is also on the local development environment.

It also increases the VCPU and memory, previous setup with 1 CPU and 1024 was too short.