### PR TITLE
PROV-3058 Support for medialess object representations

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,7 +11,7 @@ Allow from all
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|tiff|obj|bmp|mp4|pdf|svg|vtt|srt)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico)$">
         Allow from all
 </FilesMatch>
 

--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1891,6 +1891,10 @@ allow_fetching_of_media_from_remote_urls = 0
 #
 dont_use_exiftool_to_strip_exif_orientation_tags = 0
 
+# Allow creation of object representation records without associated media. This may be useful in odd cases where one wishes to create placeholder representation records prior to ingest of media
+#
+allow_representations_without_media = 0
+
 # If you wish to allow the linking to existing object representations in the manner other relationships
 # set the relevant directives below to 1. Using representations as records that can be targets of
 # relationships can be confusing and, well, odd for many common setups. Still, when you need this behavior

--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -1283,7 +1283,7 @@
 							'is_primary' => (int)$va_rep['is_primary'],
 							'is_primary_display' => ($va_rep['is_primary'] == 1) ? _t('PRIMARY') : '', 
 							'locale_id' => $va_rep['locale_id'], 
-							'icon' => $va_rep['tags']['thumbnail'], 
+							'icon' => isset($va_rep['tags']['thumbnail']) ? $va_rep['tags']['thumbnail'] : null, 
 							'mimetype' => $va_rep['info']['original']['PROPERTIES']['mimetype'], 
 							'annotation_type' => isset($va_annotation_type_mappings[$va_rep['info']['original']['PROPERTIES']['mimetype']]) ? $va_annotation_type_mappings[$va_rep['info']['original']['PROPERTIES']['mimetype']] : null,
 							'type' => $va_rep['info']['original']['PROPERTIES']['typename'], 

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -479,7 +479,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	# ------------------------------------------------------
 	public function insert($pa_options=null) {
 		// reject if media is empty
-		if ($this->mediaIsEmpty()) {
+		if ($this->mediaIsEmpty() && !(bool)$this->getAppConfig()->get('allow_representations_without_media')) {
 			$this->postError(2710, _t('No media was specified'), 'ca_object_representations->insert()');
 			return false;
 		}

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -7632,6 +7632,7 @@ a.currentSet {
 /* "New" ca_object_representations_bundle */
 .mediaUploadContainer {
 	width:700px;
+	margin-top: 14px;
 }
 
 .mediaUploadInfoArea {
@@ -7661,7 +7662,6 @@ a.currentSet {
 	display: block;
 	width: 120px;
 	height: 120px;
-	margin-top: 14px;
 }
 
 .mediaUploadAreaMessage {

--- a/themes/default/views/bundles/ca_object_representations.php
+++ b/themes/default/views/bundles/ca_object_representations.php
@@ -28,6 +28,8 @@
 	AssetLoadManager::register('fileupload');
 	AssetLoadManager::register('sortableUI');
 	
+	$upload_max_filesize = caFormatFileSize(caReturnValueInBytes(ini_get( 'upload_max_filesize' )));
+	
 	$settings 			= $this->getVar('settings');
 	
 	$is_batch			= $this->getVar('batch');
@@ -256,6 +258,13 @@
 <?php } ?>	
 			<div class="mediaUploadContainer">
 				<div style="float: left;">
+<?php					
+			if($this->request->getAppConfig()->get('allow_representations_without_media')) {
+?>
+				<div class="formLabelPlain"><?= caHTMLCheckBoxInput("{$id_prefix}_no_media_{n}", ['value' => 1, 'id' => $id_prefix.'NoMedia{n}'])._t('No media'); ?></div>
+<?php
+			}
+?>
 					<div id="<?= $id_prefix; ?>UploadArea{n}" class="mediaUploadArea">
 						<input type="file" style="display: none;" id="<?= $id_prefix; ?>UploadFileControl{n}" multiple/>
 						<div id="<?= $id_prefix; ?>UploadAreaMessage{n}" class="mediaUploadAreaMessage"> </div>
@@ -306,13 +315,6 @@
 			</div>
 			<input type="hidden" id="<?= $id_prefix; ?>MediaRefs{n}" name="<?= $id_prefix; ?>_mediarefs{n}"/>
 			<br class="clear"/>
-			<?php
-			$post_max_size = caFormatFileSize(caReturnValueInBytes(ini_get( 'post_max_size' )));
-			$upload_max_filesize = caFormatFileSize(caReturnValueInBytes(ini_get( 'upload_max_filesize' )));
-
-			$vs_element = _t("Maximum upload size is ${upload_max_filesize}");
-			print $vs_element;
-			?>
 		</div>
 		
 		<script type="text/javascript">
@@ -328,6 +330,14 @@
 					uploadAreaMessage: <?= json_encode(caNavIcon(__CA_NAV_ICON_ADD__, '30px').'<br/>'._t("Add media")); ?>,
 					uploadAreaIndicator: <?= json_encode(caNavIcon(__CA_NAV_ICON_SPINNER__, '30px').'<br/>'._t("Uploading... %percent")); ?>,
 				});	
+				
+				jQuery('#<?= $id_prefix; ?>NoMedia{n}').on('click', function(e) {
+					if(jQuery(this).attr('checked')) {
+						jQuery('#<?= $id_prefix; ?>UploadArea{n}').slideUp(250);
+					} else {
+						jQuery('#<?= $id_prefix; ?>UploadArea{n}').slideDown(250);
+					}
+				});
 			});
 		</script>
 	</textarea>


### PR DESCRIPTION
PR adds option to allow creation of object representation records without associated media. This may be useful in odd cases where one wishes to create placeholder representation records prior to media ingest.