### PR TITLE
PROV-3060 Adjust display behavior of before and after date ranges

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -634,6 +634,12 @@ class TimeExpressionParser {
 			# -------------------------------------------------------
 			case TEP_STATE_AFTER_GET_DATE:
 				if ($va_date = $this->_parseDateExpression()) {
+					if(!$va_date['month']) { $va_date['month'] = 1; }
+					if (!$va_date['day']) { $va_date['day'] = 1; }
+					$va_date['hours'] = 0;
+					$va_date['minutes'] = 0;
+					$va_date['seconds'] = 0;
+					
 					$va_dates['start'] = $va_date;
 					$va_dates['end'] = array(
 						'month' => null, 'day' => null, 
@@ -2838,6 +2844,7 @@ class TimeExpressionParser {
 							'uncertainty_units' => $va_end_pieces['uncertainty_units']
 						), $pa_options);
 					} else {
+						if ($va_end_pieces['day'] == $this->daysInMonth($va_end_pieces['month'], $va_end_pieces['year'])) { unset($va_end_pieces['day']); }
 						return $vs_before_qualifier.' '. $this->_dateToText($va_end_pieces, $pa_options);
 					}
 				} else {
@@ -2856,6 +2863,7 @@ class TimeExpressionParser {
 							'uncertainty_units' => $va_start_pieces['uncertainty_units']
 						), $pa_options);
 					} else {
+						if ($va_start_pieces['day'] == 1) { unset($va_start_pieces['day']); }
 						$vs_date = $this->_dateToText($va_start_pieces, $pa_options);
 					}
 				} else {

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -1687,7 +1687,7 @@ class TimeExpressionParserTest extends TestCase {
 		$this->assertEquals($va_historic['end'], '2001.032723595900');
 	}
 	
-	// https://collectiveaccess.org/support/index.php?p=/discussion/300669/date-format-1947-06-1947-june-31st#latest
+	// https://collectiveaccess.org/support/index.php?p=/discussion/300669/date-format-1947-06-1947-june-31st
 	function testMonthToYearRange() {
 		$o_tep = new TimeExpressionParser();
 		$o_tep->setLanguage("en_US");
@@ -1696,5 +1696,78 @@ class TimeExpressionParserTest extends TestCase {
 		
 		$this->assertEquals($va_historic['start'], '1947.060100000000');
 		$this->assertEquals($va_historic['end'], '1947.123123595900');
+	}
+	
+	// https://collectiveaccess.org/support/index.php?p=/discussion/300668/date-format-after-xxxx-mm-with-unknown-day-is-replaced-by-mm-1st
+	function testAfterDatesToMonth() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("AFTER 1970-03"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '1970.030100000000');
+		$this->assertEquals($va_historic['end'], '2000000000.123123595900');
+		
+		$this->assertEquals($o_tep->getText(), 'after March 1970');
+	}
+	
+	function testAfterDatesToYear() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("AFTER 1970"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '1970.010100000000');
+		$this->assertEquals($va_historic['end'], '2000000000.123123595900');
+		
+		$this->assertEquals($o_tep->getText(), 'after 1970');
+	}
+	
+	function testAfterDatesToDay() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("AFTER 1970-03-10"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '1970.031000000000');
+		$this->assertEquals($va_historic['end'], '2000000000.123123595900');
+		
+		$this->assertEquals($o_tep->getText(), 'after March 10 1970');
+	}
+	
+	function testBeforeDatesToMonth() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("BEFORE 1970-03"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '-2000000000.000000000000');
+		$this->assertEquals($va_historic['end'], '1970.033123595900');
+		
+		$this->assertEquals($o_tep->getText(), 'before March 1970');
+	}
+	
+	function testBeforeDatesToYear() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("BEFORE 1970"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '-2000000000.000000000000');
+		$this->assertEquals($va_historic['end'], '1970.123123595900');
+		
+		$this->assertEquals($o_tep->getText(), 'before 1970');
+	}
+	
+	function testBeforeDatesToDay() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		$this->assertEquals($o_tep->parse("BEFORE 1970-03-10"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		
+		$this->assertEquals($va_historic['start'], '-2000000000.000000000000');
+		$this->assertEquals($va_historic['end'], '1970.031023595900');
+		
+		$this->assertEquals($o_tep->getText(), 'before March 10 1970');
 	}
 }


### PR DESCRIPTION
PR modified display of "before <date>" and "after <date>" expressions such that month-specific expressions (Ex. 1970-03) are displayed with only year and month. Previously the implicit day value would be displayed.