### PR TITLE
PR-751 Improper handling of escaped backslashes in config files

### DIFF
--- a/tests/lib/ConfigurationTest.php
+++ b/tests/lib/ConfigurationTest.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2018 Whirl-i-Gig
+ * Copyright 2009-2020 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -39,13 +39,13 @@ class ConfigurationTest extends TestCase {
 	public function testScalars() {
 		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/data/test.conf', false, true);
 
-		$this->assertEquals($o_config->get('a_scalar'), 'Hi there');
-		$this->assertEquals($o_config->get('a_translated_scalar'), 'Hej da!');
-		$this->assertEquals($o_config->get('a_scalar_starting_with_a_bracket'), '[The bracket is part of the string]');
-		$this->assertEquals($o_config->get('a_scalar_using_a_macro'), '/usr/local/fish');
-		$this->assertEquals($o_config->get('a_scalar_using_an_embedded_macro'), 'This scalar is embedded: "/usr/local/fish"');
-		$this->assertEquals($o_config->get('a_scalar_with_utf_8_chars'), 'Expreß zug: חי תהער');
-		$this->assertEquals($o_config->get('a_scalar_with_line_breaks'), "Foo\nHello\nWorld\n");
+		$this->assertEquals('Hi there', $o_config->get('a_scalar'));
+		$this->assertEquals('Hej da!', $o_config->get('a_translated_scalar'));
+		$this->assertEquals('[The bracket is part of the string]', $o_config->get('a_scalar_starting_with_a_bracket') );
+		$this->assertEquals('/usr/local/fish', $o_config->get('a_scalar_using_a_macro'));
+		$this->assertEquals('This scalar is embedded: "/usr/local/fish"', $o_config->get('a_scalar_using_an_embedded_macro'));
+		$this->assertEquals('Expreß zug: חי תהער', $o_config->get('a_scalar_with_utf_8_chars'));
+		$this->assertEquals( "Foo\nHello\nWorld\n", $o_config->get('a_scalar_with_line_breaks'));
 	}
 
 	public function testLists() {
@@ -53,67 +53,67 @@ class ConfigurationTest extends TestCase {
 
 		$va_array = $o_config->getList('a_list');
 		$this->assertEquals(sizeof($va_array), 4);
-		$this->assertEquals($va_array[0], 'clouds');
-		$this->assertEquals($va_array[1], 'rain');
-		$this->assertEquals($va_array[2], 'sun');
-		$this->assertEquals($va_array[3], 'gewitter');
+		$this->assertEquals('clouds', $va_array[0]);
+		$this->assertEquals('rain', $va_array[1]);
+		$this->assertEquals('sun', $va_array[2]);
+		$this->assertEquals('gewitter', $va_array[3]);
 
 		$va_array = $o_config->getList('a_list_with_quoted_scalars');
-		$this->assertEquals(sizeof($va_array), 2);
-		$this->assertEquals($va_array[0], 'cloudy days');
-		$this->assertEquals($va_array[1], 'rainy days, happy nights');
+		$this->assertEquals(2, sizeof($va_array));
+		$this->assertEquals('cloudy days', $va_array[0]);
+		$this->assertEquals('rainy days, happy nights', $va_array[1]);
 
 		$va_array = $o_config->getList('a_list_with_translated_scalars');
 		$this->assertEquals(sizeof($va_array), 3);
-		$this->assertEquals($va_array[0], 'red');
-		$this->assertEquals($va_array[1], 'blue');
-		$this->assertEquals($va_array[2], 'green');
+		$this->assertEquals('red', $va_array[0]);
+		$this->assertEquals('blue', $va_array[1] );
+		$this->assertEquals('green', $va_array[2] );
 
 		$va_array = $o_config->getList('a_list_with_a_macro');
 		$this->assertEquals(sizeof($va_array), 2);
-		$this->assertEquals($va_array[0], '/usr/local/fish');
-		$this->assertEquals($va_array[1], 'and so it goes');
+		$this->assertEquals('/usr/local/fish', $va_array[0]);
+		$this->assertEquals('and so it goes', $va_array[1]);
 
 
 		$va_array = $o_config->getList('macro_list');
 		$this->assertEquals(sizeof($va_array), 3, 'Size of list defined in global.conf is not 3');
-		$this->assertEquals($va_array[0], 'flounder');
-		$this->assertEquals($va_array[1], 'lobster');
-		$this->assertEquals($va_array[2], 'haddock');
+		$this->assertEquals('flounder', $va_array[0]);
+		$this->assertEquals('lobster', $va_array[1]);
+		$this->assertEquals('haddock', $va_array[2]);
 
 		$va_array = $o_config->getList('a_list_with_embedded_brackets');
-		$this->assertEquals($va_array[0], 'Hello [there]');
+		$this->assertEquals('Hello [there]', $va_array[0]);
 	}
 
 	public function testAssocLists() {
 		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/data/test.conf');
 
 		$va_assoc = $o_config->getAssoc('an_associative_list');
-		$this->assertEquals(sizeof(array_keys($va_assoc)), 1);
-		$this->assertEquals(sizeof(array_keys($va_assoc['key 1'])), 5);
-		$this->assertEquals($va_assoc['key 1']['subkey1'], 1);
-		$this->assertEquals($va_assoc['key 1']['subkey2'], 2);
+		$this->assertEquals(1, sizeof(array_keys($va_assoc)));
+		$this->assertEquals(5, sizeof(array_keys($va_assoc['key 1'])));
+		$this->assertEquals(1, $va_assoc['key 1']['subkey1']);
+		$this->assertEquals(2, $va_assoc['key 1']['subkey2']);
 		$this->assertTrue(is_array($va_assoc['key 1']['subkey3']));
-		$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey1'], 'at the bottom of the hole');
-		$this->assertEquals($va_assoc['key 1']['subkey3']['subsubkey2'], 'this is a quoted string');
+		$this->assertEquals('at the bottom of the hole', $va_assoc['key 1']['subkey3']['subsubkey1']);
+		$this->assertEquals('this is a quoted string', $va_assoc['key 1']['subkey3']['subsubkey2']);
 		$this->assertTrue(is_array($va_assoc['key 1']['subkey4']));
-		$this->assertEquals($va_assoc['key 1']['subkey4'][0], 'Providence');
-		$this->assertEquals($va_assoc['key 1']['subkey4'][1], 'Pawtucket');
-		$this->assertEquals($va_assoc['key 1']['subkey4'][2], 'Woonsocket');
-		$this->assertEquals($va_assoc['key 1']['subkey4'][3], 'Narragansett');
-		$this->assertEquals($va_assoc['key 1']['subkey5'], '/usr/local/fish');
+		$this->assertEquals('Providence', $va_assoc['key 1']['subkey4'][0]);
+		$this->assertEquals('Pawtucket', $va_assoc['key 1']['subkey4'][1]);
+		$this->assertEquals('Woonsocket', $va_assoc['key 1']['subkey4'][2]);
+		$this->assertEquals('Narragansett', $va_assoc['key 1']['subkey4'][3]);
+		$this->assertEquals('/usr/local/fish', $va_assoc['key 1']['subkey5']);
 
 		$va_assoc = $o_config->getAssoc('macro_assoc');
-		$this->assertEquals(sizeof(array_keys($va_assoc)), 3);
-		$this->assertEquals(sizeof(array_keys($va_assoc['fish'])), 3);
-		$this->assertEquals(sizeof(array_keys($va_assoc['shellfish'])), 3);
-		$this->assertEquals(sizeof(array_keys($va_assoc['other'])), 3);
-		$this->assertEquals($va_assoc['fish'][0], 'flounder');
-		$this->assertEquals($va_assoc['shellfish'][0], 'scallop');
-		$this->assertEquals($va_assoc['other'][0], 'chicken');
+		$this->assertEquals(3,sizeof(array_keys($va_assoc)));
+		$this->assertEquals(3,sizeof(array_keys($va_assoc['fish'])));
+		$this->assertEquals(3,sizeof(array_keys($va_assoc['shellfish'])));
+		$this->assertEquals(3,sizeof(array_keys($va_assoc['other'])));
+		$this->assertEquals('flounder', $va_assoc['fish'][0]);
+		$this->assertEquals('scallop', $va_assoc['shellfish'][0]);
+		$this->assertEquals('chicken', $va_assoc['other'][0]);
 
 		$va_assoc = $o_config->getAssoc('an_assoc_list_with_embedded_brackets');
-		$this->assertEquals($va_assoc['test'], 'Hello {there}');
+		$this->assertEquals('Hello {there}', $va_assoc['test']);
 	}
 
 	public function testBoolean() {
@@ -136,14 +136,23 @@ class ConfigurationTest extends TestCase {
 
 		$va_keys = $o_config->getScalarKeys();
 		$this->assertTrue(is_array($va_keys));
-		$this->assertEquals(sizeof($va_keys), 14);		// 12 in config file + 1 "LOCALE" value that's automatically inserted
+		$this->assertEquals(14, sizeof($va_keys));		// 13 in config file + 1 "LOCALE" value that's automatically inserted
 		$va_keys = $o_config->getListKeys();
 		$this->assertTrue(is_array($va_keys));
-		$this->assertEquals(sizeof($va_keys), 6);
+		$this->assertEquals(6, sizeof($va_keys));
 		$va_keys = $o_config->getAssocKeys();
 		$this->assertTrue(is_array($va_keys));
-		$this->assertEquals(sizeof($va_keys), 3);
+		$this->assertEquals(4, sizeof($va_keys));
 
 	}
+
+
+	public function testGreps(){
+		$o_config = new Configuration(__CA_BASE_DIR__.'/tests/lib/data/test.conf');
+		$va_regexes = $o_config->get("idno_regexes");
+		$this->assertTrue(is_array($va_regexes));
+		$this->assertArrayHasKey("ca_objects", $va_regexes);
+		$this->assertEquals('[\d]{4}\.[\d]{1,5}\.[\d]{0,5}', $va_regexes["ca_objects"][0]);
+	}
 }
-?>
+

--- a/tests/lib/data/test.conf
+++ b/tests/lib/data/test.conf
@@ -38,3 +38,9 @@ an_assoc_list_with_embedded_brackets = {
 }
 
 a_list_with_embedded_brackets = ["Hello [there]"]
+
+idno_regexes = {
+ 	ca_objects = [
+ 		"[\\d]{4}\\.[\\d]{1,5}\\.[\\d]{0,5}"
+ 	]
+}


### PR DESCRIPTION
PR addresses issue where escaped backslashes in lists were not honored and updates Configuration caching process for nominally improved performance