### PR TITLE
PROV-3056 PNGs with a transparent background render jpg preview with black background

### DIFF
--- a/app/conf/media_processing.conf
+++ b/app/conf/media_processing.conf
@@ -1302,79 +1302,79 @@ ca_object_representations = {
 			SCALE = {
 				width = 72, height = 72, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_iconlarge_image = {
 			SCALE = {
 				width = 250, height = 250, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_tiny_image = {
 			SCALE = {
 				width = 72, height = 72, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_thumbnail_image = {
 			SCALE = {
 				width = 120, height = 120, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_widethumbnail_image = {
 			SCALE = {
 				width = 110, height = 75, mode = fill_box, crop_from = center, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},		
 		rule_preview170_image = {
 			SCALE = {
 				width = 170, height = 170, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_widepreview_image = {
 			SCALE = {
 				width = 200, height = 120, mode = fill_box, crop_from = center, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_preview_image = {
 			SCALE = {
 				width = 180, height = 180, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_small_image = {
 			SCALE = {
 				width = 240, height = 240, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_medium_image = {
 			SCALE = {
 				width = 400, height = 400, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_mediumlarge_image = {
 			SCALE = {
 				width = 580, height = 450, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_image = {
 			SCALE = {
 				width = 700, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_page_image = {
 			SCALE = {
 				width = 1000, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_to_ctm = {
 			SET = {format = application/ctm}
@@ -1396,73 +1396,73 @@ ca_object_representations = {
 			SCALE = {
 				width = 72, height = 72, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_iconlarge_dpx_image = {
 			SCALE = {
 				width = 250, height = 250, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_tiny_dpx_image = {
 			SCALE = {
 				width = 72, height = 72, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_thumbnail_dpx_image = {
 			SCALE = {
 				width = 120, height = 120, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_widethumbnail_dpx_image = {
 			SCALE = {
 				width = 110, height = 75, mode = fill_box, crop_from = center, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},		
 		rule_preview170_dpx_image = {
 			SCALE = {
 				width = 170, height = 170, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_widepreview_dpx_image = {
 			SCALE = {
 				width = 200, height = 120, mode = fill_box, crop_from = center, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_preview_dpx_image = {
 			SCALE = {
 				width = 180, height = 180, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_small_dpx_image = {
 			SCALE = {
 				width = 240, height = 240, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_medium_dpx_image = {
 			SCALE = {
 				width = 400, height = 400, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_mediumlarge_dpx_image = {
 			SCALE = {
 				width = 580, height = 450, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_large_dpx_image = {
 			SCALE = {
 				width = 700, height = 600, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_tilepic_dpx_image = {
 			SET = {quality = 40, tile_mimetype = image/jpeg, format = image/tilepic, gamma = 1.7, reference-black = 6080, reference-white = 43840}
@@ -1863,25 +1863,25 @@ ca_object_representation_multifiles = {
 			SCALE = {
 				width = 180, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_preview_image = {
 			SCALE = {
 				width = 700, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_page_preview_image = {
 			SCALE = {
 				width = 1000, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_page_preview_image = {
 			SCALE = {
 				width = 2000, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_original_image = {},
 		rule_tilepic_image = {
@@ -1894,17 +1894,17 @@ ca_object_representation_multifiles = {
 			SCALE = {
 				width = 180, height = 180, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_tilepic_dpx_image = {
-			SET = {quality = 40, tile_mimetype = image/jpeg, format = image/tilepic, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 40, tile_mimetype = image/jpeg, format = image/tilepic, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		# ---------------------------------------------------------
 		rule_large_preview_dpx_image = {
 			SCALE = {
 				width = 250, height = 250, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		# ---------------------------------------------------------
 		rule_video = {}
@@ -2243,25 +2243,25 @@ ca_attribute_value_multifiles = {
 			SCALE = {
 				width = 180, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_preview_image = {
 			SCALE = {
 				width = 700, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_page_preview_image = {
 			SCALE = {
 				width = 1000, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_page_preview_image = {
 			SCALE = {
 				width = 2000, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_original_image = {},
 		rule_tilepic_image = {
@@ -2274,14 +2274,14 @@ ca_attribute_value_multifiles = {
 			SCALE = {
 				width = 180, height = 180, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		# ---------------------------------------------------------
 		rule_large_preview_dpx_image = {
 			SCALE = {
 				width = 250, height = 250, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840}
+			SET = {quality = 75, format = image/jpeg, gamma = 1.7, reference-black = 6080, reference-white = 43840, background = "#ffffff" }
 		},
 		rule_tilepic_dpx_image = {
 			SET = {quality = 40, tile_mimetype = image/jpeg, format = image/tilepic, gamma = 1.7, reference-black = 6080, reference-white = 43840}
@@ -2333,14 +2333,14 @@ ca_icons = {
 			SCALE = {
 				width = 48, height = 48, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		# ---------------------------------------------------------
 		rule_largeicon_image = {
 			SCALE = {
 				width = 72, height = 72, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		# ---------------------------------------------------------
 		rule_original_image = {}
@@ -2436,25 +2436,25 @@ floorplans = {
 			SCALE = {
 				width = 180, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_preview_image = {
 			SCALE = {
 				width = 700, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_page_preview_image = {
 			SCALE = {
 				width = 1000, mode = width, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_page_preview_image = {
 			SCALE = {
 				width = 2000, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_original_image = {},
 		rule_tilepic_image = {
@@ -2522,25 +2522,25 @@ ca_item_comments_media = {
 			SCALE = {
 				width = 72, height = 72, mode = fill_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_tiny_image = {
 			SCALE = {
 				width = 72, height = 72, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_thumbnail_image = {
 			SCALE = {
 				width = 120, height = 120, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_large_preview_image = {
 			SCALE = {
 				width = 250, height = 250, mode = bounding_box, antialiasing = 0.5
 			},
-			SET = {quality = 75, format = image/jpeg}
+			SET = {quality = 75, format = image/jpeg, background = "#ffffff" }
 		},
 		rule_original_image = {},
 		# ---------------------------------------------------------

--- a/app/lib/Plugins/Media/GraphicsMagick.php
+++ b/app/lib/Plugins/Media/GraphicsMagick.php
@@ -130,6 +130,7 @@ class WLPlugMediaGraphicsMagick Extends BaseMediaPlugin Implements IWLPlugMedia 
 			'layers'			=> 'W',
 			"quality" 			=> 'W',
 			'colorspace'		=> 'W',
+			'background'		=> 'W',
 			'tile_width'		=> 'W',
 			'tile_height'		=> 'W',
 			'antialiasing'		=> 'W',
@@ -1184,6 +1185,9 @@ class WLPlugMediaGraphicsMagick Extends BaseMediaPlugin Implements IWLPlugMedia 
 						break;
 				}
 			}
+			if($background = caGetOption('background', $this->properties, null)) {
+				$pa_handle['ops'][] = ['op' => 'background', 'color' => $background];
+			}
 			
 			$va_ops = array();	
 			foreach($pa_handle['ops'] as $va_op) {
@@ -1247,6 +1251,9 @@ class WLPlugMediaGraphicsMagick Extends BaseMediaPlugin Implements IWLPlugMedia 
 						if (isset($va_op['amount'])) { $vs_tmp .= '+'.$va_op['amount'];}
 						if (isset($va_op['threshold'])) { $vs_tmp .= '+'.$va_op['threshold'];}
 						$va_ops['convert'][] = $vs_tmp;
+						break;
+					case 'background':
+						$va_ops['convert'][] = '-background "'.$va_op['color'].'"  -extent 0x0';
 						break;
 				}
 			}

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -211,6 +211,7 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			'layers'			=> 'W',
 			"quality" 			=> 'W',
 			'colorspace'		=> 'W',
+			'background'		=> 'W',
 			'tile_width'		=> 'W',
 			'tile_height'		=> 'W',
 			'antialiasing'		=> 'W',
@@ -1295,6 +1296,9 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 						break;
 				}
 			}
+			if($background = caGetOption('background', $this->properties, null)) {
+				$pa_handle['ops'][] = ['op' => 'background', 'color' => $background];
+			}
 			
 			$va_ops = array();	
 			foreach($pa_handle['ops'] as $va_op) {
@@ -1356,6 +1360,9 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 						if (isset($va_op['amount'])) { $vs_tmp .= '+'.$va_op['amount'];}
 						if (isset($va_op['threshold'])) { $vs_tmp .= '+'.$va_op['threshold'];}
 						$va_ops['convert'][] = $vs_tmp;
+						break;
+					case 'background':
+						$va_ops['convert'][] = '-background "'.$va_op['color'].'"  -extent 0x0';
 						break;
 				}
 			}

--- a/app/lib/Plugins/Media/Imagick.php
+++ b/app/lib/Plugins/Media/Imagick.php
@@ -131,6 +131,7 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			'layers'			=> 'W',
 			"quality" 			=> 'W',
 			'colorspace'		=> 'W',
+			'background'		=> 'W',
 			'tile_width'		=> 'W',
 			'tile_height'		=> 'W',
 			'antialiasing'		=> 'W',
@@ -511,17 +512,17 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 								$vb_is_rotated = false;
 								switch($vn_orientation) {
 									case 3:
-										$this->handle->rotateImage("#FFFFFF", 180);
+										$this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), 180);
 										unset($va_exif['IFD0']['Orientation']);
 										$vb_is_rotated = true;
 										break;
 									case 6:
-										$this->handle->rotateImage("#FFFFFF", 90);
+										$this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), 90);
 										unset($va_exif['IFD0']['Orientation']);
 										$vb_is_rotated = true;
 										break;
 									case 8:
-										$this->handle->rotateImage("#FFFFFF", -90);
+										$this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), -90);
 										unset($va_exif['IFD0']['Orientation']);
 										$vb_is_rotated = true;
 										break;
@@ -821,7 +822,7 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			case "ROTATE":
 				$angle = $parameters["angle"];
 				if (($angle > -360) && ($angle < 360)) {
-					if ( !$this->handle->rotateImage("#FFFFFF", $angle ) ) {
+					if ( !$this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), $angle ) ) {
 						$this->postError(1610, _t("Error during image rotate"), "WLPlugImagick->transform()");
 						return false;
 					}
@@ -960,8 +961,9 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 				$this->handle->setCompressionQuality($this->properties["quality"]);
 			}
 			
-			$this->handle->setImageBackgroundColor(new ImagickPixel("#CC0000"));
-			$this->handle->setImageMatteColor(new ImagickPixel("#CC0000"));
+			$background = caGetOption('background', $this->properties, "#FFFFFF");
+			$this->handle->setImageBackgroundColor(new ImagickPixel($background));
+			$this->handle->setImageMatteColor(new ImagickPixel($background));
 		
 			if ($this->properties['gamma']) {
 				if (!$this->properties['reference-black']) { $this->properties['reference-black'] = 0; }


### PR DESCRIPTION
PR implements new "background" media processing property allowing specification of background color for transparent PNG and GIF. Support implemented for all plugins, but only tested for Gmagick, GraphicsMagick and GD. ImageMagick support is likely to work as options for GraphicsMagick and ImageMagick are similar. No idea if the Imagick patch will work. Buginess in the Gmagick API means we have to jump through some very specific hoops to get transparency to work. For Imagick the code takes a API at its word. 

Will set up and test with Imagick/Imagemagick as time allows. Would appreciate if someone running IM might take the time to evaluate and return feedback.