### PR TITLE
PROV-3063 Refactor display template parser and helpers to use DOMDocument

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3223,14 +3223,22 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 
 		foreach($pa_text as $vn_i => $vs_text) {
 			$vs_text = preg_replace("!([A-Za-z0-9]+)='([^']*)'!", "$1=\"$2\"", $vs_text);
-			$va_l_tags = array();
+			if(!strlen($vs_text)) { 
+				$va_links[$vn_i] = null;
+				continue; 
+			}
 			
-			$o_doc = str_get_dom($vs_text);
-			$o_links = $o_doc('l');
+			$va_l_tags = [];
+			
+			$o_doc = new DOMDocument();
+			libxml_use_internal_errors(true);
+			$o_doc->loadHTML($vs_text, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOWARNING);
+			libxml_clear_errors();
+			$o_links = $o_doc->getElementsByTagName('l');
 
 			foreach($o_links as $o_link) {
 				if (!$o_link) { continue; }
-				$vs_html = $o_link->html();
+				$vs_html = $o_link->ownerDocument->saveHTML($o_link);
 
 				$vs_content = preg_replace("!^<[^\>]+>!", "", $vs_html);
 				$vs_content = preg_replace("!<[^\>]+>$!", "", $vs_content);

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -1458,20 +1458,21 @@ function caFileIsIncludable($ps_file) {
 	/**
 	 * Remove all HTML tags and their contents
 	 *
-	 * @param string $ps_string The string to process
-	 * @return string $ps_string with HTML tags and associated content removed
+	 * @param string $string The string to process
+	 * @return string $string with HTML tags and associated content removed
 	 */
-	function caStripTagsAndContent($ps_string) {
-		$o_doc = str_get_dom($ps_string);
-		foreach($o_doc("*") as $o_node) {
-			if ($o_node->tag != '~text~') {
-				$o_node->delete();
-			}
+	function caStripTagsAndContent($string) {
+		$o_doc = new DOMDocument();
+		libxml_use_internal_errors(true);
+		$o_doc->loadHTML($string, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOWARNING);
+		libxml_clear_errors();
+		
+		$content = '';
+		foreach($o_doc->childNodes as $node) {
+			$content .= $node->nodeValue;
 		}
-		$vs_proc_string = $o_doc->html();
-		$vs_proc_string = str_replace("<~root~>", "", $vs_proc_string);
-		$vs_proc_string = str_replace("</~root~>", "", $vs_proc_string);
-		return trim($vs_proc_string);
+		
+		return trim($content);
 	}
 	# ---------------------------------------
 	/**


### PR DESCRIPTION
PR refactors the DisplayTemplateParser class to use DOMDocument in place of the "ganon" library.

The DisplayTemplateParser class uses the pure-PHP "ganon" HTML library to parse the HTML-like tags used in templates. ganon has not been updated in years and may well break with the advent of PHP 8.0. This PR refactors the DisplayTemplateParser to use DOMDocument, a standard PHP parsing API, to process templates entirely removing the ganon dependency.