### PR TITLE
PROV-3065 Enable background metadata imports

### DIFF
--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -1376,16 +1376,16 @@
 					$va_errors['general'][] = array(
 						'idno' => "*",
 						'label' => "*",
-						'errors' => array(_t("Could not import source %1", $ps_source)),
+						'errors' => array(_t("Could not import source %1", $vs_source)),
 						'status' => 'ERROR'
 					);
-					BatchProcessor::$s_import_error_list[] = _t("Could not import source %1", $ps_source);
+					BatchProcessor::$s_import_error_list[] = _t("Could not import source %1", $vs_source);
 					return false;
 				} else {
 					$va_notices['general'][] = array(
 						'idno' => "*",
 						'label' => "*",
-						'errors' => array(_t("Imported data from source %1", $ps_source)),
+						'errors' => array(_t("Imported data from source %1", $vs_source)),
 						'status' => 'SUCCESS'
 					);
 					//return true;
@@ -1397,16 +1397,21 @@
 			
 			if (isset($pa_options['sendMail']) && $pa_options['sendMail']) {
 				if ($vs_email = trim($po_request->user->get('email'))) {
+					$info = $t_importer->getInfoForLastImport();
 					caSendMessageUsingView($po_request, array($vs_email => $po_request->user->get('fname').' '.$po_request->user->get('lname')), __CA_ADMIN_EMAIL__, _t('[%1] Batch metadata import completed', $po_request->config->get('app_display_name')), 'batch_metadata_import_completed.tpl', 
-						array(
-							'notices' => $va_notices, 'errors' => $va_errors,
-							'numErrors' => sizeof($va_errors), 'numProcessed' => sizeof($va_notices),
+						[
+							'sourceFile' => $pa_options['sourceFile'],
+							'sourceFileName' => $pa_options['sourceFileName'],
+							'notices' => $va_notices['general'], 'errors' => $va_errors['general'],
+							'total' => $info['total'],
+							'numErrors' => $info['numErrors'], 'numProcessed' => $info['numProcessed'],
+							'numSkipped' => $info['numSkipped'],
 							'subjectNameSingular' => _t('row'),
 							'subjectNamePlural' => _t('rows'),
 							'startedOn' => caGetLocalizedDate($vn_start_time),
 							'completedOn' => caGetLocalizedDate(time()),
 							'elapsedTime' => caFormatInterval($vn_elapsed_time)
-						), null, null, ['source' => 'Metadata import complete']
+						], null, null, ['source' => 'Metadata import complete']
 					);
 				}
 			}

--- a/app/lib/Plugins/TaskQueueHandlers/metadataImport.php
+++ b/app/lib/Plugins/TaskQueueHandlers/metadataImport.php
@@ -93,6 +93,7 @@ class WLPlugTaskQueueHandlermetadataImport Extends WLPlug Implements IWLPlugTask
 		
 		set_time_limit(3600*72); // if it takes more than 72 hours we're in trouble
 	
+		define('__CA_DONT_QUEUE_SEARCH_INDEXING__', true);
 		$report = BatchProcessor::importMetadata(
 			$req, 
 			$parameters['sourceFile'],

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -580,7 +580,7 @@ class SearchIndexer extends SearchBase {
 		// Prevent endless recursive reindexing
 		if (is_array($pa_exclusion_list[$pn_subject_table_num]) && (isset($pa_exclusion_list[$pn_subject_table_num][$pn_subject_row_id]))) { return; }
 
-		if(caGetOption('queueIndexing', $pa_options, false) && !$t_subject->getAppConfig()->get('disable_out_of_process_search_indexing')) {
+		if(caGetOption('queueIndexing', $pa_options, false) && !$t_subject->getAppConfig()->get('disable_out_of_process_search_indexing') && !defined('__CA_DONT_QUEUE_SEARCH_INDEXING__')) {
 			$this->queueIndexRow(array(
 				'table_num' => $pn_subject_table_num,
 				'row_id' => $pn_subject_row_id,
@@ -1812,7 +1812,7 @@ if (!$for_current_value_reindex) {
 	public function commitRowUnIndexing($pn_subject_table_num, $pn_subject_row_id, $pa_options = null) {
 		$vb_can_do_incremental_indexing = $this->opo_engine->can('incremental_reindexing') ? true : false;		// can the engine do incremental indexing? Or do we need to reindex the entire row every time?
 
-		if(caGetOption('queueIndexing', $pa_options, false) && !$this->opo_app_config->get('disable_out_of_process_search_indexing')) {
+		if(caGetOption('queueIndexing', $pa_options, false) && !$this->opo_app_config->get('disable_out_of_process_search_indexing') && !defined('__CA_DONT_QUEUE_SEARCH_INDEXING__')) {
 			$this->queueUnIndexRow(array(
 				'table_num' => $pn_subject_table_num,
 				'row_id' => $pn_subject_row_id,

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -3853,6 +3853,19 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	/**
 	 * 
 	 */
+	public function getInfoForLastImport(array $options=null) {
+		return [
+			'numErrors' => $this->num_import_errors,
+			'numProcessed' => $this->num_records_processed,
+			'numSkipped' => $this->num_records_skipped,
+			'total' => $this->num_import_errors + $this->num_records_processed + $this->num_records_skipped,
+			'errors' => $this->import_error_list
+		];
+	}
+	# ------------------------------------------------------
+	/**
+	 * 
+	 */
 	private function _processChildren($parent_table, $parent_id, $children, $options=null) {
 		$log = caGetOption('log', $options, null);
 		$trans = caGetOption('transaction', $options, null);

--- a/themes/default/views/mailTemplates/batch_metadata_import_completed.tpl
+++ b/themes/default/views/mailTemplates/batch_metadata_import_completed.tpl
@@ -1,0 +1,64 @@
+<?php
+/** ---------------------------------------------------------------------
+ * views/mailTemplates/batch_metadata_import_completed.tpl
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2020 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ * 
+ * @package CollectiveAccess
+ * @subpackage batch
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ * 
+ * ----------------------------------------------------------------------
+ */
+ 	
+  /**
+   *
+   */ 
+	print _t('Batch metadata import of file %1 completed on %2.
+%3 of %4 %5 were processed. %6 had errors. %7 were skipped.<br/><br/>', 
+		$this->getVar('sourceFileName'), $this->getVar('completedOn'),
+		$this->getVar('numProcessed'), $this->getVar('total'), 
+		$this->getVar('subjectNamePlural'), $this->getVar('numErrors'),
+		$this->getVar('numSkipped')
+	);
+	
+	$va_notices = $this->getVar('notices');
+	$va_errors = $this->getVar('errors');
+	
+	if (is_array($va_errors) && sizeof($va_errors)) {
+		$vs_buf .= '<strong>'._t('Errors').':</strong><br/><ul>';
+		foreach($va_errors as $id => $va_error) {
+			$vs_buf .= "<li>".$va_error['status'].": ".join('; ', $va_error['errors'])."</li>";
+		}
+		$vs_buf .= "</ul><br/><br/>";
+	}
+	if (is_array($va_notices) && sizeof($va_notices)) {
+		$vs_buf .= '<strong>'._t('Notices').':</strong><br/><ol>';
+		foreach($va_notices as $id => $va_notice) {
+			$vs_buf .= "<li>".$va_notice['status'].": ".join('; ', $va_notice['errors'])."</li>";
+		}
+		$vs_buf .= "</ol>";
+	}
+	print $vs_buf;
+	
+	print "\n<br/><br/>"._t("Processing took %1", $this->getVar('elapsedTime'));
+?>


### PR DESCRIPTION
PR adds template to support email notifications for metadata imports, and disabled search index queuing when importing in the background. Disabling queuing prevents generation of large indexing backlogs by an import.