### PR TITLE
PROV-3066 Implement compressed PDF support

### DIFF
--- a/app/conf/media_display.conf
+++ b/app/conf/media_display.conf
@@ -54,7 +54,7 @@ media_overlay = {
 	},
 	pdf = {
 		mimetypes = {application/pdf},
-		display_version = original,
+		display_version = compressed,
 		alt_display_version = mediumlarge,
 		width = 100%, height = 100%,
 		download_version = original,

--- a/app/conf/media_processing.conf
+++ b/app/conf/media_processing.conf
@@ -288,6 +288,10 @@ ca_object_representations = {
 					RULE = rule_page_image, VOLUME = images,
 					QUEUE_WHEN_FILE_LARGER_THAN = <queue_threshold_in_bytes>
 				},
+				compressed	= {
+					RULE = rule_compressed_pdf, VOLUME = images,
+					USE_EXTERNAL_URL_WHEN_AVAILABLE = <use_external_url_when_available>
+				},
 				original 	= {
 					RULE = rule_original_image, VOLUME = images,
 					USE_EXTERNAL_URL_WHEN_AVAILABLE = <use_external_url_when_available>
@@ -1384,6 +1388,9 @@ ca_object_representations = {
 		},
 		rule_to_pdf = {
 			SET = {format = application/pdf}
+		},
+		rule_compressed_pdf = {
+		    SET = {format = application/pdf, compress = screen }
 		},
 		rule_original_image = {},
 		rule_tilepic_image = {

--- a/app/lib/Media/BaseMediaViewer.php
+++ b/app/lib/Media/BaseMediaViewer.php
@@ -69,6 +69,8 @@
 			$t_media = isset($pa_data['t_media']) ? $pa_data['t_media'] : $t_subject;
 			$pa_check_access = caGetOption('checkAccess', $pa_options, null);
 			
+			$display_version = caGetOption('display_version', $pa_data['display'], null);
+			
 			// Controls
 			$vs_controls = '';
 			if ($t_subject) {
@@ -106,11 +108,14 @@
 					
 					$o_view->setVar('page', $vn_rep_index);		
 				}
-				$o_view->setVar('original_media_url', $t_instance->getMediaUrl('media', 'original', []));
+				$o_view->setVar('original_media_url', $original_media_url = $t_instance->getMediaUrl('media', 'original', []));
+				$o_view->setVar('display_media_url', $display_version ? $t_instance->getMediaUrl('media', $display_version, []) : $original_media_url);
 			} elseif(is_a($t_instance, 'ca_attribute_values')) {
-				$o_view->setVar('original_media_url', $t_instance->getMediaUrl('value_blob', 'original', []));
+				$o_view->setVar('original_media_url', $original_media_url = $t_instance->getMediaUrl('value_blob', 'original', []));
+				$o_view->setVar('display_media_url', $display_version ? $t_instance->getMediaUrl('media', $display_version, []) : $original_media_url);
 			} elseif(is_a($t_instance, 'ca_site_page_media')) {
-				$o_view->setVar('original_media_url', $t_instance->getMediaUrl('media', 'original', []));
+				$o_view->setVar('original_media_url', $original_media_url = $t_instance->getMediaUrl('media', 'original', []));
+				$o_view->setVar('display_media_url', $display_version ? $t_instance->getMediaUrl('media', $display_version, []) : $original_media_url);
 			}
 			if ($t_subject && $t_instance && ($po_request->user->canDoAction('can_download_media') || $po_request->user->canDoAction('can_download_ca_object_representations'))) {
 					if (is_array($va_versions = $po_request->config->getList('ca_object_representation_download_versions'))) {

--- a/app/lib/Plugins/Media/PDFWand.php
+++ b/app/lib/Plugins/Media/PDFWand.php
@@ -589,7 +589,7 @@ class WLPlugMediaPDFWand Extends BaseMediaPlugin implements IWLPlugMedia {
 			if($this->ops_ghostscript_path && ($compress = strtolower($this->get("compress")))) {
 				if (!in_array($compress, ['screen', 'ebook', 'printer', 'prepress', 'default'], true)) { $compress = 'default'; }
 				
-				caExec($z=$this->ops_ghostscript_path." -dPDFSETTINGS=/{$compress} -dNumRenderingThreads=6 -dNOPAUSE -dBATCH -sDEVICE=pdfwrite {$vs_antialiasing} -dMaxPatternBitmap=1000000 -dBandBufferSpace=500000000 -sBandListStorage=memory -dBufferSpace=1000000000 -dBandHeight=100 -sOutputFile=".caEscapeShellArg($ps_filepath.".".$vs_ext)." -c \"30000000 setvmthreshold\" -f ".caEscapeShellArg($this->handle["filepath"]).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
+				caExec($this->ops_ghostscript_path." -dPDFSETTINGS=/{$compress} -dNumRenderingThreads=6 -dNOPAUSE -dBATCH -sDEVICE=pdfwrite {$vs_antialiasing} -dMaxPatternBitmap=1000000 -dBandBufferSpace=500000000 -sBandListStorage=memory -dBufferSpace=1000000000 -dBandHeight=100 -sOutputFile=".caEscapeShellArg($ps_filepath.".".$vs_ext)." -c \"30000000 setvmthreshold\" -f ".caEscapeShellArg($this->handle["filepath"]).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
 				if($vn_return == 0) {
 					$va_files[] = "{$ps_filepath}.{$vs_ext}";
 				} else {

--- a/themes/default/views/mediaViewers/pdfjs.php
+++ b/themes/default/views/mediaViewers/pdfjs.php
@@ -391,7 +391,7 @@
  <script>
  	// Set viewer config vars
  	window.pdfjsPath = '<?= $this->request->getBaseUrlPath(); ?>/assets';
- 	window.pdfjsContentURL = '<?= $this->getVar('original_media_url'); ?>';
+ 	window.pdfjsContentURL = '<?= $this->getVar('display_media_url'); ?>';
  	window.pdfjsContainerID = 'caMediaOverlayContent';
  </script>
  <script src="<?= $this->request->getBaseUrlPath(); ?>/assets/pdfjs/viewer/viewer.js"></script>


### PR DESCRIPTION
PR adds "compress" property to PDFWand media processing plugin. The property exposes Ghostscript's dPDFSETTINGS option, which provides five presets for control of PDF file size (and quality). Changes include:

- Add property to support dPDFSETTINGS when processing PDFs
- Add "compressed" PDF version to standard media_process.conf file using "screen" PDF size/quality settings. This provides smallest file at reasonable quality (YMMV).
- Modify pdfjs media viewer to use versions other than original pdf.
- Modify standard media_display.conf file to use compressed version when displaying PDFs.