### PR TITLE
NOJIRA properly count previews, avoiding potentially infinite loop

### DIFF
--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -974,13 +974,14 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		@unlink($output_file_prefix);
 		
 		$files = [];
-		$i = 1;
+		$i = 0;
 		
 		$this->handle->setimageindex(0);
 		$num_previews = 0;
 		do {
 			if ($i > 1) { $this->handle->nextImage(); }
 			$num_previews++;
+			$i++;
 		} while($this->handle->hasnextimage());
 		
 		$this->handle->setimageindex(0);


### PR DESCRIPTION
PR fixes incorrect counting of image previews that could result in an infinite loop, stalling media processing.