### PR TITLE
NOJIRA allow type_id lists to be generated for label types using subject record types;

### DIFF
--- a/app/helpers/accessHelpers.php
+++ b/app/helpers/accessHelpers.php
@@ -311,6 +311,7 @@
 		}
 		$t_instance = Datamodel::getInstanceByTableName($vs_table_name, true);
 		if (!$t_instance) { return null; }	// bad table
+		if(is_a($t_instance, 'BaseLabel')) { $t_instance = $t_instance->getSubjectTableInstance(); }
 		if (!($vs_type_list_code = $t_instance->getTypeListCode())) { return null; }	// table doesn't use types
 		
 		$va_ret = caMakeItemIDList($vs_type_list_code, $pa_types, $pa_options);


### PR DESCRIPTION
PR extends caMakeTypeIDList() helper to use subject table type_ids when a label table is passed. This allows the "types" parameter in search indexing (which is used to restrict indexing of related records to specific types) to be used for labels as well as the primary record type.