### PR TITLE
PROV-3067, PROV-2781  add remove-existing-media option to batch media importer; expand metdata extraction to metadata importer

### DIFF
--- a/app/controllers/batch/MediaImportController.php
+++ b/app/controllers/batch/MediaImportController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2020 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -262,6 +262,7 @@
 				'representation_idno' => $this->request->getParameter('idno_representation_number', pString),
  				'logLevel' => $this->request->getParameter('log_level', pString),
  				'allowDuplicateMedia' => $this->request->getParameter('allow_duplicate_media', pInteger),
+ 				'replaceExistingMedia' => $this->request->getParameter('replace_existing_media', pInteger),
  				'locale_id' => $g_ui_locale_id,
  				'user_id' => $this->request->getUserID(),
  				'skipFileList' => $this->request->getParameter('skip_file_list', pString),

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -4163,8 +4163,11 @@ if (!$vb_batch) {
 										$vn_rank = $va_rep_ids_sorted[$vn_rank_index];
 									}
 									
+									// import embedded metadata?
+									$vn_object_representation_mapping_id = $po_request->getParameter($vs_prefix_stub.'importer_id_'.$va_rep['relation_id'], pInteger);
+										
 									$vn_rel_type_id = $po_request->getParameter($vs_prefix_stub.'rel_type_id_'.$va_rep['relation_id'], pString);
-									$t_rep = $this->editRepresentation($va_rep['representation_id'], $vs_path, $vals['locale_id'], $vals['status'], $vals['access'], $vals['is_primary'], $vals, array('original_filename' => $vs_original_name, 'rank' => $vn_rank, 'centerX' => $vn_center_x, 'centerY' => $vn_center_y, 'type_id' => $vals['type_id'], 'rel_type_id' => $vn_rel_type_id));
+									$t_rep = $this->editRepresentation($va_rep['representation_id'], $vs_path, $vals['locale_id'], $vals['status'], $vals['access'], $vals['is_primary'], $vals, array('original_filename' => $vs_original_name, 'rank' => $vn_rank, 'centerX' => $vn_center_x, 'centerY' => $vn_center_y, 'type_id' => $vals['type_id'], 'rel_type_id' => $vn_rel_type_id, 'mapping_id' => $vn_object_representation_mapping_id));
 									if ($this->numErrors()) {
 										//$po_request->addActionErrors($this->errors(), $vs_f, $va_rep['relation_id']);
 										foreach($this->errors() as $o_e) {
@@ -4177,37 +4180,6 @@ if (!$vb_batch) {
 													$po_request->addActionError($o_e, $vs_f, $va_rep['relation_id']);
 													break;
 											}
-										}
-									} elseif($vs_path) {
-										// import embedded metadata?
-										$vn_object_representation_mapping_id = $po_request->getParameter($vs_prefix_stub.'importer_id_'.$va_rep['relation_id'], pInteger);
-										
-										$log = caGetImportLogger(['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level')]);
-										if(!$vn_object_representation_mapping_id && is_array($media_metadata_extraction_defaults = $po_request->getAppConfig()->getAssoc('embedded_metadata_extraction_mapping_defaults'))) {
-											$media_mimetype = $t_rep->get('mimetype');
-											
-											foreach($media_metadata_extraction_defaults as $m => $importer_code) {
-												if(caCompareMimetypes($media_mimetype, $m)) {
-													if (!($vn_object_representation_mapping_id = ca_data_importers::find(['importer_code' => $importer_code], ['returnAs' => 'firstId']))) {
-														if ($log) { $log->logInfo(_t('Could not find embedded metadata importer with code %1', $importer_code)); }
-													}
-													break;
-												}
-											}
-                                        }
-										
-										if ($vn_object_representation_mapping_id && ($t_mapping = ca_data_importers::find(['importer_id' => $vn_object_representation_mapping_id], ['returnAs' => 'firstModelInstance']))) {
-											$format = $t_mapping->getSetting('inputFormats');
-											if(is_array($format)) { $format = array_shift($format); }
-											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-											
-											$t_importer = new ca_data_importers();
-											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, [
-												'logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 
-												'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 
-												'transaction' => $this->getTransaction()],
-												'environment' => ['original_filename' => $vs_original_name, '/original_filename' => $vs_original_name]
-											]); 
 										}
 									}
 									
@@ -4368,11 +4340,14 @@ if (!$vb_batch) {
                                    		}
                                 	}
                                 	
+									// import embedded metadata?
+									$vn_object_representation_mapping_id = $po_request->getParameter($vs_prefix_stub.'importer_id_new_'.$va_matches[1], pInteger);
+                                	
                                     // Get user-specified center point (images only)
                                     $vn_center_x = $po_request->getParameter($vs_prefix_stub.'center_x_new_'.$va_matches[1], pString);
                                     $vn_center_y = $po_request->getParameter($vs_prefix_stub.'center_y_new_'.$va_matches[1], pString);
                         
-                                    $t_rep = $this->addRepresentation($vs_path, $vn_rep_type_id, $vals['locale_id'], $vals['status'], $vals['access'], $vn_is_primary, array_merge($vals, ['name' => $vals['rep_label']]), array('original_filename' => $vs_original_name, 'returnRepresentation' => true, 'centerX' => $vn_center_x, 'centerY' => $vn_center_y, 'type_id' => $vn_type_id));	// $vn_type_id = *relationship* type_id (as opposed to representation type)
+                                    $t_rep = $this->addRepresentation($vs_path, $vn_rep_type_id, $vals['locale_id'], $vals['status'], $vals['access'], $vn_is_primary, array_merge($vals, ['name' => $vals['rep_label']]), array('original_filename' => $vs_original_name, 'returnRepresentation' => true, 'centerX' => $vn_center_x, 'centerY' => $vn_center_y, 'type_id' => $vn_type_id, 'mapping_id' => $vn_object_representation_mapping_id));	// $vn_type_id = *relationship* type_id (as opposed to representation type)
                                     
                                     if ($this->numErrors()) {
                                         $po_request->addActionErrors($this->errors(), $vs_f, 'new_'.$va_matches[1]);
@@ -4380,36 +4355,6 @@ if (!$vb_batch) {
                                         if ($t_rep && is_array($pa_options['existingRepresentationMap'])) { 
                                             $pa_options['existingRepresentationMap'][$vs_path] = $t_rep->getPrimaryKey();
                                         }
-                                        // import embedded metadata?
-                                        $vn_object_representation_mapping_id = $po_request->getParameter($vs_prefix_stub.'importer_id_new_'.$va_matches[1], pInteger);
-										
-										if(!$vn_object_representation_mapping_id && is_array($media_metadata_extraction_defaults = $po_request->getAppConfig()->getAssoc('embedded_metadata_extraction_mapping_defaults'))) {
-											$media_mimetype = $t_rep->get('mimetype');
-										
-											$log = caGetImportLogger(['logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level')]);
-											foreach($media_metadata_extraction_defaults as $m => $importer_code) {
-												if(caCompareMimetypes($media_mimetype, $m)) {
-													if (!($vn_object_representation_mapping_id = ca_data_importers::find(['importer_code' => $importer_code], ['returnAs' => 'firstId']))) {
-														if ($log) { $log->logInfo(_t('Could not find embedded metadata importer with code %1', $importer_code)); }
-													}
-													break;
-												}
-											}
-                                        }
-                                        
-										if ($vn_object_representation_mapping_id && ($t_mapping = ca_data_importers::find(['importer_id' => $vn_object_representation_mapping_id], ['returnAs' => 'firstModelInstance']))) {
-											$format = $t_mapping->getSetting('inputFormats');
-											if(is_array($format)) { $format = array_shift($format); }
-											if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
-											
-											$t_importer = new ca_data_importers();
-											$t_importer->importDataFromSource($t_rep->getMediaPath('media', 'original'), $vn_object_representation_mapping_id, [
-												'logLevel' => $po_request->getAppConfig()->get('embedded_metadata_extraction_mapping_log_level'), 
-												'format' => $format, 'forceImportForPrimaryKeys' => [$t_rep->getPrimaryKey(), 
-												'transaction' => $this->getTransaction()],
-												'environment' => ['original_filename' => $vs_original_name, '/original_filename' => $vs_original_name]
-											]); 
-										}
                                     }
                                 }
                             }

--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -200,6 +200,7 @@
                 'matchMode' => $vs_match_mode,
                 'matchType' => $vs_match_type,
                 'allowDuplicateMedia' => (bool)$po_opts->getOption('allow-duplicate-media'),
+                'replaceExistingMedia' => (bool)$po_opts->getOption('replace-existing-media'),
                 'includeSubDirectories' => (bool)$po_opts->getOption('include-subdirectories'),
                 'deleteMediaOnImport' => (bool)$po_opts->getOption('delete-media-on-import'),
                 
@@ -284,6 +285,7 @@
 				"match-mode-s" => _t('Determines how matches are made between media and records. Valid values are DIRECTORY_NAME, FILE_AND_DIRECTORY_NAMES, FILE_NAME. Set to DIRECTORY_NAME to match media directory names to target record identifiers; to FILE_AND_DIRECTORY_NAMES to match on both file and directory names; to FILE_NAME to match only on file names. Default is FILE_NAME.'),
 				"import-mode-s" => _t('Determines if target records are created for media that do not match existing target records. Set to TRY_TO_MATCH to create new target records when no match is found. Set to ALWAYS_MATCH to only import media for existing records. Default is TRY_TO_MATCH.'),
 				'allow-duplicate-media' => _t('Import media even if it already exists in CollectiveAccess. Default is false – skip import of duplicate media.'),
+				'replace-existing-media' => _t('Delete existing media on match records before importing new media. This option is destructive. Use with caution! Default is false.'),
 				'import-target-s' => _t('Table name of record to import media into. Should be a valid representation-taking table such as ca_objects, ca_entities, ca_occurrences, ca_places, etc. Default is ca_objects.'),
 				'import-target-type|t-s' => _t('Type to use for all newly created target records. Default is the first type in the target\'s type list.'),
 				'import-target-idno|i-s' => _t('Identifier to use for all newly created target records.'),

--- a/themes/default/views/batch/mediaimport/import_options_html.php
+++ b/themes/default/views/batch/mediaimport/import_options_html.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2020 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -502,18 +502,34 @@
 				<span class="formLabelText"><?php print _t('Miscellaneous'); ?></span>
 					<div class="bundleContainer">
 						<div class="caLabelList" >
-							<p class='formLabel'>
-	<?php
-				print caHTMLCheckboxInput('allow_duplicate_media', array('value' => 1,  'id' => 'caAllowDuplicateMedia', 'checked' => $va_last_settings['allowDuplicateMedia']), array());
-				print " "._t('Allow duplicate media?');
-	?>
-							</p>
+							<table>
+								<tr valign="top">
+									<td>
 							<p class='formLabel'>
 	<?php
 								print _t('Log level').'<br/>';
 								print caHTMLSelect('log_level', caGetLogLevels(), array('id' => 'caLogLevel'), array('value' => $va_last_settings['logLevel']));
 	?>
 							</p>
+									</td>
+									<td>
+							<p class='formLabel'>
+	<?php
+				print caHTMLCheckboxInput('allow_duplicate_media', array('value' => 1,  'id' => 'caAllowDuplicateMedia', 'checked' => $va_last_settings['allowDuplicateMedia']), []);
+				print " "._t('Allow duplicate media?');
+	?>
+							</p>
+									</td>
+									<td>
+							<p class='formLabel'>
+	<?php
+				print caHTMLCheckboxInput('replace_existing_media', array('value' => 1,  'id' => 'caReplaceExistingMedia', 'checked' => 0), array());
+				print " "._t('Replace existing media?');
+	?>
+							</p>
+									</td>
+								</tr>
+							</table>
 						</div>
 					</div>
 			</div>


### PR DESCRIPTION
PR add remove-existing-media option to batch media importer, facilitating in-place replacement of media; and  moves embedded metadata mapping data extraction to the representation model to ensure it is performed during metadata imports via the objectRepresentation splitter.