### PR TITLE
PROV-3053 Set default dollar currency properly when used in command-line environment

### DIFF
--- a/app/lib/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/Attributes/Values/CurrencyAttributeValue.php
@@ -276,7 +276,8 @@
 			switch($vs_currency_specifier) {
 				case '$':
 					$o_config = Configuration::load();
-					$vs_currency_specifier = ($vs_dollars_are_this = caGetOption('dollarCurrency', $va_settings, $o_config->get('default_dollar_currency'))) ? $vs_dollars_are_this : 'USD';
+					$vs_dollars_are_this = caGetOption('dollarCurrency', $va_settings, $o_config->get('default_dollar_currency'), ['defaultOnEmptyString' => true]);
+					$vs_currency_specifier = $vs_dollars_are_this ? $vs_dollars_are_this : 'USD';
 					break;
 				case '¥':
 					$vs_currency_specifier = 'JPY';


### PR DESCRIPTION
PR properly sets currency for dollar-sign denominated values when run from command-line. Previously USD would be used no matter what the default was set to.