### PR TITLE
PROV-3068 Include date-less entries

### DIFF
--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -949,7 +949,7 @@
 						$relation_id = $linking_table ? $qr_lots->get("{$linking_table}.relation_id") : $vn_lot_id;
 		
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_lot_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date))) { continue; }
 							
@@ -1047,7 +1047,7 @@
                         }
 				
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_loan_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date))) { continue; }
 							
@@ -1153,7 +1153,7 @@
 						}
 		
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_movement_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date))) { continue; }
 							
@@ -1266,7 +1266,7 @@
                         }
 				
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_occurrence_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date) || ($va_date['bounds'][1] < $vn_current_date))) { continue; }
 					
@@ -1382,7 +1382,7 @@
                         }
 				
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_entity_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date) || ($va_date['bounds'][1] < $vn_current_date))) { continue; }
 					
@@ -1491,7 +1491,7 @@
                         }
 				
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_collection_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date) || ($va_date['bounds'][1] < $vn_current_date))) { continue; }
 					
@@ -1600,7 +1600,7 @@
                         }
 				
 						foreach($va_dates as $va_date) {
-							if (!$va_date['sortable']) { continue; }
+							if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 							if (!in_array($vn_type_id, $va_object_types)) { continue; }
 							if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date) || ($va_date['bounds'][1] < $vn_current_date))) { continue; }
 					
@@ -1671,6 +1671,7 @@
 					$loc_table_num = Datamodel::getTableNum('ca_storage_locations');
 					$rel_table_num = Datamodel::getTableNum($linking_table);
 				
+					$unsortable = [];
 					while($qr_locations->nextHit()) {
 						if ((string)$qr_locations->get('ca_storage_locations.deleted') !== '0') { continue; }	// filter out deleted
 					    
@@ -1693,7 +1694,7 @@
 							);
 						}
 
-						if (!$va_date['sortable']) { continue; }
+						if (!$va_date['sortable']) { $va_date['sortable'] = 0; }
 						if (sizeof($va_location_types) && sizeof($va_location_types) && !in_array($vn_rel_type_id = $qr_locations->get("{$linking_table}.type_id"), $va_location_types)) { continue; }
 						
 						if ($pb_get_current_only && (($va_date['bounds'][0] > $vn_current_date))) { continue; }


### PR DESCRIPTION
PR modifies behavior of history tracking getHistory() call to include undated entries at the end of the returned chronology. Previously, undated entries were omitted.