### PR TITLE
PROV-2827 Fix settings regression and sort warning

### DIFF
--- a/app/lib/BaseSettings.php
+++ b/app/lib/BaseSettings.php
@@ -605,6 +605,50 @@
 								$va_opts = array('id' => $vs_input_id, 'width' => $vn_width, 'height' => $vn_height, 'value' => is_array($vs_value) ? $vs_value[0] : $vs_value, 'multiple' => 1, 'values' => is_array($vs_value) ? $vs_value : array($vs_value));
 								$vs_select_element = caHTMLSelect($vs_input_name, $va_select_opts,  $va_select_attr, $va_opts);
 							}
+						} elseif ($va_properties['showMetadataElementsWithDataType']) {
+							require_once(__CA_MODELS_DIR__.'/ca_metadata_elements.php');
+							
+							if (!is_array($va_properties['table'])) { $va_properties['table'] = [$va_properties['table']]; }
+							
+							$va_select_opts = [];
+							foreach($va_properties['table'] as $vs_table) {
+								$va_rep_elements = ca_metadata_elements::getElementsAsList(true, $vs_table, null, true, false, true, is_numeric($va_properties['showMetadataElementsWithDataType']) ? array($va_properties['showMetadataElementsWithDataType']) : null);
+							
+								if (is_array($va_rep_elements)) {
+									foreach($va_rep_elements as $vs_element_code => $va_element_info) {
+										$va_select_opts[$va_element_info['display_label']] = "{$vs_table}.{$vs_element_code}";
+									}
+								}
+							
+								if($va_properties['includeIntrinsics']) {
+									if (!($t_rep = Datamodel::getInstanceByTableName($vs_table, true))) { continue; }
+							
+									foreach($t_rep->getFormFields() as $vs_f => $va_field_info) {
+										if (is_array($va_properties['includeIntrinsics']) && !in_array($vs_f, $va_properties['includeIntrinsics'])) { continue; }
+										if(in_array($va_field_info['DT_DISPLAY'], array('DT_OMIT', 'DT_HIDDEN'))) { continue; }
+										if (isset($va_field_info['IDENTITY']) && $va_field_info['IDENTITY']) { continue; }
+									
+										$va_select_opts[$va_field_info['LABEL']] = $vs_f;
+									}	
+								}
+								if($va_properties['includePreferredLabels']) {
+									if (!($t_rep = Datamodel::getInstanceByTableName($vs_table, true))) { continue; }
+									foreach($t_rep->getLabelUIFields() as $vs_f) {
+										$va_select_opts[$t_rep->getDisplayLabel("{$vs_table}.preferred_labels.{$vs_f}")] = "{$vs_table}.preferred_labels.{$vs_f}";
+									}	
+								}
+							}
+							
+							if (sizeof($va_select_opts)) {	
+								
+								$va_select_attr = [];
+								if($vn_height > 1) {
+									$vs_input_name .= '[]'; 
+									$va_select_attr = ['multiple' => 1];
+								}
+								$va_opts = array('id' => $vs_input_id, 'width' => $vn_width, 'height' => $vn_height, 'value' => is_array($vs_value) ? $vs_value[0] : $vs_value, 'multiple' => 1, 'values' => is_array($vs_value) ? $vs_value : array($vs_value));
+								$vs_select_element = caHTMLSelect($vs_input_name, $va_select_opts,  $va_select_attr, $va_opts);
+							}
 						} else {
 							// Regular drop-down with configured options
 							if ($vn_height > 1) { $va_attr['multiple'] = 1; $vs_input_name .= '[]'; }

--- a/themes/default/views/bundles/ca_object_representations_classic.php
+++ b/themes/default/views/bundles/ca_object_representations_classic.php
@@ -529,7 +529,7 @@
 	<div class="bundleContainer">
 	    <div class='bundleSubLabel'>
 <?php
-            print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName(), $t_instance->tableName(), array_merge($settings, ['sort' => $loaded_sort, 'sortDirection' => $loaded_sort_direction]));
+            print caEditorBundleSortControls($this->request, $vs_id_prefix, $t_item->tableName(), $t_instance->tableName(), array_merge($va_settings, ['sort' => $loaded_sort, 'sortDirection' => $loaded_sort_direction]));
 
 		    if (($vn_rep_count > 1) && $this->request->getUser()->canDoAction('can_download_ca_object_representations')) {
 			    print "<div style='float: right'>".caNavLink($this->request, caNavIcon(__CA_NAV_ICON_DOWNLOAD__, 1)." "._t('Download all'), 'button', '*', '*', 'DownloadMedia', [$t_subject->primaryKey() => $t_subject->getPrimaryKey()])."</div>";


### PR DESCRIPTION
PR resolves missing "editable elements" configuration list in representation bundle config; eliminates warning in classic representation bundle due to incorrect call to sort control helper.