### PR TITLE
PROV-3069 Re-establish maximumLength option for bundle displays

### DIFF
--- a/app/models/ca_bundle_displays.php
+++ b/app/models/ca_bundle_displays.php
@@ -2419,7 +2419,11 @@ if (!$pb_omit_editing_info) {
 			}
 			
 		}
-		
+		if(($options['maximumLength'] > 0) && (mb_strlen($vs_val) > $options['maximumLength'])) {
+			$doc = new DOMDocument();
+			@$doc->loadHTML('<?xml encoding="utf-8" ?>'.mb_substr($vs_val, 0, $options['maximumLength']));
+			return $doc->saveHTML();
+		}
 		return $vs_val;
 	}
 	# ----------------------------------------


### PR DESCRIPTION
PR re-establishes maximumLength option for bundle display placements, with provision for dealing with HTML in truncated text. The option had been disabled because it would trash pages when truncating HTML text, creating un-closed tags.
