### PR TITLE
PROV-3072 Improve entity preferred label matching in importer

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -195,7 +195,14 @@
 					$va_attributes['preferred_labels']['name'] = $va_attributes['_preferred_labels'] = $vs_name;
 					break;
 				case 'ca_entities':
-					$vn_id = DataMigrationUtils::getEntityID($va_entity_label = DataMigrationUtils::splitEntityName($vs_name, array_merge($pa_options, ['doNotParse' => $pa_item['settings']["{$ps_refinery_name}_doNotParse"]])), $vs_type, $g_ui_locale_id, $va_attributes, $pa_options);
+					// Try to match on display name alone, then parsed name
+					$va_entity_label = DataMigrationUtils::splitEntityName($vs_name, array_merge($pa_options, ['doNotParse' => $pa_item['settings']["{$ps_refinery_name}_doNotParse"]]));
+					
+					foreach([['displayname' => $vs_name], $va_entity_label] as $e) {
+						if($vn_id = DataMigrationUtils::getEntityID($e, $vs_type, $g_ui_locale_id, $va_attributes, $pa_options)) {
+							break;
+						}
+					}
 					$va_attributes['preferred_labels'] = $va_entity_label;
 					$va_attributes['_preferred_labels'] = $vs_name;
 					break;

--- a/app/lib/LabelableBaseModelWithAttributes.php
+++ b/app/lib/LabelableBaseModelWithAttributes.php
@@ -122,6 +122,7 @@
 		 * @return int id for newly created label, false on error or null if no row is loaded
 		 */ 
 		public function addLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=false, $pa_options=null) {
+			if(!is_array($pa_options)) { $pa_options = []; }
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
 			if ($pb_is_preferred && $this->preferredLabelExistsForLocale($pn_locale_id)) { return false; }
 			$vb_truncate_long_labels = caGetOption('truncateLongLabels', $pa_options, false);
@@ -163,7 +164,7 @@
 			
 			$this->opo_app_plugin_manager->hookBeforeLabelInsert(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
-			$vn_label_id = $t_label->insert(array('queueIndexing' => $pb_queue_indexing, 'subject' => $this));
+			$vn_label_id = $t_label->insert(array_merge($pa_options, ['queueIndexing' => $pb_queue_indexing, 'subject' => $this]));
 			
 			$this->opo_app_plugin_manager->hookAfterLabelInsert(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'label_instance' => $t_label));
 		
@@ -368,7 +369,7 @@
 		/**
 		 * 
 		 */
- 		public function replaceLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=true, $pa_options = null) {
+ 		public function replaceLabel($pa_label_values, $pn_locale_id, $pn_type_id=null, $pb_is_preferred=true, $pa_options=null) {
  			if (!($vn_id = $this->getPrimaryKey())) { return null; }
  			$va_labels = $this->getLabels(array($pn_locale_id), $pb_is_preferred ? __CA_LABEL_TYPE_PREFERRED__ : __CA_LABEL_TYPE_NONPREFERRED__);
  			

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -2239,7 +2239,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 								}
 								continue( 2 );
 							}
-							if ( $va_item['settings']['skipIfValue']
+							if ( isset($va_item['settings']['skipIfValue']) && strlen($va_item['settings']['skipIfValue']) 
 							     && ! is_array( $va_item['settings']['skipIfValue'] )
 							) {
 								$va_item['settings']['skipIfValue'] = array( $va_item['settings']['skipIfValue'] );
@@ -2537,7 +2537,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 								}
 							}
 
-							if ( $va_item['settings']['skipIfValue']
+							if ( isset($va_item['settings']['skipIfValue']) && strlen($va_item['settings']['skipIfValue'])
 							     && ! is_array( $va_item['settings']['skipIfValue'] )
 							) {
 								$va_item['settings']['skipIfValue'] = array( $va_item['settings']['skipIfValue'] );
@@ -2901,6 +2901,11 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 								) {
 									$va_group_buf[ $vn_c ]['_truncateLongLabels'] = true;
 								}
+								if ( isset( $va_item['settings']['displaynameFormat'] )
+								     && $va_item['settings']['displaynameFormat']
+								) {
+									$va_group_buf[ $vn_c ]['_displaynameFormat'] = $va_item['settings']['displaynameFormat'];
+								}
 							}
 
 							if ( isset( $va_item['settings']['mediaPrefix'] ) && $va_item['settings']['mediaPrefix'] ) {
@@ -3255,7 +3260,10 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 								try {
 									if (is_array($va_element_content)) { 														
 										$vb_truncate_long_labels = caGetOption('_truncateLongLabels', $va_element_content, false);
-										unset($va_element_content['_truncateLongLabels']);
+										unset($va_element_content['_truncateLongLabels']);	
+																		
+										$vs_displayname_format = caGetOption('_displaynameFormat', $va_element_content, false);
+										unset($va_element_content['_displaynameFormat']);
 									
 										$vs_item_error_policy = $va_element_content['_errorPolicy'];
 										unset($va_element_content['_errorPolicy']); 
@@ -3276,6 +3284,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 										$vb_skip_if_data_present = false;
 										$vb_treat_numeric_value_as_id = false;
 										$vs_item_error_policy = null;
+										$vs_displayname_format = null;
 									}
 								
 									$t_subject->clearErrors();
@@ -3294,7 +3303,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 												if ($vb_skip_if_data_present && ($t_subject->getLabelCount(true, $vn_locale_id) > 0)) { continue(2); }
 												
 												$t_subject->replaceLabel(
-													$va_element_content, $vn_locale_id, isset($va_element_content['type_id']) ? $va_element_content['type_id'] : null, true, array('truncateLongLabels' => $vb_truncate_long_labels)
+													$va_element_content, $vn_locale_id, isset($va_element_content['type_id']) ? $va_element_content['type_id'] : null, true, ['truncateLongLabels' => $vb_truncate_long_labels, 'displaynameFormat' => $vs_displayname_format]
 												);
 												if ($t_subject->numErrors() == 0) {
 													$vb_output_subject_preferred_label = true;
@@ -3325,7 +3334,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 										case 'nonpreferred_labels':
 											if ($vb_skip_if_data_present && ($t_subject->getLabelCount(false, $vn_locale_id) > 0)) { continue(2); }
 											$t_subject->addLabel(
-												$va_element_content, $vn_locale_id, isset($va_element_content['type_id']) ? $va_element_content['type_id'] : null, false, array('truncateLongLabels' => $vb_truncate_long_labels)
+												$va_element_content, $vn_locale_id, isset($va_element_content['type_id']) ? $va_element_content['type_id'] : null, false, ['truncateLongLabels' => $vb_truncate_long_labels, 'displaynameFormat' => $vs_displayname_format]
 											);
 										
 											if ($vs_error = DataMigrationUtils::postError($t_subject, _t("[%1] Could not add non-preferred label to %2:", $vs_idno, $t_subject->tableName()), __CA_DATA_IMPORT_ERROR__, array('dontOutputLevel' => true, 'dontPrint' => true))) {

--- a/app/models/ca_entity_labels.php
+++ b/app/models/ca_entity_labels.php
@@ -279,6 +279,7 @@ class ca_entity_labels extends BaseLabel {
 	public function insert($pa_options=null) {
 		if (!trim($this->get('surname')) && !trim($this->get('forename'))) {
 			// auto-split entity name if displayname is set
+			$we_set_displayname = false;
 			if($vs_display_name = trim($this->get('displayname'))) {
 			
 				if (($t_entity = caGetOption('subject', $pa_options, null)) && ($t_entity->getTypeSetting('entity_class') == 'ORG')) {
@@ -288,10 +289,11 @@ class ca_entity_labels extends BaseLabel {
 						'forename' => ''	
 					];
 				} else {
-					$va_label = DataMigrationUtils::splitEntityName($vs_display_name);
+					$va_label = DataMigrationUtils::splitEntityName($vs_display_name, $pa_options);
+					$we_set_displayname = true;
 				}
 				if(is_array($va_label)) {
-					unset($va_label['displayname']); // just make sure we don't mangle the user-entered displayname
+					if (!$we_set_displayname) { unset($va_label['displayname']); } // just make sure we don't mangle the user-entered displayname
 
 					foreach($va_label as $vs_fld => $vs_val) {
 						$this->set($vs_fld, $vs_val);
@@ -305,7 +307,6 @@ class ca_entity_labels extends BaseLabel {
 				return false;
 			}
 		}
-		
 		if (($t_entity = caGetOption('subject', $pa_options, null)) && ($t_entity->getTypeSetting('entity_class') == 'ORG')) {
 			$this->set('displayname', $this->get('surname'));
 		} elseif (!$this->get('displayname')) {


### PR DESCRIPTION
When matching entity preferred labels, current behavior is to match all elements of the name (forename, surname, middlename, etc). This should be expanded such that displayname is checked first, then forename/surname (without other elements), with options for full matching.

PR implement first element of required changes:
- Try matching display name first in splitters
- Apply skipIfEmpty and skipIfExpression options when determining preferred label mapping to use for matching (in cases where there are multiple conditional mappings)
-Pass through importer options to entity label setter, to allow for application of doNotParse option
