### PR TITLE
PROV-1037 Adjust timezone to UTC while processing Excel files to avoid date/time skew

### DIFF
--- a/app/lib/Import/DataReaders/ExcelDataReader.php
+++ b/app/lib/Import/DataReaders/ExcelDataReader.php
@@ -110,7 +110,7 @@ class ExcelDataReader extends BaseDataReader {
 				$o_cells = $o_row->getCellIterator();
 				$o_cells->setIterateOnlyExistingCells(false); 
 			
-				date_default_timezone_set('Europe/London');
+				date_default_timezone_set('UTC');
 				$vn_col = 1;
 				foreach ($o_cells as $o_cell) {
 					if (\PhpOffice\PhpSpreadsheet\Shared\Date::isDateTime($o_cell)) {


### PR DESCRIPTION
PR temporarily sets timezone to UTC during reading of Excel files for import to avoid skew of date/times from UTC to local timezone.