### PR TITLE
Data importer improvements

### DIFF
--- a/app/lib/BaseModelWithAttributes.php
+++ b/app/lib/BaseModelWithAttributes.php
@@ -154,7 +154,7 @@
 			                $vn_element_id = $o_value->getElementID();
 			                $vs_element_code = ca_metadata_elements::getElementCodeForId($vn_element_id);
 			                
-			                $pv = $o_value->getDisplayValue();
+			                $pv = $o_value->getDisplayValue(['dateFormat' => 'original']); // need to compare dates as-entered
 			                if (
 			                	(strlen($pa_values[$vn_element_id] && ($pa_values[$vn_element_id] != $pv)))
 			            		||


### PR DESCRIPTION
PR adds data importer improvements:

- Adds skipDuplicateValues mapping option to suppress duplicate import values across entire mapping
- Adds support for evaluation of skipIfEmpty and skipIfExpression options when determining which preferred label mapping to use for existingRecordPolicy evaluation. Previously the first found mapping would be used, regardless of options set.
- Avoids warnings when skipIfValue value is non-scalar.