### PR TITLE
NOJIRA Run event log content through Purifier as logs may contain unsafe content

### DIFF
--- a/app/lib/Logging/Eventlog.php
+++ b/app/lib/Logging/Eventlog.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2004-2012 Whirl-i-Gig
+ * Copyright 2004-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -83,7 +83,7 @@ class Eventlog extends BaseLogger {
 				(date_time, code, message, source)
 				VALUES
 				(unix_timestamp(), ?, ?, ?)
-			", $pa_entry["CODE"], $pa_entry["MESSAGE"], $pa_entry["SOURCE"]);
+			", $pa_entry["CODE"], $this->purify($pa_entry["MESSAGE"]), $pa_entry["SOURCE"]);
 			
 			return true;
 		}
@@ -125,7 +125,12 @@ class Eventlog extends BaseLogger {
 						ORDER BY date_time DESC
 					");
 				}
-				return $qr_log->getAllRows();
+				$entries = $qr_log->getAllRows();
+				$purifier = new HTMLPurifier();
+				return array_map(function($e) use ($purifier) { 
+					$e['message'] = $purifier->purify($e['message']);
+					return $e;
+				}, $entries);
 			}
 		}
 		return null;


### PR DESCRIPTION
PR filters event log content through HTML Purifier, as log content may in some cases include URL logs that contain unsafe content.