### PR TITLE
NOJIRA Fix broken Shibboleth/SAML adapter

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -276,13 +276,12 @@ shibboleth_service_provider = default-sp
 # Name of Shibboleth token cookie
 shibboleth_token_cookie = shib_test
 
-# Mapping of shibboleth fields to CA user fields. Required fields are marked
+# Mapping of CA user fields to Shibboleth attributes. Required fields are marked
 shibboleth_field_map = {
-	uid = user_name, #REQUIRED
-	eduPersonPrincipalName = email, #REQUIRED
-	givenName = fname,
-	sn = lname,
-	telephoneNumber = sms_number
+	uid = uid, #REQUIRED
+	email = eduPersonPrincipalName, #REQUIRED
+	fname = firstname,
+	lname = lastname
 }
 
 # Lists of roles and groups that are *always* added to automatically created new users

--- a/app/lib/Auth/Adapters/Shibboleth.php
+++ b/app/lib/Auth/Adapters/Shibboleth.php
@@ -69,14 +69,10 @@ class ShibbolethAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		}
 		if (!($attrs = $this->opo_shibAuth->getAttributes())) { return false; }
 	    
-	    
         $map = array_flip($this->auth_config->get('shibboleth_field_map'));
 	    $uid = array_shift($attrs[$map['uid']]);
 	    if (!$uid) { return false; }
-	    if (ca_users::find(['user_name' => $uid], ['returnAs' => 'count']) > 0) {
-	        return true;
-	    }
-	    return false;
+	    return true;
 	}
     # --------------------------------------------------------------------------------
 	/**


### PR DESCRIPTION
PR resolves issues caused by incorrect code merge on Shibboleth auth adapter, including incorrect auth return value (would return negative auth in many cases, even if credentials were correct); and clarifies attribute mapping.