### PR TITLE
Quick fix for Set list by user headings

### DIFF
--- a/app/controllers/manage/SetController.php
+++ b/app/controllers/manage/SetController.php
@@ -240,8 +240,6 @@
             
          
             $this->view->setVar('set_list', $va_set_list);
-            $this->view->setVar('type_name_singular', _t('user'));
-            $this->view->setVar('type_name_plural', _t('users'));
             
             $o_result_context->setAsLastFind();
             $o_result_context->setResultList($va_set_ids);

--- a/themes/default/views/manage/set_list_by_user_html.php
+++ b/themes/default/views/manage/set_list_by_user_html.php
@@ -87,6 +87,8 @@ if (!$this->request->isAjax()) {
 ?>
 	<div id="resultBox">
 <?php
+	$this->setVar('type_name_singular', _t('user')); 
+	$this->setVar('type_name_plural', _t('users'));
 	print $this->render('sets/paging_controls_html.php');
 ?>
 


### PR DESCRIPTION
Set list by user is a nested iteration, as it iterates over users, and for each user over the user's sets. The code sort of mixes both iterations, the pagination seems to happen only on users, instead of on sets or on users and sets. The shoehorning of both iterations into presentation  code meant for one results in the wrong heading being shown. This hack does not address the pagination issue, it just postpones setting the 'user' label into type_name_* for pagination purposes until after these variables have produced the right heading for the real set type. At least users are slightly less confused...