### PR TITLE
Make ListSetByUser always show all set types

### DIFF
--- a/app/controllers/manage/SetController.php
+++ b/app/controllers/manage/SetController.php
@@ -240,6 +240,8 @@
             
          
             $this->view->setVar('set_list', $va_set_list);
+            $this->view->setVar('type_name_singular', _t('user'));
+            $this->view->setVar('type_name_plural', _t('users'));
             
             $o_result_context->setAsLastFind();
             $o_result_context->setResultList($va_set_ids);
@@ -493,7 +495,7 @@
                 'displayName' => _t("Sets by user"),
                 'action' => 'ListSetsByUser',
                 "default" => ['module' => 'manage', 'controller' => 'Set', 'action' => 'ListSetsByUser'],
-                'parameters' => [],
+                'parameters' => ['list_set_type_id' => -1],
                 'is_enabled' => 1
             );
 


### PR DESCRIPTION
Another cheap fix proposal to un-confuse users listing sets by user... Make sure the menu selection for ListSetByUser always results in all set types being shown instead of depending on a context that may have captured choices of set type for previous listings by type. In general users are baffled when the same menu choice yields different listings. 