### PR TITLE
NOJIRA add option to mark "free" controllers that do not require authentication

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -19,6 +19,9 @@ auth_adapter = CaUsers
 # Note that a working email configuration is required for this to work.
 auth_allow_password_reset = 0
 
+# A list of controller names for which authentication will not be required
+#auth_not_required_for_controllers = [front]
+
 # Uncomment to display a 'manage account' link on the login page
 # manage_account_url = http://www.mysite.org/auth/manage
 

--- a/app/lib/Auth/AuthenticationManager.php
+++ b/app/lib/Auth/AuthenticationManager.php
@@ -85,6 +85,8 @@ class AuthenticationManager {
 	 */
 	public static function authenticate($ps_username, $ps_password="", $pa_options=null) {
 		self::init();
+		if(AuthenticationManager::isFree()) { return null; }
+
 		if ($vn_rc = self::$g_authentication_adapter->authenticate($ps_username, $ps_password, $pa_options)) {
 			return $vn_rc;
 		}
@@ -187,14 +189,11 @@ class AuthenticationManager {
 	 */
 	public static function getUserInfo($ps_username, $ps_password, $pa_options=null) {
 		self::init();
-
-        try {
-            if ($vn_rc = self::$g_authentication_adapter->getUserInfo($ps_username, $ps_password, $pa_options)) {
-                return $vn_rc;
-            }
-        } catch(Exception $e) {
-            // noop
-        }
+		if(AuthenticationManager::isFree()) { return null; }
+		
+		if ($vn_rc = self::$g_authentication_adapter->getUserInfo($ps_username, $ps_password, $pa_options)) {
+			return $vn_rc;
+		}
 
 		if ((AuthenticationManager::$g_authentication_conf->get('allow_fallback_to_ca_users_auth')) && !self::$g_authentication_adapter instanceof CaUsersAuthAdapter) {
 			// fall back to ca_users "native" authentication
@@ -234,6 +233,18 @@ class AuthenticationManager {
 		}
 
 		return null;
+	}
+	
+	/**
+	 *
+	 */
+	private static function isFree() {
+		global $g_request;
+		if($g_request) {
+			$free_controllers = array_map("strtolower", AuthenticationManager::$g_authentication_conf->get('auth_not_required_for_controllers'));
+			if (in_array(strtolower($g_request->getController()), $free_controllers)) { return true; }
+		}
+		return false;
 	}
 }
 


### PR DESCRIPTION
PR adds option to external auth that marks specific controllers a "free" and not requiring authentication. Primarily useful in Pawtucket for set up of public (not authenticated) areas.