### PR TITLE
PROV-1798 Fix capitialization of Javascript lib

### DIFF
--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -61,7 +61,7 @@ packages = {
 		extendext = jquery.extendext.js,
 		querybuilder = jquery-querybuilder/js/query-builder.js,
 		querybuildercss = jquery-querybuilder/css/query-builder.default.css:500,
-		dot = dot.js
+		dot = doT.js
 	},
 	# -----------------------
 	ca = {


### PR DESCRIPTION
PR corrects capitalization on name of doT.js library. Incorrect capitalization causes issues on Linux (but not MacOS).