### PR TITLE
Localize required_field_marker

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2195,7 +2195,7 @@ ca_site_page_media_id_numbering_plugin = MultipartIDNumber
 show_required_field_marker = 0
 
 # Text to display for bundles in editors for which input is required
-required_field_marker = <span style="color: #bb0000; font-size:10px; font-weight: bold;">(Required) </span>
+required_field_marker = <span style="color: #bb0000; font-size:10px; font-weight: bold;">_([Required])</span>
 
 # These are used to format data entry elements in various editing formats. Don't change them unless
 # you know what you're doing


### PR DESCRIPTION
Localize the default text in required_field_marker, for instances where show_required_field_marker is set to 1.

The text to be translated would not be picked up if maintained verbatim  (that is, _t((Required)) would not be localized at runtime for some reason tied to the use of parenthesis). Not knowing the escape rules (if any), I've cowardly moved the string to square brackets, with _t([Required]) working as expected. Installs using the default string will notice a change from (Required) to [Required]. Hope it helps anyway.