### PR TITLE
NOJIRA Prevent prepopulate plugin from clobbering other caUtils plugin commands - further fix.

### DIFF
--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -91,7 +91,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
         $tool->setSettings($pa_params[1]);
         $tool->setMode($pa_params[2]);
         
-        $pa_params['tool'] = $tool;
+        $pa_params[]['tool'] = $tool;
         return $pa_params;
     }
 	# --------------------------------------------------------------------------------------------


### PR DESCRIPTION
Previous fix didn't actually allow the commends to run, but did make them available in the command listing.