### PR TITLE
NOJIRA Modifications to improve performance with hierarchies containing a very large number of items in a single level

### DIFF
--- a/app/controllers/lookup/ObjectCollectionHierarchyController.php
+++ b/app/controllers/lookup/ObjectCollectionHierarchyController.php
@@ -367,7 +367,7 @@ class ObjectCollectionHierarchyController extends BaseLookupController {
 					$va_tmp['children'] = sizeof($qr_children->get("{$vs_table}.children.{$vs_pk}", ['returnAsArray' => true]));
 
 					if ($t_item->tableName() == 'ca_collections') {
-						$va_tmp['children'] += sizeof($qr_children->get('ca_objects.object_id', ['returnAsArray' => true, 'restrictToRelationshipTypes' => [$vs_object_collection_rel_type]]));
+						$va_tmp['children'] += sizeof($qr_children->get('ca_objects.object_id', ['limit' => 2, 'returnAsArray' => true, 'restrictToRelationshipTypes' => [$vs_object_collection_rel_type]]));
 					}
 
 					if (is_array($va_sorts)) {
@@ -422,7 +422,7 @@ class ObjectCollectionHierarchyController extends BaseLookupController {
 							'sortDirection' => $vs_object_sort_dir,
 							'restrictToRelationshipTypes' => array($vs_object_collection_rel_type),
 							'start' => $vn_start,
-							'limit' => $vn_max_items_per_page
+							'limit' => 2
 						), $vn_count
 					);
 

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -6358,6 +6358,7 @@ if (!$vb_batch) {
 			
 			if (!is_null($pn_count)) { $pn_count = $qr_res->numRows(); }
 			
+			$total = $qr_res->numRows();
 			if ($vb_uses_relationship_types)  {
 				$va_rel_types = $t_rel->getRelationshipInfo($t_tmp->tableName());
 				if(method_exists($t_tmp, 'getLeftTableName')) {
@@ -6375,7 +6376,7 @@ if (!$vb_batch) {
 			$va_relation_ids = $va_rels_for_id_by_date = [];
 			while($qr_res->nextRow()) {
 				$va_rels_for_id = [];
-				if (($vn_c >= $pn_limit) && !is_array($pa_sort_fields)) { break; }
+				if (($vn_c >= $pn_limit) && (($total > 1000) || !is_array($pa_sort_fields))) { break; }
 				
 				if (is_array($pa_primary_ids) && is_array($pa_primary_ids[$vs_related_table])) {
 					if (in_array($qr_res->get($vs_key), $pa_primary_ids[$vs_related_table])) { continue; }


### PR DESCRIPTION
PR mitigates two bottlenecks that can cause very slow performance when viewing hierarchies with large numbers of records in single hierarchy levels.