### PR TITLE
make $opn_value_id protected

### DIFF
--- a/app/lib/Attributes/Values/AttributeValue.php
+++ b/app/lib/Attributes/Values/AttributeValue.php
@@ -43,7 +43,7 @@ abstract class AttributeValue extends BaseObject {
 	private $opn_element_id;
 	private $ops_element_code;
 	private $opn_datatype;
-	private $opn_value_id;
+	protected $opn_value_id;
 	private $opa_source_info;
 	private $ops_sort_value;
 


### PR DESCRIPTION
Since MediaAttributeValue accesses this, it can't be private.