### PR TITLE
NOJIRA Fix indexing type for _content_ids fields.

### DIFF
--- a/app/lib/Plugins/SearchEngine/ElasticSearch/Mapping.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch/Mapping.php
@@ -495,6 +495,17 @@ class Mapping {
 				'format' => 'date_optional_time',
 				'ignore_malformed' => true
 			);
+
+			$va_mapping_config[$vs_table]['dynamic_templates'] = [
+				[
+					'content_ids' => [
+						'match' => '*_content_ids',
+						'mapping' => [
+							'type' => 'integer',
+						]
+					]
+				]
+			];
 		}
 		return $va_mapping_config;
 	}


### PR DESCRIPTION
* Use a dynamic template to always store these as integers so that we don't get exceptions when indexing records for this data type.


When sending the data to ES without this _depending how much / what type of data is in the system_ this can end with a Fatal error:
```
 PHP Fatal error:  Uncaught ApplicationException: Indexing error [illegal_argument_exception]: mapper [ca_object_labels/name_content_ids] cannot be changed from type [text] to [keyword] in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php:671
Stack trace:
#0 /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php(497): WLPlugSearchEngineElasticSearch->flushContentBuffer()
#1 /var/www/html/providence/app/lib/Search/SearchIndexer.php(1128): WLPlugSearchEngineElasticSearch->commitRowIndexing()
#2 /var/www/html/providence/app/lib/Search/SearchIndexer.php(264): SearchIndexer->indexRow('67', '322', Array, true)
#3 /var/www/html/providence/app/lib/Utils/CLIUtils/Search.php(50): SearchIndexer->reindex(NULL, Array)
#4 /var/www/html/providence/support/bin/caUtils(170): CLIUtils::rebuild_search_index(Object(Zend_Console_Getopt))
#5 {main}

Next ApplicationException: Indexing error [illegal_argument_exception]: mapper [ca_object_labels/name_content_ids] cannot be changed from type [text] to [keyword] in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php:671
Stack trace:
#0 /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php(357): WLPlugSearchEngineElasticSearch->flushContentBuffer()
#1 /var/www/html/providence/support/bin/caUtils(170): WLPlugSearchEngineElasticSearch->__destruct()
#2 {main}
  thrown in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php on line 671

Fatal error: Uncaught ApplicationException: Indexing error [illegal_argument_exception]: mapper [ca_object_labels/name_content_ids] cannot be changed from type [text] to [keyword] in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php:671
Stack trace:
#0 /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php(497): WLPlugSearchEngineElasticSearch->flushContentBuffer()
#1 /var/www/html/providence/app/lib/Search/SearchIndexer.php(1128): WLPlugSearchEngineElasticSearch->commitRowIndexing()
#2 /var/www/html/providence/app/lib/Search/SearchIndexer.php(264): SearchIndexer->indexRow('67', '322', Array, true)
#3 /var/www/html/providence/app/lib/Utils/CLIUtils/Search.php(50): SearchIndexer->reindex(NULL, Array)
#4 /var/www/html/providence/support/bin/caUtils(170): CLIUtils::rebuild_search_index(Object(Zend_Console_Getopt))
#5 {main}

Next ApplicationException: Indexing error [illegal_argument_exception]: mapper [ca_object_labels/name_content_ids] cannot be changed from type [text] to [keyword] in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php:671
Stack trace:
#0 /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php(357): WLPlugSearchEngineElasticSearch->flushContentBuffer()
#1 /var/www/html/providence/support/bin/caUtils(170): WLPlugSearchEngineElasticSearch->__destruct()
#2 {main}
  thrown in /var/www/html/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php on line 671
```