### PR TITLE
PROV-3084 Make sure default bundles are used

### DIFF
--- a/themes/default/views/administrate/setup/Results/ca_list_items_results_list_html.php
+++ b/themes/default/views/administrate/setup/Results/ca_list_items_results_list_html.php
@@ -81,7 +81,7 @@ if (!$this->getVar('no_hierarchies_defined')) {
 				</td>
 <?php
 				foreach($va_display_list as $vn_placement_id => $va_display_item) {
-					print "<td>".$t_display->getDisplayValue($vo_result, $vn_placement_id)."</td>";
+					print "<td>".$t_display->getDisplayValue($vo_result, ($vn_placement_id > 0) ? $vn_placement_id : $va_display_item['bundle_name'])."</td>";
 				}
 				print "<td class='listtableEditDelete'>".caEditorLink($this->request, caNavIcon(__CA_NAV_ICON_EDIT__, 2), 'list-button', 'ca_list_items', $vn_item_id, array());
 				print " <a href='#' onclick='caOpenBrowserWith({$vn_item_id}); return false;'>".caNavIcon(__CA_NAV_ICON_GO__, 2, array('title' => _t('View in hierarchy')))."</a>";

--- a/themes/default/views/administrate/setup/Results/ca_relationship_types_list_html.php
+++ b/themes/default/views/administrate/setup/Results/ca_relationship_types_list_html.php
@@ -100,7 +100,7 @@
 				</td>
 <?php
 				foreach($va_display_list as $vn_placement_id => $va_display_item) {
-					print "<td>".$t_display->getDisplayValue($vo_result, $vn_placement_id)."</td>";
+					print "<td>".$t_display->getDisplayValue($vo_result, ($vn_placement_id > 0) ? $vn_placement_id : $va_display_item['bundle_name'])."</td>";
 				}
 				print "<td class='listtableEditDelete'>".caEditorLink($this->request, caNavIcon(__CA_NAV_ICON_EDIT__, 2), 'editIcon', 'ca_relationship_types', $vn_type_id, array());
 				print " <a href='#' onclick='caOpenBrowserWith({$vn_type_id}); return false;' class='hierarchyIcon'>".caNavIcon(__CA_NAV_ICON_HIER__, 2, array('title' => _t('View in hierarchy'), 'style' => 'margin-top:5px;'), array('rotate' => 270))."</a>";


### PR DESCRIPTION
When using the default display in the Lists & Vocabularies editor or Relationship Type editor, all display values are blank. This PR ensures appropriate default bundle specs are used for these two views.