### PR TITLE
PROV-3085 Allow selection of root directory in media importer directory browser

### DIFF
--- a/assets/ca/ca.directorybrowser.js
+++ b/assets/ca/ca.directorybrowser.js
@@ -6,7 +6,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2020 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -376,6 +376,11 @@ var caUI = caUI || {};
 									}
 									return false;
 								});
+							} else if(item.type == 'FILE') {
+								jQuery('#' + newLevelListID + " li:last a:last").click(function() { 
+									that.deselectItem();
+									return false;
+								});
 							}
 							
 							if (item.type == 'DIR') {
@@ -512,6 +517,28 @@ var caUI = caUI || {};
 		
 			if (that.onSelection) {
 				that.onSelection(item_id, that.selectedItemIDs.join("/"), item.name, item.type);
+			}
+		}
+		// --------------------------------------------------------------------------------
+		// Clear user item selection
+		//
+		that.deselectItem = function() {
+			if (!that.allowSelection) return false;
+			
+			// set current selection display
+			if (that.currentSelectionDisplayID) {
+				jQuery('#' + that.currentSelectionDisplayID).html('');
+			}
+			
+			if (that.currentSelectionIDID) {
+				jQuery('#' + that.currentSelectionIDID).attr('value', null);
+			}
+			
+			that.selectedItemIDs = [];
+			jQuery('#' + that.container + '_scrolling_container').find('a').removeClass(that.classNameSelected).addClass(that.className);
+		
+			if (that.onSelection) {
+				that.onSelection(null, '', null, 'DESELECT');
 			}
 		}
 		// --------------------------------------------------------------------------------

--- a/themes/default/views/batch/mediaimport/import_options_html.php
+++ b/themes/default/views/batch/mediaimport/import_options_html.php
@@ -101,7 +101,7 @@
 			currentSelectionDisplayID: 'browseCurrentSelection',
 
 			onSelection: function(item_id, path, name, type) {
-				if (type == 'DIR') { jQuery('#caDirectoryValue').val(path); }
+				if (type == 'DIR') { jQuery('#caDirectoryValue').val(path); } else { jQuery('#caDirectoryValue').val(''); }
 			}
 		});
 
@@ -548,7 +548,8 @@
 	<script type="text/javascript">
 		function caShowConfirmBatchExecutionPanel() {
 			var msg = '<?php print addslashes(_t("You are about to import files from <em>%1</em>")); ?>';
-			msg = msg.replace("%1", jQuery('#caDirectoryValue').val());
+			var dir = jQuery('#caDirectoryValue').val();
+			msg = msg.replace("%1", dir ? dir : '<?= addslashes('the import root'); ?>');
 			caConfirmBatchExecutionPanel.showPanel();
 			jQuery('#caConfirmBatchExecutionPanelAlertText').html(msg);
 		}


### PR DESCRIPTION
PR implements ability to click on non-directories to deselect current directory, implicitly selecting root of directory hierarchy for import. Previously it was not possible to select the root directory once a sub-directory had been selected.