### PR TITLE
Optimise calculation of whether a mapping needs a refresh by using a single instance of the CA mapping.

### DIFF
--- a/app/lib/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch.php
@@ -111,7 +111,12 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 	 * @throws \Exception
 	 */
 	public function refreshMapping($pb_force=false) {
-		$o_mapping = new ElasticSearch\Mapping();
+
+		static $o_mapping;
+		if (!$o_mapping) {
+			$o_mapping= new ElasticSearch\Mapping();
+		}
+
 		if($o_mapping->needsRefresh() || $pb_force) {
 			foreach ($o_mapping->get() as $table => $va_config) {
 				$index_name = $this->getIndexName($table);


### PR DESCRIPTION
I did some profiling against the ItemService API and found that \ElasticSearch\Mapping::prefetchElementInfo was getting called a lot:

https://blackfire.io/profiles/9c0111fb-4a4f-4b2f-ac6e-4e0e4e6f637d/graph

This reuses a static mapping rather than newing one up a number of times during the request.

