### PR TITLE
PROV-3087 Backslash escapes in scalars in configuration aren't processed as in other entries

### DIFF
--- a/app/conf/search.conf
+++ b/app/conf/search.conf
@@ -30,7 +30,7 @@ search_sql_search_do_stemming = 1
 # -------------------
 
 # Set to 2 for version 2.x, 5 for 5.x, 6 for 6.x, 7 for 7.x
-elasticsearch_version = 6
+elasticsearch_version = 7
 
 # Enter the elastic search base url here (without any index names)
 search_elasticsearch_base_url = http://localhost:9200/
@@ -51,16 +51,16 @@ elasticsearch_indexing_buffer_size = 250
 # -------------------
 # Suffixes to add to searches if they conform to a listed regular expression
 search_suffixes = {
-#	[\d]+\.[0-9A-Za-z\.]* = *
+#	[\\d]+\\.[0-9A-Za-z\\.]* = *
 }
 
 # Regex character class used when indexing; values matched will be used as token delimiters
 # (in other words, the search expression will be broken into words wherever the matched characters are)
-indexing_tokenizer_regex = ^\pL\pN\pNd/_#\@\&\-
+indexing_tokenizer_regex = ^\\pL\\pN\\pNd/_#\\@\\&\\-
 
 # Regex character class used when searching; values matched will be used as token delimiters
 # (this is the same thing as indexing_tokenizer_regex except that it's used when searching rather than indexing)
-search_tokenizer_regex = ^\pL\pN\pNd/_#\@\&\-
+search_tokenizer_regex = ^\\pL\\pN\\pNd/_#\\@\\&\\-
 
 # List of regular expressions that if matched cause search input to be treated "as-is" - searched without processing
 # This is useful for preventing tokenization of accession numbers and other values that rely upon punctuation being
@@ -80,7 +80,7 @@ asis_regexes = [
 #
 idno_regexes = {
 	ca_objects = [
-		"[\d]{4}\\.[\d]{1,5}\\.[\d]{0,5}"
+		"[\\d]{4}\\.[\d]{1,5}\\.[\\d]{0,5}"
 	]
 }
 

--- a/app/lib/Configuration.php
+++ b/app/lib/Configuration.php
@@ -384,32 +384,59 @@ class Configuration {
 					# handle scalar values
 					case 20:
 						// end quote? -> accept scalar
-						if((trim($vs_token) == '"') && $vn_in_quote) {
-							if($vn_in_quote) {
-								$vn_in_quote = 0;
-								$vn_state = -1;
+						switch($vs_token) {
+							# -------------------
+							case '"':
+								if ($vb_escape_set || (!$vn_in_quote && strlen($vs_scalar_value))) {	// Quote in interior of scalar - assume literal
+									$vs_scalar_value .= '"';
+									if(sizeof($va_tokens) == 0) {
+										$this->ops_config_settings["scalars"][$vs_key] = $this->_trimScalar($vs_scalar_value);
+										$vn_in_quote = 0;
+										$vb_escape_set = false;
+										$vn_state = -1;
+									}
+								} else {
+									if (!$vn_in_quote) {	// Quoted scalar
+										$vn_in_quote = 1;
+									} else {
+										// Accept quoted scalar
+										$vn_in_quote = 0;
+										$vb_escape_set = false;
+										$vn_state = -1;
 
-								$this->ops_config_settings["scalars"][$vs_key] = $vs_scalar_value;
+										$this->ops_config_settings["scalars"][$vs_key] = $vs_scalar_value;
+									}
+								}
+								$vb_escape_set = false;
 								break;
-							}
-						}
-
-						if (preg_match("/[\r\n]/", $vs_token) && !$vn_in_quote) {
-							$this->ops_config_settings["scalars"][$vs_key] = $this->_trimScalar($vs_scalar_value);
-							$vn_state = -1;
-						} else {
-							if ((sizeof($va_tokens) == 0) && !$vn_in_quote) {
-								$vs_scalar_value .= $vs_token;
-
-								# accept scalar
-								$this->ops_config_settings["scalars"][$vs_key] = $this->_trimScalar($vs_scalar_value);
-
-								# initialize
-								$vn_state = -1;
-							} else { # keep going to next line
-								$vs_scalar_value .= $vs_token;
-								$vn_state = 20;
-							}
+							# -------------------
+							case '\\':
+								if ($vb_escape_set) {
+									$vs_scalar_value .= $vs_token;
+									$vb_escape_set = false;
+								} else {
+									$vb_escape_set = true;
+								}
+								break;
+							# -------------------
+							default:
+								if (preg_match("/[\r\n]/", $vs_token) && !$vn_in_quote) {	// Return ends scalar
+									$this->ops_config_settings["scalars"][$vs_key] = $this->_trimScalar($vs_scalar_value);
+									$vn_in_quote = 0;
+									$vb_escape_set = false;
+									$vn_state = -1;
+								} elseif ((sizeof($va_tokens) == 0) && !$vn_in_quote) {
+									$vs_scalar_value .= $vs_token;
+									$this->ops_config_settings["scalars"][$vs_key] = $this->_trimScalar($vs_scalar_value);
+									$vn_in_quote = 0;
+									$vb_escape_set = false;
+									$vn_state = -1;
+								} else { # keep going to next line
+									$vs_scalar_value .= $vs_token;
+									$vn_state = 20;
+								}
+								break;
+							# -------------------
 						}
 						break;
 					# ------------------------------------

--- a/tests/lib/ConfigurationTest.php
+++ b/tests/lib/ConfigurationTest.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -46,6 +46,8 @@ class ConfigurationTest extends TestCase {
 		$this->assertEquals('This scalar is embedded: "/usr/local/fish"', $o_config->get('a_scalar_using_an_embedded_macro'));
 		$this->assertEquals('Expreß zug: חי תהער', $o_config->get('a_scalar_with_utf_8_chars'));
 		$this->assertEquals( "Foo\nHello\nWorld\n", $o_config->get('a_scalar_with_line_breaks'));
+		$this->assertEquals( 'This is a " test of escaped @ characters', $o_config->get('a_scalar_with_escaped_characters'));
+		$this->assertEquals( 'This is a \" test of escaped \@ characters', $o_config->get('a_scalar_with_escaped_backslashes'));
 	}
 
 	public function testLists() {
@@ -136,7 +138,7 @@ class ConfigurationTest extends TestCase {
 
 		$va_keys = $o_config->getScalarKeys();
 		$this->assertTrue(is_array($va_keys));
-		$this->assertEquals(14, sizeof($va_keys));		// 13 in config file + 1 "LOCALE" value that's automatically inserted
+		$this->assertEquals(16, sizeof($va_keys));		// 15 in config file + 1 "LOCALE" value that's automatically inserted
 		$va_keys = $o_config->getListKeys();
 		$this->assertTrue(is_array($va_keys));
 		$this->assertEquals(6, sizeof($va_keys));

--- a/tests/lib/data/test.conf
+++ b/tests/lib/data/test.conf
@@ -8,6 +8,8 @@ a_scalar_with_line_breaks = "Foo
 Hello
 World
 "
+a_scalar_with_escaped_characters = This is a \" test of escaped \@ characters
+a_scalar_with_escaped_backslashes = This is a \\" test of escaped \\@ characters
 
 a_list = [clouds, rain, sun, gewitter]
 a_list_with_quoted_scalars = ["cloudy days", "rainy days, happy nights"]


### PR DESCRIPTION
For scalar configuration entries (standalone key-values) backslash escaped characters are not processed. This results in inconsistent behavior where backslashes are returned as-is. Need to process backslashes in scalars such that \<char> returns \<char> and <char> returns \<char>. PR changes parsing of scalar values to handle backslash escaping similarly to that done for list and associative values.