### PR TITLE
NOJIRA Check for existence

### DIFF
--- a/app/lib/Auth/AuthenticationManager.php
+++ b/app/lib/Auth/AuthenticationManager.php
@@ -241,8 +241,10 @@ class AuthenticationManager {
 	private static function isFree() {
 		global $g_request;
 		if($g_request) {
-			$free_controllers = array_map("strtolower", AuthenticationManager::$g_authentication_conf->get('auth_not_required_for_controllers'));
-			if (in_array(strtolower($g_request->getController()), $free_controllers)) { return true; }
+			if(is_array($free_controllers = AuthenticationManager::$g_authentication_conf->get('auth_not_required_for_controllers'))) {
+				$free_controllers = array_map("strtolower", $free_controllers);
+				if (in_array(strtolower($g_request->getController()), $free_controllers)) { return true; }
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
PR prevents warnings when authentication.conf file lacks `auth_not_required_for_controllers` setting.