### PR TITLE
PROV-2287 Avoid imagick/imagemagick color shifts

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -4767,7 +4767,6 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 							$magic = rand(0,99999);
 							$filepath = $vi["absolutePath"]."/".$dirhash."/".$magic."_".$this->_genMediaName($ps_field)."_".$v;
 
-                            $m->set('colorspace', 'RGB');
 							if (!($vs_output_file = $m->write($filepath, $output_mimetype, $va_media_write_options))) {
 								$this->postError(1600,_t("Couldn't write file: %1", join("; ", $m->getErrors())),"BaseModel->_processMedia()", $this->tableName().'.'.$ps_field);
 								$m->cleanup();

--- a/app/lib/Parsers/TilepicParser.php
+++ b/app/lib/Parsers/TilepicParser.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2004-2020 Whirl-i-Gig
+ * Copyright 2004-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -382,7 +382,7 @@ class TilepicParser {
 	}
 	# ------------------------------------------------
 	private function _imageMagickProcess($ps_source_filepath, $ps_dest_filepath, $pa_ops, $pn_quality=null) {
-		$va_ops = array('-colorspace RGB');
+		$va_ops = [];
 		if (!is_null($pn_quality)) {
 			$va_ops[] = '-quality '.intval($pn_quality);
 		}
@@ -436,7 +436,7 @@ class TilepicParser {
 	}
 	# ------------------------------------------------
 	private function _graphicsMagickProcess($ps_source_filepath, $ps_dest_filepath, $pa_ops, $pn_quality=null) {
-		$va_ops = array('-colorspace RGB');
+		$va_ops = [];
 		if (!is_null($pn_quality)) {
 			$va_ops[] = '-quality '.intval($pn_quality);
 		}
@@ -1099,9 +1099,11 @@ class TilepicParser {
         
         $h->setImageType(imagick::IMGTYPE_TRUECOLOR);
 
-		if (!$h->setImageColorspace(imagick::COLORSPACE_RGB)) {
-			$this->error = "Error during RGB colorspace transformation operation";
-			return false;
+		if ($h->getImageColorspace() === imagick::COLORSPACE_CMYK) {
+			if (!$h->setImageColorspace(imagick::COLORSPACE_RGB)) {
+				$this->error = "Error during RGB colorspace transformation operation";
+				return false;
+			}
 		}
 		
 		$va_tmp = $h->getImageGeometry();
@@ -1329,9 +1331,11 @@ class TilepicParser {
         
 		$h->setimagetype(Gmagick::IMGTYPE_TRUECOLOR);
 
-		if (!$h->setimagecolorspace(Gmagick::COLORSPACE_RGB)) {
-			$this->error = "Error during RGB colorspace transformation operation";
-			return false;
+		if ($h->getimagecolorspace() === Gmagick::COLORSPACE_CMYK) {
+			if (!$h->setimagecolorspace(Gmagick::COLORSPACE_RGB)) {
+				$this->error = "Error during RGB colorspace transformation operation";
+				return false;
+			}
 		}
 		
 		$image_width = 	$image_dimensions['width'];

--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2020 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *

--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -905,7 +905,7 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 						$this->handle->setimagedepth(1);
 						break;
 				}
-				if ($vn_colorspace) { $this->handle->setimagecolorspace($vn_colorspace); }
+				if (!is_null($vn_colorspace)) { $this->handle->setimagecolorspace($vn_colorspace); }
 			}
 			
 			# write the file
@@ -1229,9 +1229,12 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			$this->filepath = $ps_filepath;
 			
 			$background = caGetOption('background', $this->properties, "#FFFFFF");
-			if (!$this->handle->setimagecolorspace(Gmagick::COLORSPACE_RGB)) {
-				$this->postError(1610, _t("Error during RGB colorspace transformation operation"), "WLPlugGmagick->read()");
-				return false;
+			
+			if ($this->handle->getimagecolorspace(Gmagick::COLORSPACE_CMYK)) { 
+				if (!$this->handle->setimagecolorspace(Gmagick::COLORSPACE_RGB)) {
+					$this->postError(1610, _t("Error during RGB colorspace transformation operation"), "WLPlugGmagick->read()");
+					return false;
+				}
 			}
 		
 			// force all images to true color (takes care of GIF transparency for one thing...)

--- a/app/lib/Plugins/Media/GraphicsMagick.php
+++ b/app/lib/Plugins/Media/GraphicsMagick.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2020 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -1275,7 +1275,9 @@ class WLPlugMediaGraphicsMagick Extends BaseMediaPlugin Implements IWLPlugMedia 
 				if (!is_null($pn_quality)) {
 					array_unshift($va_ops['convert'], '-quality '.intval($pn_quality));
 				}
-				array_unshift($va_ops['convert'], '-colorspace RGB');
+				if($this->properties["colorspace"] === 'CMYK') {
+					array_unshift($va_ops['convert'], '-colorspace RGB');
+				}
 				caExec($this->ops_graphicsmagick_path.' convert '.caEscapeShellArg($vs_input_file.'[0]').' '.join(' ', $va_ops['convert']).' '.caEscapeShellArg($ps_filepath).(caIsPOSIX() ? " 2> /dev/null" : ""));
 				$vs_input_file = $ps_filepath;
 			}

--- a/app/lib/Plugins/Media/ImageMagick.php
+++ b/app/lib/Plugins/Media/ImageMagick.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2020 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -1384,7 +1384,10 @@ class WLPlugMediaImageMagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 				if (!is_null($pn_quality)) {
 					array_unshift($va_ops['convert'], '-quality '.intval($pn_quality));
 				}
-				array_unshift($va_ops['convert'], '-colorspace RGB');
+				
+				if($this->properties["colorspace"] === 'CMYK') {
+					array_unshift($va_ops['convert'], '-colorspace RGB');
+				}
 				caExec( join( ' ', array(
 					$this->commandWithDefaultArgs( 'convert' ),
 					caEscapeShellArg( $vs_input_file . '[0]' ),

--- a/app/lib/Plugins/Media/Imagick.php
+++ b/app/lib/Plugins/Media/Imagick.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -557,9 +557,11 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					// force all images to true color (takes care of GIF transparency for one thing...)
 					$this->handle->setImageType(imagick::IMGTYPE_TRUECOLOR);
 
-					if (!$this->handle->setImageColorspace(imagick::COLORSPACE_RGB)) {
-						$this->postError(1610, _t("Error during RGB colorspace transformation operation"), "WLPlugImagick->read()");
-						return false;
+					if($this->handle->getImageColorspace() === imagick::COLORSPACE_CMYK) {
+						if (!$this->handle->setImageColorspace(imagick::COLORSPACE_RGB)) {
+							$this->postError(1610, _t("Error during RGB colorspace transformation operation"), "WLPlugImagick->read()");
+							return false;
+						}
 					}
 					
 					$this->properties["mimetype"] = $this->_getMagickImageMimeType($this->handle);
@@ -963,7 +965,7 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			
 			$background = caGetOption('background', $this->properties, "#FFFFFF");
 			$this->handle->setImageBackgroundColor(new ImagickPixel($background));
-			$this->handle->setImageMatteColor(new ImagickPixel($background));
+			if(method_exists($this->handle, 'setImageMatteColor')) { $this->handle->setImageMatteColor(new ImagickPixel($background)); }
 		
 			if ($this->properties['gamma']) {
 				if (!$this->properties['reference-black']) { $this->properties['reference-black'] = 0; }
@@ -982,9 +984,6 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					case 'color':
 						$vn_colorspace = imagick::COLORSPACE_RGB;
 						break;
-					case 'sRGB':
-						$vn_colorspace = imagick::COLORSPACE_SRGB;
-						break;
 					case 'CMYK':
 						$vn_colorspace = imagick::COLORSPACE_CMYK;
 						break;
@@ -992,11 +991,15 @@ class WLPlugMediaImagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 						$vn_colorspace = imagick::COLORSPACE_GRAY;
 						$this->handle->setimagedepth(1);
 						break;
+					default:
+					case 'sRGB':
+						$vn_colorspace = imagick::COLORSPACE_SRGB;
+						break;
 				}
-				if ($vn_colorspace) { $this->handle->setimagecolorspace($vn_colorspace); }
+				if (!is_null($vn_colorspace) && ($vn_colorspace !== $this->handle->getImageColorspace())) { $this->handle->setimagecolorspace($vn_colorspace); }
 			}
 			
-			$this->handle->stripImage();	// remove all lingering metadata
+			//$this->handle->stripImage();	// remove all lingering metadata
 			
 			# write the file
 			try {


### PR DESCRIPTION
PR implements changes to avoid unnecessary colorspace changes which were causing color shifts in installations of ImageMagick without color management installed.