### PR TITLE
PROV-3089 Replace full profile load with XMLReader() streaming parser

### DIFF
--- a/install/profiles/xml/base.xml
+++ b/install/profiles/xml/base.xml
@@ -5144,23 +5144,11 @@
     
     <relationshipTable name="ca_loans_x_object_representations">
       <types>
-        <type code="lender" default="1">
+        <type code="part_of" default="1">
           <labels>
             <label locale="en_US">
-              <typename>is lent from</typename>
-              <typename_reverse>is lender of</typename_reverse>
-            </label>
-            <label locale="en_CA">
-              <typename>is lent from</typename>
-              <typename_reverse>is lender of</typename_reverse>
-            </label>
-            <label locale="fr_FR">
-              <typename>est prêté par</typename>
-              <typename_reverse>a prêté</typename_reverse>
-            </label>
-            <label locale="sv_SE">
-              <typename>lånas ut från</typename>
-              <typename_reverse>är långivare av</typename_reverse>
+              <typename>contains</typename>
+              <typename_reverse>part of</typename_reverse>
             </label>
           </labels>
           <subTypeLeft> </subTypeLeft>


### PR DESCRIPTION
The installer parses each installed profile in full in order to extract the name, description, status and locales. This is slow and unnecessary as the required information is always at the top of the file. For installations with many profiles, installer loading time is often > 10 seconds. 

This PR modifies profile information extraction to use a streaming XML parser that only reads profiles to the extent necessary and then bails. This results in much faster loading types - under 1 second in all cases tested so far.

PR also includes minor changes to base profile (base.xml) suggested by users.