### PR TITLE
NOJIRA update test to use current year interval

### DIFF
--- a/tests/testsWithData/queries/TimestampSearchQueryTest.php
+++ b/tests/testsWithData/queries/TimestampSearchQueryTest.php
@@ -72,7 +72,7 @@ class TimestampSearchQueryTest extends AbstractSearchQueryTest {
 			'created.administrator:' . date('Y') => 1,
 			'created.cataloguer:' . date('Y') => 0,
 			'created:"1985-1986"' => 0,
-			'created:"2000-2020"' => 1,
+			'created:"2010-2030"' => 1,
 		));
 	}
 	# -------------------------------------------------------


### PR DESCRIPTION
PR updates timestamp query test to use interval containing current year.