### PR TITLE
NOJIRA Cache data from getIndexedTables() to improve performance

### DIFF
--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -371,14 +371,14 @@ class SearchIndexer extends SearchBase {
 	 */
 	public function getDependencies($ps_subject_table) {
 		/* handle total cache miss (completely new cache has been generated) */
-		if(ExternalCache::contains('ca_table_dependency_array')) {
-			$va_cache_data = ExternalCache::fetch('ca_table_dependency_array');
+		if(ExternalCache::contains('ca_table_dependency_array', 'SearchIndexer')) {
+			$va_cache_data = ExternalCache::fetch('ca_table_dependency_array', 'SearchIndexer');
 		}
 
 		/* cache outdated? (i.e. changes to search_indexing.conf) */
 		$va_configfile_stat = stat(__CA_CONF_DIR__.'/search_indexing.conf');
-		if($va_configfile_stat['mtime'] != ExternalCache::fetch('ca_table_dependency_array_mtime')) {
-			ExternalCache::save('ca_table_dependency_array_mtime', $va_configfile_stat['mtime']);
+		if($va_configfile_stat['mtime'] != ExternalCache::fetch('ca_table_dependency_array_mtime', 'SearchIndexer')) {
+			ExternalCache::save('ca_table_dependency_array_mtime', $va_configfile_stat['mtime'], 'SearchIndexer');
 			$va_cache_data = array();
 		}
 
@@ -391,7 +391,7 @@ class SearchIndexer extends SearchBase {
 			/* build dependency graph, store it in cache and return it */
 			$va_deps = $this->_getDependencies($ps_subject_table);
 			$va_cache_data[$ps_subject_table] = $va_deps;
-			ExternalCache::save('ca_table_dependency_array', $va_cache_data);
+			ExternalCache::save('ca_table_dependency_array', $va_cache_data, 'SearchIndexer');
 			return $va_deps;
 		}
 	}

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -115,7 +115,7 @@ class SearchIndexer extends SearchBase {
 	 * Returns a list of tables the require indexing
 	 */
 	public function getIndexedTables() {
-		if(ExternalCache::contains('getIndexedTables')) {  return ExternalCache::fetch('getIndexedTables'); };
+		if(ExternalCache::contains('getIndexedTables', 'SearchIndexer')) {  return ExternalCache::fetch('getIndexedTables', 'SearchIndexer'); };
 		$va_table_names = Datamodel::getTableNames();
 
 		$o_db = $this->opo_db;

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -115,6 +115,7 @@ class SearchIndexer extends SearchBase {
 	 * Returns a list of tables the require indexing
 	 */
 	public function getIndexedTables() {
+		if(ExternalCache::contains('getIndexedTables')) {  return ExternalCache::fetch('getIndexedTables'); };
 		$va_table_names = Datamodel::getTableNames();
 
 		$o_db = $this->opo_db;
@@ -127,7 +128,7 @@ class SearchIndexer extends SearchBase {
 				continue;
 			}
 
-			$qr_all = $o_db->query("SELECT count(*) c FROM $vs_table");
+			$qr_all = $o_db->query("SELECT count(*) c FROM {$vs_table}".($t_instance->hasField('delete') ? "WHERE deleted = 0" : ""));
 			$qr_all->nextRow();
 			$vn_num_rows = (int)$qr_all->get('c');
 
@@ -143,6 +144,7 @@ class SearchIndexer extends SearchBase {
 			$va_sorted_tables[$va_tables_to_index[$vs_table]['num']] = $va_tables_to_index[$vs_table];
 		}
 
+		ExternalCache::save('getIndexedTables', $va_sorted_tables, 'SearchIndexer', 3600);
 		return $va_sorted_tables;
 	}
 	# -------------------------------------------------------


### PR DESCRIPTION
PR puts cache in front of getIndexedTables() to nominally improve performance.