### PR TITLE
Fix minor code issues found in static analysis

### DIFF
--- a/app/lib/Attributes/Values/AttributeValue.php
+++ b/app/lib/Attributes/Values/AttributeValue.php
@@ -43,7 +43,7 @@ abstract class AttributeValue extends BaseObject {
 	private $opn_element_id;
 	private $ops_element_code;
 	private $opn_datatype;
-	private $opn_value_id;
+	protected $opn_value_id;
 	private $opa_source_info;
 	private $ops_sort_value;
 

--- a/app/lib/Parsers/ExpressionParser.php
+++ b/app/lib/Parsers/ExpressionParser.php
@@ -57,7 +57,7 @@ class ExpressionParser {
 		// init compiler/visitor if necessary
 
 		if(!self::$s_compiler) {
-			self::$s_compiler = Hoa\Compiler\Llk::load(
+			self::$s_compiler = Hoa\Compiler\Llk\Llk::load(
 				new Hoa\File\Read(__CA_LIB_DIR__.'/Parsers/ExpressionParser/ExpressionGrammar.pp')
 			);
 		}


### PR DESCRIPTION
PR adds two suggestions for Tac:
1. value_id attribute should be protected in attribute base class to allow access from subclasses
2. HOA class name is incorrect (oddly both the incorrect and "correct" versions work without error)