### PR TITLE
PROV-1798 Don't use unsupported character class – throws errors in PHP 7.2

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -357,7 +357,7 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 	 	//	2. Search for is blank values
 	 	//	3. Search is not non-blank values
 	 	//	4. Search includes non-letter characters
-	 	if ($this->do_stemming && !$is_blank && !$is_not_blank && !preg_match("![^\L]+!u", $text)) {
+	 	if ($this->do_stemming && !$is_blank && !$is_not_blank && !preg_match("![^A-Za-z]+!u", $text)) {
 	 		$text_stem = $this->stemmer->stem($text);
 	 		if (($text !== $text_stem) && ($text_stem[strlen($text_stem)-1] !== '*')) { 
 	 			$text = $text_stem.'*';


### PR DESCRIPTION
PR changes stemming criteria to require ascii letter rather than unicode letter class, which throws errors in PHP 7.2 and on systems built against older PCRE libraries. Since stemming is english-specific, requiring an ascii character to initiate stemming seems reasonable.