### PR TITLE
PROV-3093 Add ignoreType and ignoreParent refinery options to hierarchy builder refineries

### DIFF
--- a/app/lib/Utils/DataMigrationUtils.php
+++ b/app/lib/Utils/DataMigrationUtils.php
@@ -202,7 +202,6 @@
 				if ($o_log) { $o_log->logError(_t("%2Could not find list with list code %1", $pm_list_code_or_id, $log_reference_str)); }
 				return DataMigrationUtils::$s_cached_list_item_ids[$vs_cache_key] = null;
 			}
-			if ($pb_ignore_parent) { $vn_parent_id = false; }
 			if (!$vn_parent_id && ($vn_parent_id !== false)) { $vn_parent_id = caGetListRootID($pm_list_code_or_id); }
 			
 
@@ -225,7 +224,7 @@
 						$vs_label_spec = ($vs_match_on == 'nonpreferred_labels') ? 'nonpreferred_labels' : 'preferred_labels';
 						if (trim($vs_singular_label) || trim($vs_plural_label)) {
 							$va_criteria = array($vs_label_spec => array('name_singular' => $vs_singular_label), 'list_id' => $vn_list_id);
-							if ($vn_parent_id !== false) { $va_criteria['parent_id'] = $vn_parent_id; }
+							if (($vn_parent_id !== false) && !$pb_ignore_parent) { $va_criteria['parent_id'] = $vn_parent_id; }
 							if ($vn_item_id = (ca_list_items::find($va_criteria, array('returnAs' => 'firstId', 'purifyWithFallback' => true, 'transaction' => $pa_options['transaction'], 'restrictToTypes' => $va_restrict_to_types)))) {
 								if ($o_log) { $o_log->logDebug(_t("%4Found existing list item %1 (member of list %2) in DataMigrationUtils::getListItemID() using singular label %3", $ps_item_idno, $pm_list_code_or_id, $vs_singular_label, $log_reference_str)); }
 								break(2);
@@ -241,7 +240,7 @@
 					case 'idno':
 						if ($ps_item_idno == '%') { break; }	// don't try to match on an unreplaced idno placeholder
 						$va_criteria = array('idno' => $ps_item_idno ? $ps_item_idno : $vs_plural_label, 'list_id' => $vn_list_id);
-						if ($vn_parent_id !== false) { $va_criteria['parent_id'] = $vn_parent_id; }
+						if (($vn_parent_id !== false) && !$pb_ignore_parent) { $va_criteria['parent_id'] = $vn_parent_id; }
 						if ($vn_item_id = (ca_list_items::find($va_criteria, array('returnAs' => 'firstId', 'purifyWithFallback' => true, 'transaction' => $pa_options['transaction'], 'restrictToTypes' => $va_restrict_to_types)))) {
 							if ($o_log) { $o_log->logDebug(_t("%4Found existing list item %1 (member of list %2) in DataMigrationUtils::getListItemID() using idno with %3", $ps_item_idno, $pm_list_code_or_id, $ps_item_idno, $log_reference_str)); }
 							break(2);

--- a/app/lib/Utils/DataMigrationUtils.php
+++ b/app/lib/Utils/DataMigrationUtils.php
@@ -137,7 +137,7 @@
 		 * @param string/int $pn_type_id
 		 * @param int $pn_locale_id
 		 * @param null/array $pa_values
-		 * @param array $pa_options An optional array of options. See DataMigrationUtils::_getID() for a list.
+		 * @param array $pa_options An optional array of options. See DataMigrationUtils::_getID() for a list. Note that the default for ignoreType for list items is true.
 		 * @return bool|ca_list_items|mixed|null
 		 *
 		 * @see DataMigrationUtils::_getID()
@@ -162,7 +162,7 @@
 			if(!isset($pa_options['cache'])) { $pa_options['cache'] = true; }
 			
 			
-			$va_restrict_to_types 			= ($pn_type_id && !caGetOption('ignoreType', $pa_options, false)) ? [$pn_type_id] : null;
+			$va_restrict_to_types 			= ($pn_type_id && !caGetOption('ignoreType', $pa_options, true)) ? [$pn_type_id] : null;
 			$pb_ignore_parent			 	= caGetOption('ignoreParent', $pa_options, false);
 			
 			$log_reference 					= caGetOption('logReference', $pa_options, null);

--- a/app/refineries/collectionHierarchyBuilder/collectionHierarchyBuilderRefinery.php
+++ b/app/refineries/collectionHierarchyBuilder/collectionHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -125,5 +125,23 @@
 			'default' => '',
 			'label' => _t('Parents'),
 			'description' => _t('Collection parents to create')
+		),
+		'collectionHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'collectionHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/app/refineries/collectionIndentedHierarchyBuilder/collectionIndentedHierarchyBuilderRefinery.php
+++ b/app/refineries/collectionIndentedHierarchyBuilder/collectionIndentedHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2019-2020 Whirl-i-Gig
+ * Copyright 2019-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -259,5 +259,23 @@
 				'default' => '',
 				'label' => _t('Relationships'),
 				'description' => _t('List of relationships to process.')
+			),			
+			'collectionIndentedHierarchyBuilder_ignoreParent' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 10, 'height' => 1,
+				'takesLocale' => false,
+				'default' => '',
+				'label' => _t('Ignore parent when trying to match row'),
+				'description' => _t('Ignore parent when trying to match row.')
 			),
+			'collectionIndentedHierarchyBuilder_ignoreType' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 10, 'height' => 1,
+				'takesLocale' => false,
+				'default' => '',
+				'label' => _t('Ignore type when trying to match row'),
+				'description' => _t('Ignore type when trying to match row.')
+			)
 		);

--- a/app/refineries/entityHierarchyBuilder/entityHierarchyBuilderRefinery.php
+++ b/app/refineries/entityHierarchyBuilder/entityHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -124,5 +124,23 @@
 			'default' => '',
 			'label' => _t('Do not parse name'),
 			'description' => _t('Take the entity name as is from the data source and insert it without intervention in the surname and display name fields. This is often useful for organization names, especially when using the entity class "org" setting.')
+		),
+		'entityHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'entityHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/app/refineries/listItemHierarchyBuilder/listItemHierarchyBuilderRefinery.php
+++ b/app/refineries/listItemHierarchyBuilder/listItemHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -109,6 +109,24 @@
 	
 	BaseRefinery::$s_refinery_settings['listItemHierarchyBuilder'] = array(		
 		'listItemHierarchyBuilder_matchOn' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_SELECT,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Match on'),
+			'description' => _t('List indicating sequence of checks for an existing record; values of array can be "preferred_labels" (or "label"), "nonpreferred_labels", "idno" or a metadata element code. Ex. array("idno", "label") will first try to match on idno and then label if the first match fails')
+		),
+		'listItemHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'listItemHierarchyBuilder_ignoreType' => array(
 			'formatType' => FT_TEXT,
 			'displayType' => DT_SELECT,
 			'width' => 10, 'height' => 1,

--- a/app/refineries/listItemIndentedHierarchyBuilder/listItemIndentedHierarchyBuilderRefinery.php
+++ b/app/refineries/listItemIndentedHierarchyBuilder/listItemIndentedHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -229,6 +229,24 @@
 				),
 				'label' => _t('Operating mode'),
 				'description' => _t('Set to "returnData" to return the id of lowest item in the hierarchy to the importer; set to "processOnly" to create the list items in the hierarchy but not return values to the importer. Default is to process only.')
+			),			
+			'listItemIndentedHierarchyBuilder_ignoreParent' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 10, 'height' => 1,
+				'takesLocale' => false,
+				'default' => '',
+				'label' => _t('Ignore parent when trying to match row'),
+				'description' => _t('Ignore parent when trying to match row.')
+			),
+			'listItemIndentedHierarchyBuilder_ignoreType' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 10, 'height' => 1,
+				'takesLocale' => false,
+				'default' => '',
+				'label' => _t('Ignore type when trying to match row'),
+				'description' => _t('Ignore type when trying to match row.')
 			)
 		);
 ?>

--- a/app/refineries/objectHierarchyBuilder/objectHierarchyBuilderRefinery.php
+++ b/app/refineries/objectHierarchyBuilder/objectHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -134,5 +134,23 @@
 			'default' => '',
 			'label' => _t('Do not match on label'),
 			'description' => _t('set to prohibit matching using label')
+		),
+		'objectHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'objectHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/app/refineries/occurrenceHierarchyBuilder/occurrenceHierarchyBuilderRefinery.php
+++ b/app/refineries/occurrenceHierarchyBuilder/occurrenceHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -125,5 +125,23 @@
 			'default' => '',
 			'label' => _t('Parents'),
 			'description' => _t('Occurrence parents to create')
+		),
+		'occurrenceHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'occurrenceHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/app/refineries/placeHierarchyBuilder/placeHierarchyBuilderRefinery.php
+++ b/app/refineries/placeHierarchyBuilder/placeHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -162,5 +162,23 @@
 			'default' => '',
 			'label' => _t('Parents'),
 			'description' => _t('Place parents to create')
+		),
+		'placeHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'placeHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/app/refineries/storageLocationHierarchyBuilder/storageLocationHierarchyBuilderRefinery.php
+++ b/app/refineries/storageLocationHierarchyBuilder/storageLocationHierarchyBuilderRefinery.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2016 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -125,5 +125,23 @@
 			'default' => '',
 			'label' => _t('Parents'),
 			'description' => _t('Storage location parents to create')
+		),
+		'storageLocationHierarchyBuilder_ignoreParent' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore parent when trying to match row'),
+			'description' => _t('Ignore parent when trying to match row.')
+		),
+		'storageLocationHierarchyBuilder_ignoreType' => array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 10, 'height' => 1,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Ignore type when trying to match row'),
+			'description' => _t('Ignore type when trying to match row.')
 		)
 	);

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -7358,7 +7358,6 @@ create table if not exists ca_media_upload_sessions (
    index i_created_on			    (created_on),
    index i_completed_on			    (completed_on),
    index i_last_activity_on			(last_activity_on),
-   index i_cancelled      	        (cancelled),
    index i_error_code      	        (error_code),
    index i_status   	            (status),
    unique index i_session_key      	(session_key)


### PR DESCRIPTION
PR adds to data importer two record matching modifiers that are currently only available in splitter refineries, ignoreType and ignoreParent. These would be useful for hierarchy builders as well, when parents to be matched may include items imported by the primary mapping.