### PR TITLE
PROV-3094 Fix broken existing record policy checks for ca_list_items due

### DIFF
--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -1873,7 +1873,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				
 				$va_base_criteria = ($vs_type && !(bool)$t_mapping->getSetting('ignoreTypeForExistingRecordPolicy')) ? ['type_id' => $vs_type] : [];
 				if($vn_list_mapping_list_id !== null ) {
-				    $va_base_criteria['list_id'] = $vn_list_mapping_list_id;
+				    $va_base_criteria['list_id'] = caGetListID(ca_data_importers::getValueFromSource($va_mapping_items[$vn_list_mapping_list_id], $o_reader, array('otherValues' => $va_rule_set_values, 'environment' => $va_environment, 'log' => $o_log, 'logReference' => $vs_idno)));
 				}  
 				
 				if (is_array($pa_force_import_for_primary_keys) && sizeof($pa_force_import_for_primary_keys) > 0) {


### PR DESCRIPTION
PR resolves issue where existing record checks in the importer were not being honored when importing list items due to incorrect injection of list context. The item_id of the list_id mapping was being injected, rather than the actual numeric list_id.