### PR TITLE
PROV-3066 Use standard PDF when compression fails

### DIFF
--- a/app/lib/Plugins/Media/PDFWand.php
+++ b/app/lib/Plugins/Media/PDFWand.php
@@ -590,12 +590,13 @@ class WLPlugMediaPDFWand Extends BaseMediaPlugin implements IWLPlugMedia {
 				if (!in_array($compress, ['screen', 'ebook', 'printer', 'prepress', 'default'], true)) { $compress = 'default'; }
 				
 				caExec($this->ops_ghostscript_path." -dPDFSETTINGS=/{$compress} -dAutoRotatePages=/None -dNumRenderingThreads=6 -dNOPAUSE -dBATCH -sDEVICE=pdfwrite {$vs_antialiasing} -dMaxPatternBitmap=1000000 -dBandBufferSpace=500000000 -sBandListStorage=memory -dBufferSpace=1000000000 -dBandHeight=100 -sOutputFile=".caEscapeShellArg($ps_filepath.".".$vs_ext)." -c \"30000000 setvmthreshold\" -f ".caEscapeShellArg($this->handle["filepath"]).(caIsPOSIX() ? " 2> /dev/null" : ""), $va_output, $vn_return);
-				if($vn_return == 0) {
-					$va_files[] = "{$ps_filepath}.{$vs_ext}";
-				} else {
-					$this->postError(1610, _t("Couldn't write compressed PDF file to '%1'", $ps_filepath), "WLPlugPDFWand->write()");
-					return false;
+				if($vn_return != 0) {
+					if (!copy($this->filepath, $ps_filepath.".pdf")) {
+						$this->postError(1610, _t("Couldn't write file to '%1'", $ps_filepath), "WLPlugPDFWand->write()");
+						return false;
+					}
 				}
+				$va_files[] = "{$ps_filepath}.{$vs_ext}";
 			} elseif (!copy($this->filepath, $ps_filepath.".pdf")) {
 				$this->postError(1610, _t("Couldn't write file to '%1'", $ps_filepath), "WLPlugPDFWand->write()");
 				return false;


### PR DESCRIPTION
PR changes PDF processing behavior to use standard uploaded PDF as "compressed" version when compression fails. The previous behavior threw an error when Ghostscript compression failed and effectively made some PDFs un-uploadable.