### PR TITLE
Add support for `Custom` paper size when printing.

### DIFF
--- a/app/helpers/printHelpers.php
+++ b/app/helpers/printHelpers.php
@@ -290,7 +290,7 @@ use Zend\Stdlib\Glob;
 				$ps_value_in_points = $va_matches[1] * ($vn_dpi/2.54);
 				break;
 			case 'mm':
-				$ps_value_in_points = $va_matches[1] * ($vn_dpi/24.4);
+				$ps_value_in_points = $va_matches[1] * ($vn_dpi/25.4);
 				break;
 			case '':
 			case 'px':
@@ -327,10 +327,10 @@ use Zend\Stdlib\Glob;
 				return $vn_in_points/72;
 				break;
 			case 'cm':
-				return $vn_in_points/28.346;
+				return $vn_in_points/28.3465;
 				break;
 			case 'mm':
-				return $vn_in_points/2.8346;
+				return $vn_in_points/2.83465;
 				break;
 			default:
 			case 'px':

--- a/app/lib/Plugins/PDFRenderer/wkhtmltopdf.php
+++ b/app/lib/Plugins/PDFRenderer/wkhtmltopdf.php
@@ -113,11 +113,18 @@ class WLPlugPDFRendererwkhtmltopdf Extends BasePDFRendererPlugIn Implements IWLP
 		
 		file_put_contents($vs_content_path = caMakeGetFilePath("wkhtmltopdf", "html"), $content); 
 		file_put_contents($vs_header_path = caMakeGetFilePath("wkhtmltopdf", "html"), $vs_header); 
-		file_put_contents($vs_footer_path = caMakeGetFilePath("wkhtmltopdf", "html"), $vs_footer); 
+		file_put_contents($vs_footer_path = caMakeGetFilePath("wkhtmltopdf", "html"), $vs_footer);
 		$vs_output_path = caMakeGetFilePath("wkhtmltopdf", "pdf", ['useAppTmpDir' => true]);
-		
-		caExec($this->ops_wkhtmltopdf_path." --enable-local-file-access  --disable-smart-shrinking --dpi 96 --encoding UTF-8 --margin-top {$this->ops_margin_top} --margin-bottom {$this->ops_margin_bottom} --margin-left {$this->ops_margin_left} --margin-right {$this->ops_margin_right} --page-size {$this->ops_page_size} --orientation {$this->ops_page_orientation} page ".caEscapeShellArg($vs_content_path)." --header-html {$vs_header_path} --footer-html {$vs_footer_path} {$vs_output_path}", $va_output, $vn_return);	
-		
+		if (PDFRenderer::isCustomPageSize($this->ops_page_size)){
+			$vs_page_size_arg = '';
+			$va_size = PDFRenderer::getPageSize($this->ops_page_size, null, $this->ops_page_orientation);
+			foreach($va_size as $vs_name => $vs_value) {
+				$vs_page_size_arg .= "--page-$vs_name $vs_value ";
+			}
+		} else {
+			$vs_page_size_arg = "--page-size {$this->ops_page_size}";
+		}
+		caExec($this->ops_wkhtmltopdf_path." --enable-local-file-access  --disable-smart-shrinking --print-media-type --dpi 96 --encoding UTF-8 --margin-top {$this->ops_margin_top} --margin-bottom {$this->ops_margin_bottom} --margin-left {$this->ops_margin_left} --margin-right {$this->ops_margin_right} {$vs_page_size_arg} --orientation {$this->ops_page_orientation} page ".caEscapeShellArg($vs_content_path)." --header-html {$vs_header_path} --footer-html {$vs_footer_path} {$vs_output_path}", $va_output, $vn_return);
 		$vs_pdf_content = file_get_contents($vs_output_path);
 		if (caGetOption('stream', $options, false)) {
 			header("Cache-Control: private");


### PR DESCRIPTION
* Enable wkhtmltopdf support for custom page size and print media queries.
  * use --page-height and --page-width for custom page size
  * Use --page-size for standard page size
* Fix calculation of points when initial measurement is in mm (25.4 mm in an inch).
* More precision when calculating metric lengths from point.

This is specified as follows:
```
 * @pageSize Custom(89mm,28.5mm)
```