### PR TITLE
PROV-3097 Broken hierarchy location bundle when strict type checking is enabled

### DIFF
--- a/themes/default/views/bundles/hierarchy_location.php
+++ b/themes/default/views/bundles/hierarchy_location.php
@@ -376,7 +376,7 @@
 		</div>
 <?php
 	}
-		if ($show_add_object) {
+	if ($show_add_object) {
 ?>
 			<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-addObject"  class="hierarchyBrowseTab">
 				<div class="hierarchyBrowserMessageContainer">
@@ -582,7 +582,7 @@
 <?php
 	}
 	
-	if (!$vb_batch && (!$vb_read_only && $vb_has_privs) && (!$strict_type_hierarchy || ($strict_type_hierarchy && $vs_type_selector))) {
+	if ($show_add) {
 ?>
 	// Set up "add" hierarchy browser
 	var o<?php print $vs_id_prefix; ?>AddHierarchyBrowser = null;
@@ -608,7 +608,7 @@
 <?php
 	}
 	
-	if ((!$vb_batch && !$vb_read_only && $vb_has_privs) && $vb_objects_x_collections_hierarchy_enabled && ($t_subject->tableName() == 'ca_collections')) {
+	if ($show_add_object) {
 ?>
 	// Set up "add object" hierarchy browser
 	var o<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser = null;

--- a/themes/default/views/bundles/hierarchy_location.php
+++ b/themes/default/views/bundles/hierarchy_location.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -376,7 +376,7 @@
 		</div>
 <?php
 	}
-		if ((!$vb_read_only && $vb_has_privs && !$vb_batch) && $vb_objects_x_collections_hierarchy_enabled && ($t_subject->tableName() == 'ca_collections')) {
+		if ($show_add_object) {
 ?>
 			<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-addObject"  class="hierarchyBrowseTab">
 				<div class="hierarchyBrowserMessageContainer">


### PR DESCRIPTION
PR addresses issue where the Location in Hierarchy (`hierarchy_location`) bundle appears broken when strict type checking is enabled for collections and object-collection hierarchies are enabled. Issue is due to improper hiding of "add object" pane while "add object" table is correct suppressed.