### PR TITLE
NOJIRA calling rotate() with null value causes errors on some systems

### DIFF
--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -1519,7 +1519,7 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 					break;
 			}
 			
-			$this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), $rotation);
+			if ($rotation) { $this->handle->rotateImage(caGetOption('background', $this->properties, "#FFFFFF"), $rotation); }
 						
 			if (($rotation) && (abs($rotation) === 90)) {
 				$w = $this->properties["width"]; $h = $this->properties["height"];


### PR DESCRIPTION
PR prevents null calls to gmagick rotation, which cause errors on some systems (and are never needed in any event).