### PR TITLE
NOJIRA return values in repeating structure as required.

### DIFF
--- a/app/lib/Import/DataReaders/FMPXMLResultReader.php
+++ b/app/lib/Import/DataReaders/FMPXMLResultReader.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2014-2019 Whirl-i-Gig
+ * Copyright 2014-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -184,8 +184,8 @@ class FMPXMLResultReader extends BaseXMLDataReader {
 			$row = $this->opa_row_buf['/COL'];
 			$row_with_labels = [];
 			foreach($this->opa_metadata as $i => $l) {
-				$row_with_labels[$l] = $row[$i];
-				$row_with_labels[strtolower($l)] = $row[$i];
+				$row_with_labels[$l][] = $row[$i];
+				$row_with_labels[strtolower($l)][] = $row[$i];
 			}
 			$this->opa_row_buf = $row_with_labels;
 		}


### PR DESCRIPTION
PR modified FileMakerPro XML import data reader to return values in repeating structure, as implied by reader settings. Without this change the reader is broken in most scenarios.