### PR TITLE
PROV-2793 Refactor return to home location endpoint

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3542,7 +3542,7 @@ require_once(__CA_LIB_DIR__.'/Media/MediaInfoCoder.php');
 									caBundleUpdateManager.reloadBundle('history_tracking_current_contents'); 
 									caBundleUpdateManager.reloadBundle('ca_storage_locations_current_contents'); 
 									caBundleUpdateManager.reloadBundle('{$target}'); 
-								}, 3000);
+								}, 2000);
 							}
 					}, 'json');
 				}

--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2018-2020 Whirl-i-Gig
+ * Copyright 2018-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -2237,7 +2237,7 @@
 								$field_class = '';
 								break;
 						}
-						$buf .= "<td><div class='formLabel'>{$label}<br/>".$t_rel->htmlFormElement($element_code, '', ['name' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'id' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'value' => _t('today'), 'classname' => $field_class])."</td>";
+						$buf .= "<td><div class='formLabel'>{$label}<br/>".$t_rel->htmlFormElement($element_code, '', ['name' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'id' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'value' => _t('now'), 'classname' => $field_class])."</td>";
 					} else {
 						$buf .= "<td class='formLabel'>{$label}<br/>".$t_rel->getAttributeHTMLFormBundle($request, null, $element_code, $placement_code, $settings, ['elementsOnly' => true])."</td>";
 					}	

--- a/assets/ca/ca.bundleupdate.js
+++ b/assets/ca/ca.bundleupdate.js
@@ -47,9 +47,9 @@ var caBundleUpdateManager = null;
 		// Methods
 		// --------------------------------------------------------------------------------
 		that.registerBundle = function(id, bundle, placement_id) {
-			that.byID[id] = that.byPlacementID[placement_id] = [{
+			that.byID[id] = that.byPlacementID[placement_id] = {
 				id: id, bundle: bundle, placement_id: placement_id
-			}];
+			};
 			if(!that.byBundle[bundle]) { that.byBundle[bundle] = []; }
 			that.byBundle[bundle].push(that.byID[id]);
 		}
@@ -80,7 +80,6 @@ var caBundleUpdateManager = null;
 				jQuery.each(b, function(k, v) {
 					for(var i in v) {
 						var loadURL = that.url + "/" + that.key + "/" + that.id + "/bundle/" + v.bundle + "/placement_id/" + v.placement_id;
-					
 						if (options) { 
 							for(var k in options) {
 								loadURL += "/" + k + "/" + options[k];

--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -712,7 +712,7 @@ if($show_entity_controls) {
 		if($show_return_home_controls) {
 ?>			
 			if (!_currentHomeLocation) {
-				_currentHomeLocation = '<?php print addslashes($home_location_idno); ?>';
+				_currentHomeLocation = <?= json_encode($home_location_idno); ?>;
 			}
 			caRelationBundle<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
 				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_',
@@ -738,7 +738,7 @@ if($show_entity_controls) {
 					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 					jQuery("#<?php print $vs_id_prefix; ?>_ca_storage_locations_return_homenew_0").val(1);
 					
-					var msg = '<?php print addslashes(_t('Return to home location ')); ?>';
+					var msg = <?= json_encode(_t('Return to home location ')); ?>;
 					jQuery("#<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_heading").html(msg + "<em>" + _currentHomeLocation + "</em>");
 				
 				},


### PR DESCRIPTION
PR modifies return to home location endpoint  to only consider items currently in location, not all. This saves time and provides accurate counts of records modified; fix bundle update mechanism to provide for update of current content list after return to home has run.