### PR TITLE
PROV-1798 Add config for movements, object representations and list items

### DIFF
--- a/app/conf/search_query_builder.conf
+++ b/app/conf/search_query_builder.conf
@@ -26,6 +26,9 @@ query_builder_enabled_ca_collections = 1
 query_builder_enabled_ca_occurrences = 1
 query_builder_enabled_ca_storage_locations = 1
 query_builder_enabled_ca_loans = 1
+query_builder_enabled_ca_movements = 1
+query_builder_enabled_ca_list_items = 1
+query_builder_enabled_ca_object_representations = 1
 
 # Per-table list of filter names to move to the top of the query builder's list, in the order given.  Filters can come
 # from intrinsic fields, attributes or search access points.
@@ -99,6 +102,30 @@ query_builder_priority_ca_loans = [
 	_fulltext
 ]
 
+query_builder_priority_ca_movements = [
+	ca_movements.idno,
+	ca_movement_labels.name,
+	ca_movements.type_id,
+	ca_movements.status,
+	_fulltext
+]
+
+query_builder_priority_ca_list_items = [
+	ca_list_items.idno,
+	ca_list_item_labels.name_plural,
+	ca_list_items.type_id,
+	ca_list_items.status,
+	_fulltext
+]
+
+query_builder_priority_ca_object_representations = [
+	ca_object_representations.idno,
+	ca_object_representations_labels.name,
+	ca_object_representations.type_id,
+	ca_object_representations.status,
+	_fulltext
+]
+
 # Per-table list of filter names to exclude from the query builder.  Filters can come from intrinsic fields, attributes
 # or search access points.
 query_builder_exclude_ca_objects = []
@@ -109,6 +136,9 @@ query_builder_exclude_ca_collections = []
 query_builder_exclude_ca_occurrences = []
 query_builder_exclude_ca_storage_locations = []
 query_builder_exclude_ca_loans = []
+query_builder_exclude_ca_movements = []
+query_builder_exclude_ca_object_representations = []
+query_builder_exclude_ca_list_items = []
 
 query_builder_icons = {
 	add_group = fas fa-plus-circle,


### PR DESCRIPTION
PR adds search builder configuration for three tables that may benefit from builder functionality: movements, object representations and list items.