### PR TITLE
PROV-3102 Support inclusion of duplicated item in related sets via the record duplication tool

### DIFF
--- a/app/conf/user_pref_defs.conf
+++ b/app/conf/user_pref_defs.conf
@@ -591,7 +591,8 @@ preferenceDefinitions = {
 			_("Loans") = ca_loans,
 			_("Movements") = ca_movements,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_objects_duplicate_current_relationships_only = {
@@ -681,7 +682,8 @@ preferenceDefinitions = {
 			_("Collections") = ca_collections,
 			_("Storage locations") = ca_storage_locations,
 			_("Movements") = ca_movements,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_object_lots_duplicate_current_relationships_only = {
@@ -763,7 +765,8 @@ preferenceDefinitions = {
 			_("Loans") = ca_loans,
 			_("Movements") = ca_movements,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_entities_duplicate_current_relationships_only = {
@@ -841,7 +844,8 @@ preferenceDefinitions = {
 			_("Occurrences") = ca_occurrences,
 			_("Collections") = ca_collections,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_places_duplicate_current_relationships_only = {
@@ -921,7 +925,8 @@ preferenceDefinitions = {
 			_("Collections") = ca_collections,
 			_("Storage locations") = ca_storage_locations,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_collections_duplicate_current_relationships_only = {
@@ -1000,7 +1005,8 @@ preferenceDefinitions = {
 			_("Occurrences") = ca_occurrences,
 			_("Collections") = ca_collections,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_occurrences_duplicate_current_relationships_only = {
@@ -1075,7 +1081,8 @@ preferenceDefinitions = {
 			_("Objects") = ca_objects,
 			_("Object lots") = ca_object_lots,
 			_("Entities") = ca_entities,
-			_("Collections") = ca_collections
+			_("Collections") = ca_collections,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_storage_locations_duplicate_current_relationships_only = {
@@ -1224,7 +1231,8 @@ preferenceDefinitions = {
 			_("Objects") = ca_objects,
 			_("Object lots") = ca_object_lots,
 			_("Entities") = ca_entities,
-			_("Loans") = ca_loans
+			_("Loans") = ca_loans,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_movements_duplicate_current_relationships_only = {
@@ -1353,7 +1361,8 @@ preferenceDefinitions = {
 			_("Occurrences") = ca_occurrences,
 			_("Collections") = ca_collections,
 			_("Tour stops") = ca_tour_stops,
-			_("Vocabulary") = ca_list_items
+			_("Vocabulary") = ca_list_items,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_tour_stops_duplicate_element_settings = {
@@ -1449,7 +1458,8 @@ preferenceDefinitions = {
 			_("Places") = ca_places,
 			_("Occurrences") = ca_occurrences,
 			_("Collections") = ca_collections,
-			_("Tour stops") = ca_tour_stops
+			_("Tour stops") = ca_tour_stops,
+			_("Sets") = ca_sets
 		}
 	},
 	ca_list_items_duplicate_children = {

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -593,6 +593,22 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			}
 		}
 		
+		// duplicate sets
+		if (in_array('ca_sets', $va_duplicate_relationships) || (isset($va_duplicate_element_settings['ca_sets_checklist']) && $va_duplicate_element_settings['ca_sets_checklist'])) {
+			global $g_request;
+			$user_id = $g_request ? $g_request->user->getUserID() : null;
+			
+			$t_set = new ca_sets();
+			$set_ids = $t_set->getSets(['setIDsOnly' => true, 'table' => $this->tableName(), 'row_id' => $this->getPrimaryKey(), 'user_id' => $user_id, 'access' => __CA_SET_EDIT_ACCESS__]);
+			if(is_array($set_ids)) {
+				foreach($set_ids as $set_id) {
+					if($t_set->load($set_id)) {
+						$t_set->addItem($t_dupe->getPrimaryKey(), null, $user_id);
+					}
+				}
+			}
+		}
+		
 		// Set rank of duplicated record such that it immediately follows its original
 		if($t_dupe->getProperty('RANK') && $this->isHierarchical() && ($vn_parent_id = $this->get($vs_parent_id_fld) > 0)) {
 			$t_dupe->setRankAfter($this->getPrimaryKey());


### PR DESCRIPTION
PR addresses inability to include duplicated records in related sets when using the editor "duplicate record" tool.