### PR TITLE
NOJIRA Ensure real path is used

### DIFF
--- a/app/helpers/initializeLocale.php
+++ b/app/helpers/initializeLocale.php
@@ -42,10 +42,10 @@
 	 */
 	function validateLocale($ps_locale) {
    		$va_locale_paths = [];
-   		if (file_exists($vs_locale_path = __CA_THEME_DIR__.'/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_THEMES_DIR__.'/default/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_APP_DIR__.'/locale/user/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_APP_DIR__.'/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }	
+   		if (file_exists($vs_locale_path = realpath(__CA_THEME_DIR__.'/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_THEMES_DIR__.'/default/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_APP_DIR__.'/locale/user/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_APP_DIR__.'/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }	
    		
    		return (sizeof($va_locale_paths) > 0) ? $va_locale_paths : false;
 	}	


### PR DESCRIPTION
PR ensures real path (no symlinks) are used when loading locale files, due to an apparent limitation of Zend_Locale.