### PR TITLE
PROV-3094 Fix broken ERP checks for ca_list_items due to incorrect injection of list_id into search criteria.

### DIFF
--- a/app/helpers/initializeLocale.php
+++ b/app/helpers/initializeLocale.php
@@ -42,10 +42,10 @@
 	 */
 	function validateLocale($ps_locale) {
    		$va_locale_paths = [];
-   		if (file_exists($vs_locale_path = __CA_THEME_DIR__.'/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_THEMES_DIR__.'/default/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_APP_DIR__.'/locale/user/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }
-   		if (file_exists($vs_locale_path = __CA_APP_DIR__.'/locale/'.$ps_locale.'/messages.mo')) { $va_locale_paths[] = $vs_locale_path; }	
+   		if (file_exists($vs_locale_path = realpath(__CA_THEME_DIR__.'/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_THEMES_DIR__.'/default/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_APP_DIR__.'/locale/user/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }
+   		if (file_exists($vs_locale_path = realpath(__CA_APP_DIR__.'/locale/'.$ps_locale.'/messages.mo'))) { $va_locale_paths[] = $vs_locale_path; }	
    		
    		return (sizeof($va_locale_paths) > 0) ? $va_locale_paths : false;
 	}	


### PR DESCRIPTION
PR fixes broken ERP checks for ca_list_items due to incorrect injection of list_id into search criteria. The item_id of the list_id mapping was being injected, rather than the actual numeric list_id.