### PR TITLE
PROV-3101 Trigger filters on child attributes inside a container.

### DIFF
--- a/app/lib/MetadataAlerts/TriggerTypes/Modification.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Modification.php
@@ -82,8 +82,13 @@ class Modification extends Base {
 		} else {
 			// Trigger on specific element
 			$vs_code = \ca_metadata_elements::getElementCodeForId($va_values['element_id']);
+			$vs_parent_code = \ca_metadata_elements::getParentCode($va_values['element_id']);
+			$vs_get_spec = $vs_code;
+			if ($vs_parent_code && $vs_parent_code !== $vs_code){
+				$vs_get_spec = "$vs_parent_code.$vs_get_spec";
+			}
 			if (is_array($va_filter_vals = caGetOption($vs_code, $va_filters, null)) && sizeof($va_filter_vals)) {
-				if(!in_array($t_instance->get($t_instance->tableName().".{$vs_code}"), $va_filter_vals)) { return false; }
+				if(!in_array($t_instance->get($t_instance->tableName().".{$vs_get_spec}"), $va_filter_vals)) { return false; }
 			}
 			return $t_instance->attributeDidChange($vs_code);
 		}


### PR DESCRIPTION
This PR further fixes an issue where modification metadata alerts don't get triggered for attributes inside a container.