### PR TITLE
PROV-3104 Display ISO dates on boundary intervals properly

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -2641,15 +2641,7 @@ class TimeExpressionParser {
 			
 			
 			if (isset($pa_options['dateFormat']) && ($pa_options['dateFormat'] == 'iso8601')) {
-				// $vs_start = $this->getISODateTime($va_start_pieces, 'START', $pa_options);
-// 				$vs_end = $this->getISODateTime($va_end_pieces, 'END', $pa_options);
-// 				
 				return $this->getISODateRange($va_start_pieces, $va_end_pieces, $pa_options);
-				// if ($vs_start != $vs_end) {
-// 					return "{$vs_start}/{$vs_end}";
-// 				} else {
-// 					return $vs_start;
-// 				}
 			}
 
 			// special treatment for HSP

--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2006-2020 Whirl-i-Gig
+ * Copyright 2006-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -2641,14 +2641,15 @@ class TimeExpressionParser {
 			
 			
 			if (isset($pa_options['dateFormat']) && ($pa_options['dateFormat'] == 'iso8601')) {
-				$vs_start = $this->getISODateTime($va_start_pieces, 'START', $pa_options);
-				$vs_end = $this->getISODateTime($va_end_pieces, 'END', $pa_options);
-				
-				if ($vs_start != $vs_end) {
-					return "{$vs_start}/{$vs_end}";
-				} else {
-					return $vs_start;
-				}
+				// $vs_start = $this->getISODateTime($va_start_pieces, 'START', $pa_options);
+// 				$vs_end = $this->getISODateTime($va_end_pieces, 'END', $pa_options);
+// 				
+				return $this->getISODateRange($va_start_pieces, $va_end_pieces, $pa_options);
+				// if ($vs_start != $vs_end) {
+// 					return "{$vs_start}/{$vs_end}";
+// 				} else {
+// 					return $vs_start;
+// 				}
 			}
 
 			// special treatment for HSP
@@ -3515,6 +3516,90 @@ class TimeExpressionParser {
 	# -------------------------------------------------------------------
 	public function setDebug($pn_debug) {
 		$this->opb_debug = ($pn_debug) ? true: false;
+	}
+	# -------------------------------------------------------------------
+	/**
+	 * Test whether a date range (passed as arrays of date pieces) is a century, decade, year, month or day interval
+	 *
+	 * @param array $pa_start_pieces
+	 * @param array $pa_end_pieces
+	 *
+	 * @return string CENTURY|DECADE|YEAR|MONTH|DAY if interval; false is not interval
+	 */
+	public function isDMYRange($pa_start_pieces, $pa_end_pieces) {
+		if (
+			($pa_start_pieces['year'] % 100) == 0 && ($pa_end_pieces['year'] == ($pa_start_pieces['year'] + 99))  &&
+			$pa_start_pieces['day'] == 1 && $pa_start_pieces['month'] == 1 &&
+			$pa_start_pieces['hours'] == 0 && $pa_start_pieces['minutes'] == 0 && $pa_start_pieces['seconds'] == 0 &&
+			$pa_end_pieces['day'] == 31 && $pa_end_pieces['month'] == 12 &&
+			$pa_end_pieces['hours'] == 23 && $pa_end_pieces['minutes'] == 59 && $pa_end_pieces['seconds'] == 59
+		) {
+			return 'CENTURY';
+		}
+		if (
+			($pa_start_pieces['year'] % 10) == 0 && ($pa_end_pieces['year'] == ($pa_start_pieces['year'] + 9))  &&
+			$pa_start_pieces['day'] == 1 && $pa_start_pieces['month'] == 1 &&
+			$pa_start_pieces['hours'] == 0 && $pa_start_pieces['minutes'] == 0 && $pa_start_pieces['seconds'] == 0 &&
+			$pa_end_pieces['day'] == 31 && $pa_end_pieces['month'] == 12 &&
+			$pa_end_pieces['hours'] == 23 && $pa_end_pieces['minutes'] == 59 && $pa_end_pieces['seconds'] == 59
+		) {
+			return 'DECADE';
+		}
+		if (
+			$pa_start_pieces['year'] == $pa_end_pieces['year']  &&
+			$pa_start_pieces['day'] == 1 && $pa_start_pieces['month'] == 1 &&
+			$pa_start_pieces['hours'] == 0 && $pa_start_pieces['minutes'] == 0 && $pa_start_pieces['seconds'] == 0 &&
+			$pa_end_pieces['day'] == 31 && $pa_end_pieces['month'] == 12 &&
+			$pa_end_pieces['hours'] == 23 && $pa_end_pieces['minutes'] == 59 && $pa_end_pieces['seconds'] == 59
+		) {
+			return 'YEAR';
+		}
+		
+		if (
+			$pa_start_pieces['year'] == $pa_end_pieces['year']  &&
+			$pa_start_pieces['month'] == $pa_end_pieces['month']  &&
+			$pa_start_pieces['day'] == 1 && ($pa_end_pieces['day'] == $this->daysInMonth($pa_end_pieces['month'], $pa_end_pieces['year'])) &&
+			$pa_start_pieces['hours'] == 0 && $pa_start_pieces['minutes'] == 0 && $pa_start_pieces['seconds'] == 0 &&
+			$pa_end_pieces['hours'] == 23 && $pa_end_pieces['minutes'] == 59 && $pa_end_pieces['seconds'] == 59
+		) {
+			return 'MONTH';
+		}
+		
+		if (
+			$pa_start_pieces['year'] == $pa_end_pieces['year']  &&
+			$pa_start_pieces['month'] == $pa_end_pieces['month']  &&
+			$pa_start_pieces['day'] == $pa_end_pieces['day'] &&
+			$pa_start_pieces['hours'] == 0 && $pa_start_pieces['minutes'] == 0 && $pa_start_pieces['seconds'] == 0 &&
+			$pa_end_pieces['hours'] == 23 && $pa_end_pieces['minutes'] == 59 && $pa_end_pieces['seconds'] == 59
+		) {
+			return 'DAY';
+		}
+		
+		return false;
+	}
+	# -------------------------------------------------------------------
+	/**
+	 * Convert date value arrays (array with keys "month", "day", "year", "hours", "minutes", "seconds" used internally by parser) to ISO 8601 date/time range.
+	 *
+	 * @param array $pa_start_date
+	 * @param array $pa_end_date
+	 * @param array $pa_options Options include:
+	 *		timeOmit = Omit time from returned ISO 8601 date. [Default is false]
+	 *		returnUnbounded = Return extreme value for unbounded dates. For "before" dates the start date would be equal to -9999; for "after" dates the end date would equal "9999". [Default is false]
+	 *		dateFormat = If set to "yearOnly" will return bare year. [Default is null]
+	 * @return string
+	 */
+	public function getISODateRange($pa_start_date, $pa_end_date, $pa_options=null) {
+		$start = $this->getISODateTime($pa_start_date, 'START', $pa_options);
+		$end = $this->getISODateTime($pa_end_date, 'END', $pa_options);
+		
+		switch($x=$this->isDMYRange($pa_start_date, $pa_end_date)) {
+			case 'DAY':
+				return $this->getISODateTime($pa_start_date, 'FULL', array_merge($pa_options, ['timeOmit' => true]));
+			case 'MONTH':
+				return $this->getISODateTime($pa_start_date, 'FULL', array_merge($pa_options, ['timeOmit' => true])).'/'.$this->getISODateTime($pa_end_date, 'FULL', array_merge($pa_options, ['timeOmit' => true]));
+		}
+		return "{$start}/{$end}";
 	}
 	# -------------------------------------------------------------------
 	/**

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -1523,6 +1523,135 @@ class TimeExpressionParserTest extends TestCase {
 		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1984');
 		$this->assertEquals($o_tep->getText(), '8. Juni 1984');
 	}
+	
+	public function testDateTextOutputFormatsEdge() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('1/1/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(), 'January 1 1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1979/01/01');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1979.01.01');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '01/01/1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-01-01');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'text']), 'January 1 1979');
+		
+		$vb_res = $o_tep->parse('12/31/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(), 'December 31 1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1979/12/31');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1979.12.31');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '12/31/1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-12-31');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'text']), 'December 31 1979');
+		
+		$vb_res = $o_tep->parse('1/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(), 'January 1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1979/01');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1979.01');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '01/1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-01-01/1979-01-31');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'text']), 'January 1979');
+		
+		$vb_res = $o_tep->parse('12/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(), 'December 1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd']), '1979/12');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'ymd', 'dateDelimiter' => '.']), '1979.12');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'delimited']), '12/1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-12-01/1979-12-31');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'yearOnly']), '1979');
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'text']), 'December 1979');
+	}
+	
+	
+	public function testDateTextOutputISOFormat() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+
+		$vb_res = $o_tep->parse('2/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-02-01/1979-02-28');
+		
+		$vb_res = $o_tep->parse('1/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-01-01/1979-01-31');
+		
+		$vb_res = $o_tep->parse('12/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-12-01/1979-12-31');
+		
+		$vb_res = $o_tep->parse('7/3/1979');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-07-03');
+		
+		$vb_res = $o_tep->parse('7/3/1979 @ 5pm');
+		$this->assertEquals($vb_res, true);
+	
+		$this->assertEquals($o_tep->getText(['dateFormat' => 'iso8601']), '1979-07-03T17:00:00Z');
+	}
+	
+	public function testIsDMYRange() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage('en_US');
+		
+		$o_tep->parse('1/2021');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'MONTH');
+		
+		$o_tep->parse('1/10/2021');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'DAY');
+		
+		$o_tep->parse('2/1/2021 - 2/28/2021');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'MONTH');
+	
+		$o_tep->parse('2021');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'YEAR');
+		
+		$o_tep->parse('1900-1999');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'CENTURY');
+		
+		$o_tep->parse('1920s');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'DECADE');
+		
+		$o_tep->parse('19th century');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), 'CENTURY');
+		
+		$o_tep->parse('1901-2000');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), false);
+		
+		$o_tep->parse('5/3/2020 @ 5pm');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), false);
+		
+		$o_tep->parse('5/3/2020 - 10/1/2020');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), false);
+		
+		$o_tep->parse('5/1/2020 - 5/30/2020');
+		$dates = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($o_tep->isDMYRange($o_tep->getHistoricDateParts($dates['start']), $o_tep->getHistoricDateParts($dates['end'])), false);
+	}
 
 	public function testMYADate() {
 		$o_tep = new TimeExpressionParser();


### PR DESCRIPTION
PR resolves issue where ISO dates on interval boundaries would display as ranges.