### PR TITLE
PROV-3105 Add option to skip processing of additional pages in multi-page TIFF media

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1923,6 +1923,9 @@ dont_use_graphicsmagick_to_identify_pdfs = 0
 #
 dont_use_zendpdf_to_identify_pdfs = 1
 
+# Don't import additional pages on multi-page TIFFs
+dont_import_additional_pages_for_tiffs = 0
+
 # CollectiveAccess supports two methods for generating PDF output for download and printing: dompdf (slower; built-in), 
 # and wkhtmltopdf (faster; requires additional software installation). 
 # By default it will favor using wkhtmltopdf if available, falling back to dompdf which is always available. 

--- a/app/lib/Plugins/Media/Gmagick.php
+++ b/app/lib/Plugins/Media/Gmagick.php
@@ -1024,6 +1024,8 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 		$files = [];
 		$i = 0;
 		
+		$dont_import_pages_for_tiffs = $this->opo_config->get("dont_import_additional_pages_for_tiffs");
+		
 		$this->handle->setimageindex(0);
 		$num_previews = 0;
 		do {
@@ -1041,6 +1043,8 @@ class WLPlugMediaGmagick Extends BaseMediaPlugin Implements IWLPlugMedia {
 			
 				$this->handle->writeImage($output_file_prefix.sprintf("_%05d", $i).".jpg");
 				$file_cleanup_list[] = $files[$i] = $output_file_prefix.sprintf("_%05d", $i).'.jpg';
+				
+				if($dont_import_pages_for_tiffs && ($this->get('mimetype') === 'image/tiff')) { break; }
 			
 				$i++;
 			} while($this->handle->hasnextimage());


### PR DESCRIPTION
Multipage TIFF files are processed as multipage documents with previews for each image in the file. Some software packages (possibly Silverfast) appear to create TIFFs that have the image duplicated across several "pages". This PR adds an app.conf option to skip multipage processing for TIFFs across the board in these cases. The default remains to process all data present in the TIFF file.