### PR TITLE
PROV-2788 Escape sort field (which may be "rank")

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -11838,13 +11838,13 @@ $pa_options["display_form_field_tips"] = true;
 				switch($va_tmp[0]) {
 					case $vs_table:
 						if ($t_instance->hasField($va_tmp[1])) {
-							$vs_orderby = " ORDER BY {$vs_sort} {$vs_sort_direction}";
+							$vs_orderby = " ORDER BY `{$vs_sort}` {$vs_sort_direction}";
 						}
 						break;
 					default:
 						if (sizeof($va_tmp) == 1) {
 							if ($t_instance->hasField($va_tmp[0])) {
-								$vs_orderby = " ORDER BY {$vs_sort} {$vs_sort_direction}";
+								$vs_orderby = " ORDER BY `{$vs_sort}` {$vs_sort_direction}";
 							}
 						}
 						break;

--- a/app/lib/LabelableBaseModelWithAttributes.php
+++ b/app/lib/LabelableBaseModelWithAttributes.php
@@ -992,7 +992,7 @@
 					break;
 			}
 		
-            $vs_sql = "SELECT DISTINCT `{$vs_table}.{$select_flds}".($vs_sort_proc ? ", `{$vs_sort_proc}`" : "")." FROM {$vs_table}";
+            $vs_sql = "SELECT DISTINCT {$vs_table}.{$select_flds}".($vs_sort_proc ? ", `{$vs_sort_proc}`" : "")." FROM {$vs_table}";
             $vs_sql .= join("\n", $va_joins);
             $vs_sql .= ((sizeof($va_sql) > 0) ? " WHERE (".join(" AND ", $va_sql).")" : "");
 			

--- a/app/lib/LabelableBaseModelWithAttributes.php
+++ b/app/lib/LabelableBaseModelWithAttributes.php
@@ -992,7 +992,7 @@
 					break;
 			}
 		
-            $vs_sql = "SELECT DISTINCT {$vs_table}.{$select_flds}".($vs_sort_proc ? ", {$vs_sort_proc}" : "")." FROM {$vs_table}";
+            $vs_sql = "SELECT DISTINCT `{$vs_table}.{$select_flds}".($vs_sort_proc ? ", `{$vs_sort_proc}`" : "")." FROM {$vs_table}";
             $vs_sql .= join("\n", $va_joins);
             $vs_sql .= ((sizeof($va_sql) > 0) ? " WHERE (".join(" AND ", $va_sql).")" : "");
 			
@@ -1003,12 +1003,12 @@
 					switch($va_tmp[0]) {
 						case $vs_table:
 							if ($t_instance->hasField($va_tmp[1])) {
-								$vs_orderby = " ORDER BY {$vs_sort_proc} {$ps_sort_direction}";
+								$vs_orderby = " ORDER BY `{$vs_sort_proc}` {$ps_sort_direction}";
 							}
 							break;
 						case $vs_label_table:
 							if ($t_label->hasField($va_tmp[1])) {
-								$vs_orderby = " ORDER BY {$vs_sort_proc} {$ps_sort_direction}";
+								$vs_orderby = " ORDER BY `{$vs_sort_proc}` {$ps_sort_direction}";
 							}
 							break;
 					}


### PR DESCRIPTION
PR escapes sort fields in BaseModel::find() to avoid errors in MySQL8 when "rank" field name is used.