### PR TITLE
PROV-3106 Add helper options and constant to enable force reloading of external application path values

### DIFF
--- a/app/controllers/administrate/setup/ConfigurationCheckController.php
+++ b/app/controllers/administrate/setup/ConfigurationCheckController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2016 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -27,15 +27,12 @@
  */
 
 include_once(__CA_LIB_DIR__."/Search/SearchEngine.php");
-include_once(__CA_LIB_DIR__."/Media.php");
 include_once(__CA_LIB_DIR__."/Print/PDFRenderer.php");
-include_once(__CA_LIB_DIR__."/ApplicationPluginManager.php");
-include_once(__CA_LIB_DIR__."/ConfigurationCheck.php");
-include_once(__CA_MODELS_DIR__."/ca_change_log.php");
 
 class ConfigurationCheckController extends ActionController {
 	# ------------------------------------------------
 	public function DoCheck(){
+		define('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__', true);	// Force all plugins to reload their paths
 		AssetLoadManager::register('tableList');
 
 		// latest log id

--- a/app/helpers/mediaPluginHelpers.php
+++ b/app/helpers/mediaPluginHelpers.php
@@ -67,7 +67,10 @@
 	/**
 	 * Detects if ImageMagick executables is available within specified directory path
 	 *
-	 * @param $ps_imagemagick_path - path to directory containing ImageMagick executables
+	 * @param string $ps_imagemagick_path - path to directory containing ImageMagick executables
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginImageMagickInstalled($ps_imagemagick_path=null, $options=null) {
@@ -96,7 +99,10 @@
 	/**
 	 * Detects if GraphicsMagick is available in specified directory path
 	 *
-	 * @param $ps_graphicsmagick_path - path to directory containing GraphicsMagick executables
+	 * @param string $ps_graphicsmagick_path - path to directory containing GraphicsMagick executables
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginGraphicsMagickInstalled($ps_graphicsmagick_path=null, $options=null) {
@@ -125,7 +131,10 @@
 	/**
 	 * Detects if dcraw executable is available at specified path
 	 *
-	 * @param $ps_path_to_dcraw - full path to dcraw including executable name
+	 * @param string $ps_path_to_dcraw - full path to dcraw including executable name
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginDcrawInstalled($ps_path_to_dcraw=null, $options=null) {
@@ -149,7 +158,10 @@
 	/**
 	 * Detects if ffmpeg executable is available at specified path
 	 *
-	 * @param $ps_path_to_ffmpeg - full path to ffmpeg including executable name
+	 * @param string $ps_path_to_ffmpeg - full path to ffmpeg including executable name
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginFFmpegInstalled($ps_path_to_ffmpeg=null, $options=null) {
@@ -178,7 +190,10 @@
 	/**
 	 * Detects if Ghostscript (gs) executable is available at specified path
 	 *
-	 * @param $ps_path_to_ghostscript - full path to Ghostscript including executable name
+	 * @param string $ps_path_to_ghostscript - full path to Ghostscript including executable name
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginGhostscriptInstalled($ps_path_to_ghostscript=null, $options=null) {
@@ -207,7 +222,10 @@
 	/**
 	 * Detects if PdfToText executable is available at specified path
 	 *
-	 * @param $ps_path_to_pdf_to_text - full path to PdfToText including executable name
+	 * @param string $ps_path_to_pdf_to_text - full path to PdfToText including executable name
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginPdftotextInstalled($ps_path_to_pdf_to_text=null, $options=null) {
@@ -231,7 +249,10 @@
 	/**
 	 * Detects if LibreOffice executable is available at specified path
 	 *
-	 * @param $ps_path_to_libreoffice - full path to LibreOffice including executable name
+	 * @param string $ps_path_to_libreoffice - full path to LibreOffice including executable name
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaPluginLibreOfficeInstalled($ps_path_to_libreoffice=null, $options=null) {
@@ -259,6 +280,8 @@
 	/**
 	 * Detects if Imagick PHP extension is available
 	 *
+	 * @param array $options No option are currently available.
+	 *
 	 * @return boolean - true if available, false if not
 	 */
 	function caMediaPluginImagickInstalled($options=null) {
@@ -270,6 +293,8 @@
 	/**
 	 * Detects if Gmagick PHP extension is available
 	 *
+	 * @param array $options No option are currently available.
+	 *
 	 * @return boolean - true if available, false if not
 	 */
 	function caMediaPluginGmagickInstalled($options=null) {
@@ -280,7 +305,9 @@
 	 * Detects if GD PHP extension is available. Return false if GD is installed but lacks JPEG support unless "don't worry about JPEGs" parameter is set to true.
 	 *
 	 * @param boolean $pb_dont_worry_about_jpegs If set will return true if GD is installed without JPEG support; default is to consider JPEG-less GD worthless.
-	 * @return boolean - true if available, false if not
+	 * @param array $options No option are currently available.
+	 *
+	 * @return boolean true if available, false if not
 	 */
 	function caMediaPluginGDInstalled($pb_dont_worry_about_jpegs=false, $options=null) {
 		if ($pb_dont_worry_about_jpegs) {
@@ -293,7 +320,10 @@
 	/**
 	 * Detects if mediainfo is installed in the given path.
 	 *
-	 * @param $ps_mediainfo_path - full path to MediaInfo executable 
+	 * @param string $ps_mediainfo_path - full path to MediaInfo executable 
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMediaInfoInstalled($ps_mediainfo_path=null, $options=null) {
@@ -319,6 +349,9 @@
 	 * Detects if OpenCTM (http://openctm.sourceforge.net) is installed in the given path.
 	 *
 	 * @param string $ps_openctm_path path to OpenCTM ctmconv binary
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caOpenCTMInstalled($ps_openctm_ctmconv_path=null, $options=null) {
@@ -345,6 +378,9 @@
 	 * Detects if Meshlab (http://meshlab.sourceforge.net), and specifically the meshlabserver command line tool, is installed in the given path.
 	 *
 	 * @param string $ps_meshlabserver_path path to the meshlabserver binary
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caMeshlabServerInstalled($ps_meshlabserver_path=null, $options=null) {
@@ -375,6 +411,9 @@
 	 * Detects if PDFMiner (http://www.unixuser.org/~euske/python/pdfminer/index.html) is installed in the given path.
 	 *
 	 * @param string $ps_pdfminer_path path to PDFMiner
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caPDFMinerInstalled($ps_pdfminer_path=null, $options=null) {
@@ -408,6 +447,9 @@
 	 * Detects if wkhtmltopdf (http://www.wkhtmltopdf.org) is installed in the given path.
 	 *
 	 * @param string $ps_wkhtmltopdf_path path to wkhtmltopdf executable
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caWkhtmltopdfInstalled($ps_wkhtmltopdf_path=null, $options=null) {
@@ -441,6 +483,9 @@
 	 * Detects if youtube-dl (http://www.youtube-dl.org) is installed in the given path.
 	 *
 	 * @param string $youtube_dl_path path to youtube-dl executable
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caYouTubeDlInstalled($youtube_dl_path=null, $options=null) {
@@ -473,6 +518,9 @@
 	 * Detects if ExifTool (http://www.sno.phy.queensu.ca/~phil/exiftool/) is installed in the given path.
 	 *
 	 * @param string $ps_exiftool_path path to ExifTool
+	 * @param array $options Options include:
+	 *		noCache = Don't cached path value. [Default is false]
+	 *
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
 	function caExifToolInstalled($ps_exiftool_path=null, $options=null) {

--- a/app/helpers/mediaPluginHelpers.php
+++ b/app/helpers/mediaPluginHelpers.php
@@ -70,8 +70,8 @@
 	 * @param $ps_imagemagick_path - path to directory containing ImageMagick executables
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginImageMagickInstalled($ps_imagemagick_path=null) {
-		if (CompositeCache::contains("mediahelper_imagemagick_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_imagemagick_installed", "mediaPluginInfo"); }
+	function caMediaPluginImageMagickInstalled($ps_imagemagick_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_imagemagick_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_imagemagick_installed", "mediaPluginInfo"); }
 		if(!$ps_imagemagick_path) { $ps_imagemagick_path = caGetExternalApplicationPath('imagemagick', ['executableName' => 'identify']); }
 
 		if (!caIsValidFilePath($ps_imagemagick_path)) { 
@@ -99,8 +99,8 @@
 	 * @param $ps_graphicsmagick_path - path to directory containing GraphicsMagick executables
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginGraphicsMagickInstalled($ps_graphicsmagick_path=null) {
-		if (CompositeCache::contains("mediahelper_graphicsmagick_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_graphicsmagick_installed", "mediaPluginInfo"); }
+	function caMediaPluginGraphicsMagickInstalled($ps_graphicsmagick_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_graphicsmagick_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_graphicsmagick_installed", "mediaPluginInfo"); }
 		if(!$ps_graphicsmagick_path) { $ps_graphicsmagick_path = caGetExternalApplicationPath('graphicsmagick'); }
 
 		if (!caIsValidFilePath($ps_graphicsmagick_path)) { 
@@ -128,8 +128,8 @@
 	 * @param $ps_path_to_dcraw - full path to dcraw including executable name
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginDcrawInstalled($ps_path_to_dcraw=null) {
-		if (CompositeCache::contains("mediahelper_dcraw_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_dcraw_installed", "mediaPluginInfo"); }
+	function caMediaPluginDcrawInstalled($ps_path_to_dcraw=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_dcraw_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_dcraw_installed", "mediaPluginInfo"); }
 		if(!$ps_path_to_dcraw) { $ps_path_to_dcraw = caGetExternalApplicationPath('dcraw'); }
 
 		if (!caIsValidFilePath($ps_path_to_dcraw)) { 
@@ -152,8 +152,8 @@
 	 * @param $ps_path_to_ffmpeg - full path to ffmpeg including executable name
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginFFmpegInstalled($ps_path_to_ffmpeg=null) {
-		if (CompositeCache::contains("mediahelper_ffmpeg_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_ffmpeg_installed", "mediaPluginInfo"); }
+	function caMediaPluginFFmpegInstalled($ps_path_to_ffmpeg=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_ffmpeg_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_ffmpeg_installed", "mediaPluginInfo"); }
 		if(!$ps_path_to_ffmpeg) { $ps_path_to_ffmpeg = caGetExternalApplicationPath('ffmpeg'); }
 
 		if (!caIsValidFilePath($ps_path_to_ffmpeg)) { 
@@ -181,8 +181,8 @@
 	 * @param $ps_path_to_ghostscript - full path to Ghostscript including executable name
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginGhostscriptInstalled($ps_path_to_ghostscript=null) {
-		if (CompositeCache::contains("mediahelper_ghostscript_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_ghostscript_installed", "mediaPluginInfo"); }
+	function caMediaPluginGhostscriptInstalled($ps_path_to_ghostscript=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_ghostscript_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_ghostscript_installed", "mediaPluginInfo"); }
 		if(!$ps_path_to_ghostscript) { $ps_path_to_ghostscript = caGetExternalApplicationPath('ghostscript'); }
 
 		if (!caIsValidFilePath($ps_path_to_ghostscript)) { 
@@ -210,8 +210,8 @@
 	 * @param $ps_path_to_pdf_to_text - full path to PdfToText including executable name
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginPdftotextInstalled($ps_path_to_pdf_to_text=null) {
-		if (CompositeCache::contains("mediahelper_pdftotext_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_pdftotext_installed", "mediaPluginInfo"); }
+	function caMediaPluginPdftotextInstalled($ps_path_to_pdf_to_text=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_pdftotext_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_pdftotext_installed", "mediaPluginInfo"); }
 		if(!$ps_path_to_pdf_to_text) { $ps_path_to_pdf_to_text = caGetExternalApplicationPath('pdftotext'); }
 		
 		if (!caIsValidFilePath($ps_path_to_pdf_to_text)) { 
@@ -234,8 +234,8 @@
 	 * @param $ps_path_to_libreoffice - full path to LibreOffice including executable name
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaPluginLibreOfficeInstalled($ps_path_to_libreoffice=null) {
-		if (CompositeCache::contains("mediahelper_libreoffice_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_libreoffice_installed", "mediaPluginInfo"); }
+	function caMediaPluginLibreOfficeInstalled($ps_path_to_libreoffice=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_libreoffice_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_libreoffice_installed", "mediaPluginInfo"); }
 		if(!$ps_path_to_libreoffice) { $ps_path_to_libreoffice = caGetExternalApplicationPath('libreoffice'); }
 		if (!caIsValidFilePath($ps_path_to_libreoffice)) { 
 			CompositeCache::save("mediahelper_libreoffice_installed", false, "mediaPluginInfo");
@@ -261,7 +261,7 @@
 	 *
 	 * @return boolean - true if available, false if not
 	 */
-	function caMediaPluginImagickInstalled() {
+	function caMediaPluginImagickInstalled($options=null) {
 		$o_config = Configuration::load();
 		if ($o_config->get('dont_use_imagick')) { return false; }
 		return class_exists('Imagick') ? true : false;
@@ -272,7 +272,7 @@
 	 *
 	 * @return boolean - true if available, false if not
 	 */
-	function caMediaPluginGmagickInstalled() {
+	function caMediaPluginGmagickInstalled($options=null) {
 		return class_exists('Gmagick') ? true : false;
 	}
 	# ------------------------------------------------------------------------------------------------
@@ -282,7 +282,7 @@
 	 * @param boolean $pb_dont_worry_about_jpegs If set will return true if GD is installed without JPEG support; default is to consider JPEG-less GD worthless.
 	 * @return boolean - true if available, false if not
 	 */
-	function caMediaPluginGDInstalled($pb_dont_worry_about_jpegs=false) {
+	function caMediaPluginGDInstalled($pb_dont_worry_about_jpegs=false, $options=null) {
 		if ($pb_dont_worry_about_jpegs) {
 			return function_exists('imagecreatefromgif') ? true : false;
 		} else {
@@ -296,8 +296,8 @@
 	 * @param $ps_mediainfo_path - full path to MediaInfo executable 
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMediaInfoInstalled($ps_mediainfo_path=null) {
-		if (CompositeCache::contains("mediahelper_mediainfo_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_mediainfo_installed", "mediaPluginInfo"); }
+	function caMediaInfoInstalled($ps_mediainfo_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_mediainfo_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_mediainfo_installed", "mediaPluginInfo"); }
 		if(!$ps_mediainfo_path) { $ps_mediainfo_path = caGetExternalApplicationPath('mediainfo'); }
 		if (!caIsValidFilePath($ps_mediainfo_path)) { 
 			CompositeCache::save("mediahelper_mediainfo_installed", false, "mediaPluginInfo");
@@ -321,8 +321,8 @@
 	 * @param string $ps_openctm_path path to OpenCTM ctmconv binary
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caOpenCTMInstalled($ps_openctm_ctmconv_path=null) {
-		if (CompositeCache::contains("mediahelper_openctm_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_openctm_installed", "mediaPluginInfo"); }
+	function caOpenCTMInstalled($ps_openctm_ctmconv_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_openctm_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_openctm_installed", "mediaPluginInfo"); }
 		if(!$ps_openctm_ctmconv_path) { $ps_openctm_ctmconv_path = caGetExternalApplicationPath('openctm'); }
 
 		if (!caIsValidFilePath($ps_openctm_ctmconv_path)) { 
@@ -347,8 +347,8 @@
 	 * @param string $ps_meshlabserver_path path to the meshlabserver binary
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caMeshlabServerInstalled($ps_meshlabserver_path=null) {
-		if (CompositeCache::contains("mediahelper_meshlabserver_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_meshlabserver_installed", "mediaPluginInfo"); }
+	function caMeshlabServerInstalled($ps_meshlabserver_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_meshlabserver_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_meshlabserver_installed", "mediaPluginInfo"); }
 		if(!$ps_meshlabserver_path) { $ps_meshlabserver_path = caGetExternalApplicationPath('meshlabserver'); }
 
 		if (!caIsValidFilePath($ps_meshlabserver_path)) { 
@@ -377,8 +377,8 @@
 	 * @param string $ps_pdfminer_path path to PDFMiner
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caPDFMinerInstalled($ps_pdfminer_path=null) {
-		if (CompositeCache::contains("mediahelper_pdfminer_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_pdfminer_installed", "mediaPluginInfo"); }
+	function caPDFMinerInstalled($ps_pdfminer_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_pdfminer_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_pdfminer_installed", "mediaPluginInfo"); }
 		if(!$ps_pdfminer_path) { $ps_pdfminer_path = caGetExternalApplicationPath('pdfminer'); }
 
 		if (!caIsValidFilePath($ps_pdfminer_path)) { 
@@ -410,8 +410,8 @@
 	 * @param string $ps_wkhtmltopdf_path path to wkhtmltopdf executable
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caWkhtmltopdfInstalled($ps_wkhtmltopdf_path=null) {
-		if (CompositeCache::contains("mediahelper_wkhtmltopdf_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_wkhtmltopdf_installed", "mediaPluginInfo"); }
+	function caWkhtmltopdfInstalled($ps_wkhtmltopdf_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_wkhtmltopdf_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_wkhtmltopdf_installed", "mediaPluginInfo"); }
 		if(!$ps_wkhtmltopdf_path) { $ps_wkhtmltopdf_path = caGetExternalApplicationPath('wkhtmltopdf'); }
 		
 		if (!trim($ps_wkhtmltopdf_path) || (preg_match("/[^\/A-Za-z0-9\.:]+/", $ps_wkhtmltopdf_path)) || !@is_readable($ps_wkhtmltopdf_path)) { 
@@ -443,8 +443,8 @@
 	 * @param string $youtube_dl_path path to youtube-dl executable
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caYouTubeDlInstalled($youtube_dl_path=null) {
-		if (CompositeCache::contains("mediahelper_youtube_dl_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_youtube_dl_installed", "mediaPluginInfo"); }
+	function caYouTubeDlInstalled($youtube_dl_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_youtube_dl_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_youtube_dl_installed", "mediaPluginInfo"); }
 		if(!$youtube_dl_path) { $youtube_dl_path = caGetExternalApplicationPath('youtube-dl'); }
 		
 		if (!trim($youtube_dl_path) || (preg_match("/[^\/A-Za-z0-9\.:\-]+/", $youtube_dl_path)) || !@is_readable($youtube_dl_path)) { 
@@ -475,8 +475,8 @@
 	 * @param string $ps_exiftool_path path to ExifTool
 	 * @return mixed Path to executable if installed, false if not installed
 	 */
-	function caExifToolInstalled($ps_exiftool_path=null) {
-		if (CompositeCache::contains("mediahelper_exiftool_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_exiftool_installed", "mediaPluginInfo"); }
+	function caExifToolInstalled($ps_exiftool_path=null, $options=null) {
+		if (!caGetOption('noCache', $options, defined('__CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__')) && CompositeCache::contains("mediahelper_exiftool_installed", "mediaPluginInfo")) { return CompositeCache::fetch("mediahelper_exiftool_installed", "mediaPluginInfo"); }
 		if(!$ps_exiftool_path) { $ps_exiftool_path = caGetExternalApplicationPath('exiftool'); }
 		
 		if (!trim($ps_exiftool_path) || (preg_match("/[^\/A-Za-z0-9\.:]+/", $ps_exiftool_path)) || !@is_readable($ps_exiftool_path)) { 


### PR DESCRIPTION
Media helper functions that return paths to external applications cache values (good), but offer no way to force those values to update short of clearing the entire application cache (bad). This PR adds an option to force reloading of these values. 

Forced reloading of cached external application paths can be triggered by passing a "noCache" option to each external application path helper, or by defining the __CA_DONT_CACHE_EXTERNAL_APPLICATION_PATHS__ constant to true.
The system configuration check web UI now sets this constant, forcing update of these paths each time a configuration check is performed.