### PR TITLE
NOJIRA Set upper limit for width of sort drop-down

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1465,7 +1465,7 @@
 
 		$cache_key = caMakeCacheKeyFromOptions($options, "{$ps_table}/{$pn_type_id}");
 		
-		if (CompositeCache::contains("available_sorts") && is_array($cached_data = CompositeCache::fetch("available_sorts")) && isset($cached_data[$cache_key])) { return $cached_data[$cache_key]; }
+		if (CompositeCache::contains('available_sorts', 'SearchBuilder') && is_array($cached_data = CompositeCache::fetch('available_sorts', 'SearchBuilder')) && isset($cached_data[$cache_key])) { return $cached_data[$cache_key]; }
 
 		$o_config = Configuration::load();
 		$pn_display_id = caGetOption('restrictToDisplay', $options, null);
@@ -1730,7 +1730,7 @@
 		$ret = array_merge(['_natural' => $natural_sort_label], $va_base_fields);
 		
 		$cached_data[$cache_key] = $ret;
-		CompositeCache::save("available_sorts", $cached_data);
+		CompositeCache::save('available_sorts', $cached_data, 'SearchBuilder');
 		return $ret;
 	}
 	# ---------------------------------------

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -308,7 +308,7 @@ div.clear {
 	font-size: 13px;
 	line-height: 1.4em;
 }
-#leftNav div.visualize, #leftNav div.setTools {
+#leftNav div.visualize, #leftNav div.setTools, #leftNav div.batchTools {
 	background-color:#f7f7f7;
 	border-radius: 4px;
 	-webkit-border-radius: 4px;
@@ -319,10 +319,10 @@ div.clear {
 	text-transform:capitalize;
 	font-size:14px;
 }
-#leftNav div.setTools img {
+#leftNav div.setTools img, #leftNav div.batchTools img {
 	padding-right:5px;
 }
-#leftNav div.visualize a, #leftNav div.setTools a {
+#leftNav div.visualize a, #leftNav div.setTools a, #leftNav div.batchTools a {
 	text-decoration:none;
 }
 #caColorbox {
@@ -437,7 +437,7 @@ div.inspectorLotObjectTypeControls {
 #leftNav #toolIcons .button {
 	text-align:left;
 }
-#leftNav #searchSetTools .button {
+#leftNav #searchSetTools .button, #leftNav #batchTools .button {
 	text-align: right;
 }
 #leftNav .button.info img{
@@ -1258,6 +1258,7 @@ div.formLabelUploadSizeNote {
 	font-weight: normal;
 	height: 17px;
 	vertical-align: top;
+	max-width: 120px;
 }
 .bundleSubLabel .editorBundlePrintControl {
 	float:right;
@@ -2454,11 +2455,8 @@ select.searchToolsSelect {
 }
 /* Set Tools */
 
-#searchSetTools {
+#searchSetTools, #batchTools {
 	display:none;
-}
-
-#searchSetTools {
 	background-color: #f7f7f7;
 	border-radius: 4px;
 	-moz-border-radius: 4px;
@@ -2466,19 +2464,19 @@ select.searchToolsSelect {
 	margin: 10px;
 	padding: 10px;
 }
-#searchSetTools .col{
+#searchSetTools .col, #batchTools .col {
 	margin-bottom:15px;
 }
-#searchSetTools .header {
+#searchSetTools .header, #batchTools .header {
 	font-family: 'din-regular', helvetica, sans-serif;
 	font-weight:bold;
 }
-#searchSetTools a{
+#searchSetTools a, #batchTools a {
 	float: right;
 	clear: left;
 	text-align: right;
 }
-#searchSetTools .searchSetsToggle a{
+#searchSetTools .searchSetsToggle a {
 	float: left;
 	clear: right;
 	text-align: left;


### PR DESCRIPTION
PR sets upper limit on width of relationship bundle sort drop-downs, preventing odd formatting when user has very long field names. Also now clear cache and update sort menu when element names change (rather than wait for the cache to expire).