### PR TITLE
NOJIRA Cache path, not return code

### DIFF
--- a/app/helpers/mediaPluginHelpers.php
+++ b/app/helpers/mediaPluginHelpers.php
@@ -150,7 +150,7 @@
 		
 		$vb_ret = (($vn_return >= 0) && ($vn_return < 127));
 		
-		CompositeCache::save("mediahelper_dcraw_installed", $vb_ret, "mediaPluginInfo");
+		CompositeCache::save("mediahelper_dcraw_installed", $ps_path_to_dcraw, "mediaPluginInfo");
 		
 		return $vb_ret ? $ps_path_to_dcraw : false;
 	}


### PR DESCRIPTION
PR resolves issue where path for dcraw external application was incorrectly cached. This would cause calls to dcraw are the initial one to fail.