### PR TITLE
PROV-3109 Extend label length

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -3966,13 +3966,15 @@ function caFileIsIncludable($ps_file) {
 	 * @param array $pa_options Options include:
 	 *		locale = Locale settings to use. If omitted current default locale is used. [Default is current locale]
 	 *		omitArticle = Omit leading definite and indefinited articles, rather than moving them to the end of the text [Default is true]
+	 *		maxLength = Maximum length of returned value. [Default is 255]
 	 *
-	 * @return string Converted text. If locale cannot be found $ps_text is returned unchanged.
+	 * @return string Converted text. If locale cannot be found $ps_text is returned truncated to "maxLength" value, but otherwise unchanged.
 	 */
 	function caSortableValue($ps_text, $pa_options=null) {
 		global $g_ui_locale;
 		$ps_locale = caGetOption('locale', $pa_options, $g_ui_locale);
-		if (!$ps_locale) { return $ps_text; }
+		$max_length = caGetOption('maxLength', $pa_options, 255, ['castTo' => 'int']);
+		if (!$ps_locale) { return mb_substr($ps_text, 0, $max_length); }
 
 		$pb_omit_article = caGetOption('omitArticle', $pa_options, true);
 
@@ -3997,7 +3999,7 @@ function caFileIsIncludable($ps_file) {
 				$vs_display_value = str_replace($va_matches[$i], $vs_padded, $vs_display_value);
 			}
 		}
-		return $vs_display_value;
+		return mb_substr($vs_display_value, 0, $max_length);
 	}
 	# ----------------------------------------
 	/**

--- a/app/lib/BaseLabel.php
+++ b/app/lib/BaseLabel.php
@@ -169,7 +169,7 @@
 					$t_locale = new ca_locales();
 					$vs_locale = $t_locale->localeIDToCode($this->get('locale_id'));
 				}
-				$vs_display_value = caSortableValue($this->get($vs_display_field), array('locale' => $vs_locale));
+				$vs_display_value = caSortableValue($this->get($vs_display_field), ['locale' => $vs_locale, 'maxLength' => 255]);
 				
 				$this->set($vs_sort_field, $vs_display_value);
 			}

--- a/app/models/ca_collection_labels.php
+++ b/app/models/ca_collection_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2012 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -78,7 +78,7 @@ BaseModel::$s_ca_models_definitions['ca_collection_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Name of collection'),
-				'BOUNDS_LENGTH' => array(1,255)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -224,4 +224,3 @@ class ca_collection_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_loan_labels.php
+++ b/app/models/ca_loan_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2012 Whirl-i-Gig
+ * Copyright 2010-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -77,7 +77,7 @@ BaseModel::$s_ca_models_definitions['ca_loan_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Descriptive title for loan'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -85,7 +85,7 @@ BaseModel::$s_ca_models_definitions['ca_loan_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -222,4 +222,3 @@ class ca_loan_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_movement_labels.php
+++ b/app/models/ca_movement_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2012 Whirl-i-Gig
+ * Copyright 2010-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -77,7 +77,7 @@ BaseModel::$s_ca_models_definitions['ca_movement_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Descriptive title for movement'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -85,7 +85,7 @@ BaseModel::$s_ca_models_definitions['ca_movement_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -222,4 +222,3 @@ class ca_movement_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_object_labels.php
+++ b/app/models/ca_object_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2012 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -77,7 +77,7 @@ BaseModel::$s_ca_models_definitions['ca_object_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Name of object'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -85,7 +85,7 @@ BaseModel::$s_ca_models_definitions['ca_object_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -222,4 +222,3 @@ class ca_object_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_object_lot_labels.php
+++ b/app/models/ca_object_lot_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2012 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -78,7 +78,7 @@ BaseModel::$s_ca_models_definitions['ca_object_lot_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Name of lot'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -86,7 +86,7 @@ BaseModel::$s_ca_models_definitions['ca_object_lot_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -224,4 +224,3 @@ class ca_object_lot_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_object_representation_labels.php
+++ b/app/models/ca_object_representation_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2013 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -77,7 +77,7 @@ BaseModel::$s_ca_models_definitions['ca_object_representation_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Representation label'), 'DESCRIPTION' => _t('Label/caption for representation.'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -85,7 +85,7 @@ BaseModel::$s_ca_models_definitions['ca_object_representation_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -222,4 +222,3 @@ class ca_object_representation_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_occurrence_labels.php
+++ b/app/models/ca_occurrence_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2012 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -77,7 +77,7 @@ BaseModel::$s_ca_models_definitions['ca_occurrence_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Name of occurrence'),
-				'BOUNDS_LENGTH' => array(1,1024)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -85,7 +85,7 @@ BaseModel::$s_ca_models_definitions['ca_occurrence_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => 'Sort order', 'DESCRIPTION' => 'Sortable version of name value',
-				'BOUNDS_LENGTH' => array(0,1024)
+				'BOUNDS_LENGTH' => array(0,255)
 		),
 		'source_info' => array(
 				'FIELD_TYPE' => FT_VARS, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -223,4 +223,3 @@ class ca_occurrence_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/models/ca_tour_stop_labels.php
+++ b/app/models/ca_tour_stop_labels.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2011-2012 Whirl-i-Gig
+ * Copyright 2011-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -68,7 +68,7 @@ BaseModel::$s_ca_models_definitions['ca_tour_stop_labels'] = array(
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
 				'LABEL' => _t('Name'), 'DESCRIPTION' => _t('Name of tour'),
-				'BOUNDS_LENGTH' => array(1,255)
+				'BOUNDS_LENGTH' => array(1,16384)
 		),
 		'name_sort' => array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -199,4 +199,3 @@ class ca_tour_stop_labels extends BaseLabel {
 	}
 	# ------------------------------------------------------
 }
-?>

--- a/app/version.php
+++ b/app/version.php
@@ -3,7 +3,7 @@
 	define('__CollectiveAccess__', '1.8');
 
 	# Schema revision
-	define('__CollectiveAccess_Schema_Rev__', 168);
+	define('__CollectiveAccess_Schema_Rev__', 169);
 
 	# Release type
 	define('__CollectiveAccess_Release_Type__', 'GIT');

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -685,8 +685,8 @@ create table ca_object_representation_labels
    representation_id              int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                  not null,
-   name_sort                      varchar(1024)                  not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -835,8 +835,8 @@ create table ca_occurrence_labels
    occurrence_id                  int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                   not null,
-   name_sort                      varchar(1024)                   not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -965,7 +965,7 @@ create table ca_collection_labels
    collection_id                  int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(255)                   not null,
+   name                           varchar(16384)                 not null,
    name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
@@ -983,7 +983,7 @@ create index i_name on ca_collection_labels(name(128));
 create unique index u_all on ca_collection_labels
 (
    collection_id,
-   name,
+   name(255),
    type_id,
    locale_id
 );
@@ -1207,8 +1207,8 @@ create table ca_loan_labels (
    loan_id                        int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                  not null,
-   name_sort                      varchar(1024)                  not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -1290,8 +1290,8 @@ create table ca_movement_labels (
    movement_id                    int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                  not null,
-   name_sort                      varchar(1024)                  not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -1659,8 +1659,8 @@ create table ca_object_lot_labels
    lot_id                         int unsigned               not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                  not null,
-   name_sort                      varchar(1024)                  not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -1917,11 +1917,11 @@ create index i_submission_via_form on ca_objects(submission_via_form);
 create table ca_object_labels
 (
    label_id                       int unsigned                   not null AUTO_INCREMENT,
-   object_id                      int unsigned               not null,
+   object_id                      int unsigned                   not null,
    locale_id                      smallint unsigned              not null,
    type_id                        int unsigned                   null,
-   name                           varchar(1024)                  not null,
-   name_sort                      varchar(1024)                  not null,
+   name                           varchar(16384)                 not null,
+   name_sort                      varchar(255)                   not null,
    source_info                    longtext                       not null,
    is_preferred                   tinyint unsigned               not null,
    primary key (label_id),
@@ -5175,7 +5175,7 @@ create table ca_tour_stop_labels
    label_id                       int unsigned              not null AUTO_INCREMENT,
    stop_id                        int unsigned              not null,
    locale_id                      smallint unsigned              not null,
-   name                           varchar(255)                   not null,
+   name                           varchar(16384)                 not null,
    name_sort                      varchar(255)                   not null,
    primary key (label_id),
    
@@ -7375,4 +7375,4 @@ create table ca_schema_updates (
 ) engine=innodb CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 /* Indicate up to what migration this schema definition covers */
-INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (168, unix_timestamp());
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (169, unix_timestamp());

--- a/support/sql/migrations/169.sql
+++ b/support/sql/migrations/169.sql
@@ -1,0 +1,44 @@
+/*
+	Date: 6 April 2021
+	Migration: 169
+	Description:    Extend maximum length of primary type label fields
+*/
+
+/*==========================================================================*/
+
+ALTER TABLE ca_occurrence_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_occurrence_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+DROP INDEX u_all on ca_collection_labels;
+ALTER TABLE ca_collection_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_collection_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+create unique index u_all on ca_collection_labels
+(
+   collection_id,
+   name(255),
+   type_id,
+   locale_id
+);
+
+ALTER TABLE ca_object_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_object_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+ALTER TABLE ca_loan_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_loan_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+ALTER TABLE ca_movement_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_movement_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+ALTER TABLE ca_object_representation_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_object_representation_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+ALTER TABLE ca_tour_stop_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_tour_stop_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+ALTER TABLE ca_object_lot_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+ALTER TABLE ca_object_lot_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
+
+/*==========================================================================*/
+
+/* Always add the update to ca_schema_updates at the end of the file */
+INSERT IGNORE INTO ca_schema_updates (version_num, datetime) VALUES (169, unix_timestamp());


### PR DESCRIPTION
PR extends maximum possible preferred/non-preferred labels length to 16384 characters for these tables:

- ca_collections
- ca_occurrences
- ca_object_lots
- ca_objects
- ca_tour_stops
- ca_loansca_movements
- ca_object_representations