### PR TITLE
PROV-3109 Trim name_sort before resizing to avoid truncation errors

### DIFF
--- a/support/sql/migrations/169.sql
+++ b/support/sql/migrations/169.sql
@@ -12,7 +12,7 @@ ALTER TABLE ca_occurrence_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 DROP INDEX u_all on ca_collection_labels;
 ALTER TABLE ca_collection_labels MODIFY COLUMN name varchar(16384) NOT NULL;
-UPDATE ca_occurrence_labels SET name_sort = substr(name_sort, 0, 255);
+UPDATE ca_collection_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_collection_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 create unique index u_all on ca_collection_labels
 (

--- a/support/sql/migrations/169.sql
+++ b/support/sql/migrations/169.sql
@@ -7,10 +7,12 @@
 /*==========================================================================*/
 
 ALTER TABLE ca_occurrence_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_occurrence_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_occurrence_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 DROP INDEX u_all on ca_collection_labels;
 ALTER TABLE ca_collection_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_occurrence_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_collection_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 create unique index u_all on ca_collection_labels
 (
@@ -21,21 +23,27 @@ create unique index u_all on ca_collection_labels
 );
 
 ALTER TABLE ca_object_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_object_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_object_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 ALTER TABLE ca_loan_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_loan_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_loan_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 ALTER TABLE ca_movement_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_movement_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_movement_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 ALTER TABLE ca_object_representation_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_object_representation_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_object_representation_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 ALTER TABLE ca_tour_stop_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_tour_stop_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_tour_stop_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 ALTER TABLE ca_object_lot_labels MODIFY COLUMN name varchar(16384) NOT NULL;
+UPDATE ca_object_lot_labels SET name_sort = substr(name_sort, 0, 255);
 ALTER TABLE ca_object_lot_labels MODIFY COLUMN name_sort varchar(255) NOT NULL;
 
 /*==========================================================================*/


### PR DESCRIPTION
PR modifies schema update to avoid truncation issues when name_sort contains > 255 characters in existing db.