### PR TITLE
PROV-3110 Be sensible in the face of restrictive file permissions on media

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -4278,7 +4278,7 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 			$vs_sql =  "{$ps_field} = ".$this->quote(caSerializeForDatabase($this->_FILES[$ps_field], true)).",";
 		} else {
 			// Don't try to process files when no file is actually set
-			if(isset($this->_SET_FILES[$ps_field]['tmp_name'])) { 
+			if(isset($this->_SET_FILES[$ps_field]['tmp_name']) && is_readable($this->_SET_FILES[$ps_field]['tmp_name'])) { 
 				$o_tq = new TaskQueue();
 				$o_media_proc_settings = new MediaProcessingSettings($this, $ps_field);
 		

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -131,7 +131,7 @@
 1655 = Invalid transformation
 1660 = External application configuration file could not be loaded
 1665 = External application is not installed
-1670 = File is does not exist or is not readable
+1670 = File does not exist or is not readable
 
 # --- Search engine errors
 1700 = Specified search index is invalid

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -131,6 +131,7 @@
 1655 = Invalid transformation
 1660 = External application configuration file could not be loaded
 1665 = External application is not installed
+1670 = File is does not exist or is not readable
 
 # --- Search engine errors
 1700 = Specified search index is invalid

--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -527,7 +527,10 @@
 		public function addRepresentation($ps_media_path, $pn_type_id, $pn_locale_id, $pn_status, $pn_access, $pb_is_primary, $pa_values=null, $pa_options=null) {
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
 			if (!$pn_locale_id) { $pn_locale_id = ca_locales::getDefaultCataloguingLocaleID(); }
-		
+			if(!file_exists($ps_media_path) || !is_readable($ps_media_path)) { 
+				$this->postError(1670, _t("Media does not exist or is not readable"), "RepresentableBaseModel->addRepresentation()");
+				return false; 
+			}
 		
 			$t_rep = new ca_object_representations();
 		
@@ -706,6 +709,10 @@
 		 */
 		public function editRepresentation($pn_representation_id, $ps_media_path, $pn_locale_id, $pn_status, $pn_access, $pb_is_primary=null, $pa_values=null, $pa_options=null) {
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
+			if(!file_exists($ps_media_path) || !is_readable($ps_media_path)) { 
+				$this->postError(1670, _t("Media does not exist or is not readable"), "RepresentableBaseModel->editRepresentation()");
+				return false; 
+			}
 			
 			$t_rep = new ca_object_representations();
 			if ($this->inTransaction()) { $t_rep->setTransaction($this->getTransaction());}

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -2217,7 +2217,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	 * @return mixed ca_object_representations instance representing the first representation that contains the file, if representation exists with this file, false if the file does not yet exist
 	 */
 	static function mediaExists($ps_filepath) {
-		if (!file_exists($ps_filepath)) { return null; }
+		if (!file_exists($ps_filepath) || !is_readable($ps_filepath)) { return null; }
 		$vs_md5 = md5_file($ps_filepath);
 		$t_rep = new ca_object_representations();
 		if ($t_rep->load(array('md5' => $vs_md5, 'deleted' => 0))) { 


### PR DESCRIPTION
When media files are correctly placed but unreadable by the application (usually due to file permissions or SELinux) user PHP warnings are sprayed about and misleading errors stating that the media already exists in the database. The PR catches unreadable media files and prevents warnings. Errors are now emitted by addRepresentation() and editRepresentation().