### PR TITLE
NOJIRA make logged in users "privileged"

### DIFF
--- a/app/helpers/accessHelpers.php
+++ b/app/helpers/accessHelpers.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2018 Whirl-i-Gig
+ * Copyright 2010-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -72,7 +72,7 @@
 					$va_access = array_unique(array_merge($va_access, $va_user_access));
 				}
 			}
-			return $va_access;
+			return array_map('intval', $va_access);
 		}
 		return array();
 	}
@@ -87,6 +87,7 @@
 	  * @return boolean True if user is privileged, false if not
 	  */
 	function caUserIsPrivileged($po_request, $pa_options=null) {
+		if($po_request->isLoggedIn()) { return true; }
 		$va_privileged_networks = isset($pa_options['privileged_networks']) && is_array($pa_options['privileged_networks']) ? $pa_options['privileged_networks'] : (array)$po_request->config->getList('privileged_networks');
 		
 		if (!($va_priv_ips = $va_privileged_networks)) {


### PR DESCRIPTION
PR changes access behavior to consider all logged in users "privileged" as if they were coming from a privileged IP address. This is only used in Pawtucket and merged here for consistency.