### PR TITLE
PROV-3116 Caching improvements

### DIFF
--- a/app/controllers/system/ErrorController.php
+++ b/app/controllers/system/ErrorController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2013 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -26,29 +26,28 @@
  * ----------------------------------------------------------------------
  */
 
-	require_once(__CA_LIB_DIR__."/ApplicationError.php");
- 
- 	class ErrorController extends ActionController {
- 		# -------------------------------------------------------
+require_once(__CA_LIB_DIR__."/ApplicationError.php");
+
+class ErrorController extends ActionController {
+	# -------------------------------------------------------
+	
+	# -------------------------------------------------------
+	function Show() {
+		$o_purify = new HTMLPurifier();
 		
- 		# -------------------------------------------------------
- 		function Show() {
- 			$o_purify = new HTMLPurifier();
- 			
- 			$va_nums = explode(';', $this->request->getParameter('n', pString));
- 			
- 			$va_error_messages = array();
- 			if (is_array($va_nums)) {
- 				$o_err = new ApplicationError(0, '', '', '', false, false);
- 				foreach($va_nums as $vn_error_number) {
- 					$o_err->setError($vn_error_number, '', '', false, false);
- 					$va_error_messages[] = $o_err->getErrorMessage();
- 				}
- 			}
- 			$this->view->setVar('error_messages', $va_error_messages);
- 			$this->view->setVar('referrer', $o_purify->purify($this->request->getParameter('r', pString)));
- 			$this->render('error_html.php');
- 		}
- 		# -------------------------------------------------------
- 	}
- ?>
+		$va_nums = explode(';', $this->request->getParameter('n', pString));
+		
+		$va_error_messages = array();
+		if (is_array($va_nums)) {
+			$o_err = new ApplicationError(0, '', '', '', false, false);
+			foreach($va_nums as $vn_error_number) {
+				$o_err->setError($vn_error_number, '', '', false, false);
+				$va_error_messages[] = $o_err->getErrorMessage();
+			}
+		}
+		$this->view->setVar('error_messages', $va_error_messages);
+		$this->view->setVar('referrer', $o_purify->purify($this->request->getParameter('r', pString)));
+		$this->render('error_html.php');
+	}
+	# -------------------------------------------------------
+}

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -333,6 +333,7 @@ function caFileIsIncludable($ps_file) {
 	 * @param array $pa_options Additional options, including:
 	 *		modifiedSince = Only return files and directories modified after a Unix timestamp [Default=null]
 	 *		notModifiedSince = Only return files and directories not modified after a Unix timestamp [Default=null]
+	 *		limit = Maximum number of files to return [Default=null; no limit]
 	 * @return array An array of file paths.
 	 */
 	function &caGetDirectoryContentsAsList($dir, $pb_recursive=true, $pb_include_hidden_files=false, $pb_sort=false, $pb_include_directories=false, $pa_options=null) {
@@ -340,6 +341,8 @@ function caFileIsIncludable($ps_file) {
 		if(substr($dir, -1, 1) == "/"){
 			$dir = substr($dir, 0, strlen($dir) - 1);
 		}
+		$limit = caGetOption('limit', $pa_options, null);
+		
 		if(!file_exists($dir)) { return []; }
 		if($va_paths = @scandir($dir, 0)) {
 			foreach($va_paths as $item) {
@@ -373,6 +376,7 @@ function caFileIsIncludable($ps_file) {
 						}
 					}
 				}
+				if (($limit > 0) && (sizeof($va_file_list) >= $limit)) { break; }
 			}
 		}
 

--- a/app/lib/AppNavigation.php
+++ b/app/lib/AppNavigation.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2007-2020 Whirl-i-Gig
+ * Copyright 2007-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -34,7 +34,6 @@
   *
   */
 	require_once(__CA_LIB_DIR__."/BaseObject.php");
-	require_once(__CA_LIB_DIR__."/Datamodel.php");
 	require_once(__CA_LIB_DIR__."/Configuration.php");
  	require_once(__CA_LIB_DIR__."/ApplicationPluginManager.php");
 	
@@ -960,7 +959,7 @@
 		# -------------------------------------------------------
 		static function clearMenuBarCache($po_request) {
 			Session::setVar('ca_nav_menubar_cache', null);
-			Session::getVar('ca_nav_sidebar_cache', null);
+			Session::setVar('ca_nav_sidebar_cache', null);
 		}
 		# -------------------------------------------------------
 	}

--- a/app/lib/Cache/ExternalCache.php
+++ b/app/lib/Cache/ExternalCache.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2014-2018 Whirl-i-Gig
+ * Copyright 2014-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -31,6 +31,7 @@
  */
 
 require_once(__CA_LIB_DIR__."/Cache/MemoryCache.php");
+require_once(__CA_LIB_DIR__."/Cache/JSONEncoder.php");
 
 class ExternalCache {
 	# ------------------------------------------------
@@ -201,7 +202,7 @@ class ExternalCache {
 			if(!self::init()) { return false; }
 			
 			if ($ps_namespace) {
-				self::getCache()->deleteItem($z=substr(__CA_APP_TYPE__, 0, 4).'/'.$ps_namespace);
+				self::getCache()->deleteItem(substr(__CA_APP_TYPE__, 0, 4).'/'.$ps_namespace);
 			} else {
 			    self::getCache()->clear();
 			}
@@ -246,7 +247,8 @@ class ExternalCache {
 		try {
 			$driver = new Stash\Driver\FileSystem([
 				'path' => ExternalCache::getCacheDirectory(),
-				'dirSplit' => 2
+				'dirSplit' => 2,
+				'encoder' => 'JSON'
 			]);
 			return new Stash\Pool($driver);
 		} catch (InvalidArgumentException $e) {
@@ -307,5 +309,3 @@ class ExternalCache {
 	}
 	# ------------------------------------------------
 }
-
-class ExternalCacheInvalidParameterException extends Exception {}

--- a/app/lib/Cache/JSONEncoder.php
+++ b/app/lib/Cache/JSONEncoder.php
@@ -1,0 +1,65 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Cache/JSONEncoder.php : JSON-based Stash file cache encoder 
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Cache
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+namespace Stash\Driver\FileSystem;
+
+class JSONEncoder implements EncoderInterface {
+    public function deserialize($path) {
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $raw = json_decode(file_get_contents($path), true);
+        if (is_null($raw) || !is_array($raw)) {
+            return false;
+        }
+
+        $data = $raw['data'];
+        $expiration = isset($raw['expiration']) ? $raw['expiration'] : null;
+
+        return ['data' => $data, 'expiration' => $expiration];
+    }
+
+    public function serialize($key, $data, $expiration = null) {
+        $processed = json_encode([
+            'key' => $key,
+            'data' => $data,
+            'expiration' => $expiration
+        ]);
+
+        return $processed;
+    }
+
+    public function getExtension() {
+        return '.json';
+    }
+}

--- a/app/lib/Controller/AppController.php
+++ b/app/lib/Controller/AppController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2007-2020 Whirl-i-Gig
+ * Copyright 2007-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -96,6 +96,7 @@ class AppController {
 	}
 	# -------------------------------------------------------
 	public function dispatch($pb_dont_send_response=false) {
+		global $g_errored;
 	
 		foreach($this->getPlugins() as $vo_plugin) {
 			$vo_plugin->routeStartup();
@@ -114,14 +115,15 @@ class AppController {
 			// error dispatching
 			$va_errors = array();
 			foreach($this->opo_dispatcher->errors as $o_error) {
-				$va_errors[] = $o_error->getErrorNumber();
+				$va_errors[] = $o_error->getErrorMessage();
 			}
-			$this->opo_response->setRedirect($this->opo_request->config->get('error_display_url').'/n/'.join(';', $va_errors).'?r='.urlencode($this->opo_request->getFullUrlPath()));
+			
+			$g_errored = true;	// routing error occurred
+			throw new ApplicationException(join(';', $va_errors));
 		}
 		foreach($this->getPlugins() as $vo_plugin) {
 			$vo_plugin->dispatchLoopShutdown();
 		}
-		
 		
 		if(!$pb_dont_send_response) {
 			$this->opo_response->sendResponse();

--- a/app/lib/Exceptions/ExternalCacheInvalidParameterException.php
+++ b/app/lib/Exceptions/ExternalCacheInvalidParameterException.php
@@ -1,0 +1,36 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Exceptions/ExternalCacheInvalidParameterException.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Core
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ *
+ */
+	class ExternalCacheInvalidParameterException extends Exception {} 

--- a/app/lib/GarbageCollection.php
+++ b/app/lib/GarbageCollection.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015-2020 Whirl-i-Gig
+ * Copyright 2015-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -35,44 +35,56 @@ final class GarbageCollection {
 	# -------------------------------------------------------
 	/**
 	 * Do all jobs needed for GC
+	 *
+	 * @params array $options Options include:
+	 *		showCLIProgress = Print progress messages. [Default is false]
+	 *		force = Perform garbage collection even if last run was less than five minutes ago. [Default is false]
+	 *		limit = Maximum number of file cache files to process. Set to zero or null for no limit. [Default is 1000]
 	 */
-	public static function gc() {
+	public static function gc(array $options=null) {
 		// contains() incidentally returns false when the TTL of this item is up
 		// -> time for us to run the GC
-		if(!ExternalCache::contains('last_gc', 'gc')) {
-			self::removeStaleDiskCacheItems();
+		$show_cli = caGetOption('showCLIProgress', $options, false);
+		$force = (bool)caGetOption('force', $options, false);
+		
+		if($force || !ExternalCache::contains('last_gc', 'gc') || (((int)ExternalCache::fetch('last_gc', 'gc') + 300) < time())) {
+			if($show_cli) { CLIUtils::addMessage(_t('Removing stale disk cache items...')); }
+			self::removeStaleDiskCacheItems($options);
 
 			// refresh item with new TTL
 			ExternalCache::save('last_gc', time(), 'gc', 300);
 			
 			// remove old user media files
+			if($show_cli) { CLIUtils::addMessage(_t('Clearing old user media...')); }
 			caCleanUserMediaDirectories();
 					
 			// Purge CSRF tokens that haven't been updated for at least a day from persistent cache
+			if($show_cli) { CLIUtils::addMessage(_t('Removing old CSRF tokens...')); }
 			PersistentCache::clean(time() - 86400, 'csrf_tokens');
 		}
 	}
 	# -------------------------------------------------------
-	private static function removeStaleDiskCacheItems() {
+	/**
+	 * Check and remove expired file cache entries. We assume use of the Stash JSON-based file cache encoder. 
+	 * Each JSON file is parsed and its expiration date extracted. By default only 1000 files at a time are processed.
+	 *
+	 * @param array $options Options include:
+	 *		limit = Maximum number of files to process. Set to 0 or null for no limit. [Default is 1000]
+	 */
+	private static function removeStaleDiskCacheItems(array $options=null) {
 		if(__CA_CACHE_BACKEND__ != 'file') { return false; } // the other backends *should* honor the TTL we pass
 
 		$vs_cache_base_dir = (defined('__CA_CACHE_FILEPATH__') ? __CA_CACHE_FILEPATH__ : __CA_APP_DIR__.DIRECTORY_SEPARATOR.'tmp');
 		$vs_cache_dir = $vs_cache_base_dir.DIRECTORY_SEPARATOR.__CA_APP_NAME__.'Cache';
 
-		$va_list = caGetDirectoryContentsAsList($vs_cache_dir);
-		$va_list = array_slice($va_list, 0, 10000);
+		$va_list = caGetDirectoryContentsAsList($vs_cache_dir, true, false, false, false, ['limit' => caGetOption('limit', $options, 1000)]);	// max 1000 files to check 
 		foreach($va_list as $vs_file) {
-			$r = @fopen($vs_file, "r");
-
-			if(!is_resource($r)) { continue; } // skip if for some reason the file couldn't be opened
-
-			if (false !== ($vs_line = fgets($r))) {
-				$vn_lifetime = (integer) $vs_line;
-
-				if ($vn_lifetime !== 0 && $vn_lifetime < time()) {
-					fclose($r);
-					@unlink($vs_file);
-				}
+			// NOTE: this assumes use of the Stash JSON-based cache encoder
+			$d = @json_decode(@file_get_contents($vs_file), true);
+			$exp = $d['expiration'] ?? null;
+			
+			if(!is_null($exp) && ($exp < time())) {
+				@unlink($vs_file);
 			}
 		}
 

--- a/app/lib/Utils/CLIUtils/Maintenance.php
+++ b/app/lib/Utils/CLIUtils/Maintenance.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2018-2019 Whirl-i-Gig
+ * Copyright 2018-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -1198,7 +1198,6 @@
 		public static function check_media_fixityHelp() {
 			return _t('Verifies that media files on disk are consistent with file signatures recorded in the database at time of upload.');
 		}
-		
 		# -------------------------------------------------------
 		/**
 		 *
@@ -1269,7 +1268,49 @@
 		public static function clear_cachesHelp() {
 			return _t('CollectiveAccess stores often used values, processed configuration files, user-uploaded media and other types of data in application caches. You can clear these caches using this command.');
 		}
-		
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function garbage_collection($po_opts=null) {
+			$limit = (int)$po_opts->getOption('limit');
+			$quiet = (bool)$po_opts->getOption('quiet');
+			
+			if(!$quiet) { CLIUtils::addMessage(_t('Performing garbage collection on application caches and temporary directories...')); }
+			GarbageCollection::gc(['force' => true, 'limit' => $limit, 'showCLIProgress' => !$quiet]);
+			
+			return true;
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function garbage_collectionParamList() {
+			return [
+				"limit|l=n" => _t('Maximum number of file cache files to analyze. Large file caches may take a long time to clear. Setting a limit will cap the time spent cleaning the cache and allow cleaning to be done in stages.')
+			];
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function garbage_collectionUtilityClass() {
+			return _t('Maintenance');
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function garbage_collectionShortHelp() {
+			return _t('Remove stale files from application caches and temporary file locations.');
+		}
+		# -------------------------------------------------------
+		/**
+		 *
+		 */
+		public static function garbage_collectionHelp() {
+			return _t('CollectiveAccess stores often used values, processed configuration files, user-uploaded media and other types of data in application caches. You can clean out old expired data from these locations using this command. If you want to completely clear the application caches of all data regardless of expiration date use the "clear-caches" command.');
+		}
 		# -------------------------------------------------------
 		/**
 		 *

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2018 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -69,6 +69,7 @@
 		// run garbage collector
 		GarbageCollection::gc();
 
+		$g_errored = false;	// routing error?
 		$app = AppController::getInstance();
 
 		$g_request = $req = $app->getRequest();


### PR DESCRIPTION
PR implements fixes for various issues/problems/shortcomings in  the current Stash-based application data caching system:

1. When using the file-based cache race conditions can cause individual cache files to be corrupted. Since the cache files contain executable PHP code, subsequent loading causes fatal syntax errors. There is no Stash-provided fix for this issue. The PR includes a new JSON-based cache serializer.

2. When using the file-based cache abrupt loss of session can occur due to race conditions. The PR includes changes to prevent session data from being inadvertently overwritten when a routing error occurs.

3. Garbage collection of the cache is partially broken, resulting in cache overflows and when using the file-based cache periodic high-CPU load and unresponsiveness. GC has been updated to work with the new JSON-based serializer and to limit how many files are processed in one go.

4. Garbage collection happens randomly and in-process, which results in unpredictable GC frequency and hangs when large amounts of cache garbage is to be collected. Out of process GC has been added to caUtils.