### PR TITLE
PROV-3117 Indexer now sets index entry privacy subject to related record access

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1231,6 +1231,9 @@ ca_objects_allow_access_inheritance = 0
 # Default inheritance status for newly created ca_objects records
 ca_objects_access_inheritance_default = 1
 
+# list of values for 'access' field in objects, entities, places, etc. that allow public (unrestricted) viewing in Pawtucket
+public_access_settings = [1]
+
 
 # The "access" intrinsic field available on all primary tables determines whether a record
 # is displayed in public user interfaces, and to what groups of users it may be displayed.

--- a/app/conf/search.conf
+++ b/app/conf/search.conf
@@ -60,7 +60,7 @@ indexing_tokenizer_regex = ^\\pL\\pN\\pNd/_#\\@\\&\\-
 
 # Regex character class used when searching; values matched will be used as token delimiters
 # (this is the same thing as indexing_tokenizer_regex except that it's used when searching rather than indexing)
-search_tokenizer_regex = ^\\pL\\pN\\pNd/_#\\@\\&\\-\\*\\[\\]
+search_tokenizer_regex = ^\\pL\\pN\\pNd/_#\\@\\&\\-\\*\\[\\]\\.\\*
 
 # List of regular expressions that if matched cause search input to be treated "as-is" - searched without processing
 # This is useful for preventing tokenization of accession numbers and other values that rely upon punctuation being

--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -435,13 +435,14 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 	 	$private_sql = ($this->getOption('omitPrivateIndexing') ? ' AND swi.access = 0' : '');
 	 	
 		$qr_res = $this->db->query($x="
-			SELECT swi.row_id, swi.boost
+			SELECT swi.row_id, SUM(swi.boost) boost
 			FROM ca_sql_search_word_index swi
 			".(!$is_blank ? 'INNER JOIN ca_sql_search_words AS sw ON sw.word_id = swi.word_id' : '')."
 			WHERE
 				swi.table_num = ? AND {$word_field} {$word_op} ?
 				{$field_sql}
 				{$private_sql}
+			GROUP BY swi.row_id
 		", $params);
 	 	return $this->_arrayFromDbResult($qr_res);
 	}
@@ -668,11 +669,12 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 				$subject_tablenum, (int)$lower_text, (int)$upper_text
 			];
 			$qr_res = $this->db->query($x="
-				SELECT swi.row_id, swi.boost
+				SELECT swi.row_id, SUM(swi.boost) boost
 				FROM ca_sql_search_word_index swi
 				INNER JOIN ca_sql_search_words AS sw ON sw.word_id = swi.word_id
 				WHERE
 					swi.table_num = ? AND swi.field_num = 'COUNT' AND sw.word BETWEEN ? AND ?
+				GROUP BY swi.row_id
 			", $params);
 			return $this->_arrayFromDbResult($qr_res);
 		}


### PR DESCRIPTION
The search indexer can mark index entries as restricted and not for use by Pawtucket for public search. Currently, this must be explicitly configured in search_indexing.conf, with the typical use case making related entities with specific relationship types unsearchable (Eg donor names).

PR modifies the indexer to set privacy of related indexing according to the related record's "access" field value in the absence of specific search_index.conf configuration. Thus, an entity with no public access will now automatically be indexed as private. Previously, it would be public by default.