### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/app/lib/BaseFindController.php
+++ b/app/lib/BaseFindController.php
@@ -462,11 +462,9 @@
 				$va_defined_vars = array_keys($this->view->getAllVars());		// get list defined vars (we don't want to copy over them)
 				$va_tag_list = $this->getTagListForView($va_template_info['path']);				// get list of tags in view
 				
-				$va_barcode_files_to_delete = array();
-				
 				$vn_page_count = 0;
 				while($po_result->nextHit()) {
-					$va_barcode_files_to_delete = array_merge($va_barcode_files_to_delete, caDoPrintViewTagSubstitution($this->view, $po_result, $va_template_info['path'], array('checkAccess' => $this->opa_access_values)));
+					caDoPrintViewTagSubstitution($this->view, $po_result, $va_template_info['path'], array('checkAccess' => $this->opa_access_values));
 					
 					$vs_content .= "<div style=\"{$vs_border} position: absolute; width: {$vn_width}mm; height: {$vn_height}mm; left: {$vn_left}mm; top: {$vn_top}mm; overflow: hidden; padding: 0; margin: 0;\">";
 					$vs_content .= $this->render($va_template_info['path']);
@@ -502,17 +500,12 @@
 				}
 				
 				$vs_content .= $this->render("pdfEnd.php");
-				
 				$o_pdf->setPage(caGetOption('pageSize', $va_template_info, 'letter'), caGetOption('pageOrientation', $va_template_info, 'portrait'));
 				$o_pdf->render($vs_content, array('stream'=> true, 'filename' => ($filename = $this->view->getVar('filename')) ? $filename : caGetOption('filename', $va_template_info, 'labels.pdf')));
 
 				$vb_printed_properly = true;
-				
-				foreach($va_barcode_files_to_delete as $vs_tmp) { @unlink($vs_tmp); @unlink("{$vs_tmp}.png");}
 				exit;
 			} catch (Exception $e) {
-				foreach($va_barcode_files_to_delete as $vs_tmp) { @unlink($vs_tmp); @unlink("{$vs_tmp}.png");}
-				
 				$vb_printed_properly = false;
 				$this->postError(3100, _t("Could not generate PDF"),"BaseFindController->PrintSummary()");
 			}

--- a/app/models/ca_editor_uis.php
+++ b/app/models/ca_editor_uis.php
@@ -358,7 +358,7 @@ class ca_editor_uis extends BundlableLabelableBaseModelWithAttributes {
 		if (!$vn_type_id && method_exists($t_instance, "getTypeFieldName") && (bool)$t_instance->getFieldInfo($t_instance->getTypeFieldName(), 'IS_NULL')) {
 			$vn_type_id = '_NONE_';
 		}
-		if (!$vn_type_id || !($vn_rc = $t_ui->load($va_uis_by_type[$vn_type_id]))) {
+		if (!$vn_type_id || !(is_array($va_uis_by_type) && ($vn_rc = $t_ui->load($va_uis_by_type[$vn_type_id])))) {
 			$va_ui_ids = ca_editor_uis::getAvailableUIs($vn_table_num, $po_request, $vn_type_id, true);
 
 			if (sizeof($va_ui_ids) == 0) { return ca_editor_uis::$s_default_ui_cache[$pm_table_name_or_num.'/'.$pn_type_id] = false; }

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -1195,7 +1195,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 		$o_view->setVar('settings', $pa_bundle_settings);
 		
 		$va_inital_values = array();
-		if (sizeof($va_items = $this->getAnnotations())) {
+		if (is_array($va_items = $this->getAnnotations()) && sizeof($va_items)) {
 			$t_rel = Datamodel::getInstanceByTableName("{$vs_annotation_table}", true);
 			$vs_rel_pk = $t_rel->primaryKey();
 			foreach ($va_items as $vn_id => $va_item) {


### PR DESCRIPTION
PR resolves a grab bag of warnings:

- Avoid warning when annotation pull on a representation returns nothing
- Avoid warning in editor UI code when no type-specific definitions are available
- Remove old barcode cleanup code