### PR TITLE
PROV-3120 Ensure all hierarchy level items are displayed

### DIFF
--- a/app/controllers/lookup/ObjectCollectionHierarchyController.php
+++ b/app/controllers/lookup/ObjectCollectionHierarchyController.php
@@ -367,7 +367,7 @@ class ObjectCollectionHierarchyController extends BaseLookupController {
 					$va_tmp['children'] = sizeof($qr_children->get("{$vs_table}.children.{$vs_pk}", ['returnAsArray' => true]));
 
 					if ($t_item->tableName() == 'ca_collections') {
-						$va_tmp['children'] += sizeof($qr_children->get('ca_objects.object_id', ['limit' => 2, 'returnAsArray' => true, 'restrictToRelationshipTypes' => [$vs_object_collection_rel_type]]));
+						$va_tmp['children'] += $qr_children->get('ca_objects.object_id', ['returnAsCount' => true, 'restrictToRelationshipTypes' => [$vs_object_collection_rel_type]]);
 					}
 
 					if (is_array($va_sorts)) {
@@ -422,7 +422,7 @@ class ObjectCollectionHierarchyController extends BaseLookupController {
 							'sortDirection' => $vs_object_sort_dir,
 							'restrictToRelationshipTypes' => array($vs_object_collection_rel_type),
 							'start' => $vn_start,
-							'limit' => 2
+							'limit' => $vn_max_items_per_page
 						), $vn_count
 					);
 


### PR DESCRIPTION
In some situations the hierarchy browser will fail to show all objects and collections in a hierarchy level due to optimizations intended to limit the quantity of data pulled. The incidence and scope of the problem depends upon the record and relationship types of the data in the level and how the system is configured. PR resolves the issue by pulling additional data where needed.