### PR TITLE
PROV-3107 Allow annotations for MTS files

### DIFF
--- a/app/conf/annotation_types.conf
+++ b/app/conf/annotation_types.conf
@@ -216,6 +216,7 @@ mappings = {
 	video/x-ms-asf 					= TimeBasedVideo,
 	video/x-ms-wmv 					= TimeBasedVideo,
 	video/x-flv 					= TimeBasedVideo,
+	video/MP2T  					= TimeBasedVideo,
 	audio/x-aiff 					= TimeBasedAudio,
 	audio/x-wav 					= TimeBasedAudio,
 	audio/wav 						= TimeBasedAudio,

--- a/app/helpers/avHelpers.php
+++ b/app/helpers/avHelpers.php
@@ -49,7 +49,7 @@ function caMediaInfoGuessFileFormat($ps_path) {
 		case 'MPEG-4':
 			return 'video/mp4';
 		case 'AVC':
-			return 'video/MP2T';
+			return ($va_media_metadata['GENERAL']['Format'] === 'MPEG-4') ? 'video/mp4' : 'video/MP2T';
 		case 'AVI':
 			return 'video/avi';
 		case 'Matroska':


### PR DESCRIPTION
PR enables annotations for MTS format video and adds checks to avoid mis-classifying MP4 AVC files as MTS.