### PR TITLE
PROV-3121 "Location in hierarchy" bundle throws javascript errors when present batch editing form on some records

### DIFF
--- a/themes/default/views/bundles/hierarchy_location.php
+++ b/themes/default/views/bundles/hierarchy_location.php
@@ -37,9 +37,17 @@
 	$pn_parent_id 		= $this->getVar('parent_id');
 	$pa_ancestors 		= $this->getVar('ancestors');
 	$pn_id 				= $this->getVar('id');
-	$vs_id_prefix 		= $this->getVar('placement_code').$this->getVar('id_prefix');
+	$id_prefix 			= $this->getVar('placement_code').$this->getVar('id_prefix');
 	$vn_items_in_hier 	= $t_subject->getHierarchySize();
 	$vs_bundle_preview	= '('.$vn_items_in_hier. ') '. caProcessTemplateForIDs("^preferred_labels", $t_subject->tableName(), array($t_subject->getPrimaryKey()));
+	
+	if (!$pn_id && $vb_batch && ($t_subject->getProperty('HIERARCHY_TYPE') === __CA_HIER_TYPE_ADHOC_MONO__)) {
+		// For batching on ad-hoc hierarchies we need to load something, so we pick the first record we can find
+		$table = $t_subject->tableName();
+		if($t_subject = $table::findAsInstance('*', ['limit' => 1, 'returnAs' => 'ids'])) {
+			$pn_id = $t_subject->getPrimaryKey();
+		}
+	}
 	
 	switch($vs_priv_table) {
 		case 'ca_relationship_types':
@@ -81,7 +89,7 @@
 	}
 	
 	$strict_type_hierarchy = $this->request->config->get($t_subject->tableName().'_enforce_strict_type_hierarchy');
-	$vs_type_selector 	= trim($t_subject->getTypeListAsHTMLFormElement("{$vs_id_prefix}type_id", array('id' => "{$vs_id_prefix}typeList"), array('childrenOfCurrentTypeOnly' => (bool)$strict_type_hierarchy, 'includeSelf' => !(bool)$strict_type_hierarchy, 'directChildrenOnly' => ((bool)$strict_type_hierarchy && ($strict_type_hierarchy !== '~')))));
+	$vs_type_selector 	= trim($t_subject->getTypeListAsHTMLFormElement("{$id_prefix}type_id", array('id' => "{$id_prefix}typeList"), array('childrenOfCurrentTypeOnly' => (bool)$strict_type_hierarchy, 'includeSelf' => !(bool)$strict_type_hierarchy, 'directChildrenOnly' => ((bool)$strict_type_hierarchy && ($strict_type_hierarchy !== '~')))));
 	
 	$pa_bundle_settings = $this->getVar('settings');
 	$vb_read_only		=	((isset($pa_bundle_settings['readonly']) && $pa_bundle_settings['readonly'])  || ($this->request->user->getBundleAccessLevel($t_subject->tableName(), 'hierarchy_location') == __CA_BUNDLE_ACCESS_READONLY__));
@@ -125,7 +133,7 @@
 					$va_path[] = '<a href="'.caEditorUrl($this->request, $va_item['table'], $va_item['item_id']).'">'.$vs_label.'</a>';
 				} else {
 					$vn_item_id = array_pop(explode("-", $vs_item_id));
-					$va_path[] = "<a href='#' onclick='jQuery(\"#{$vs_id_prefix}HierarchyBrowserContainer\").slideDown(250); o{$vs_id_prefix}ExploreHierarchyBrowser.setUpHierarchy(\"{$vn_item_id}\"); return false;'>{$vs_label}</a>";
+					$va_path[] = "<a href='#' onclick='jQuery(\"#{$id_prefix}HierarchyBrowserContainer\").slideDown(250); o{$id_prefix}ExploreHierarchyBrowser.setUpHierarchy(\"{$vn_item_id}\"); return false;'>{$vs_label}</a>";
 				}
 			}
 		}
@@ -137,36 +145,36 @@
 	// Handle browse header scrolling
 	//
 	jQuery(document).ready(function() {
-		if (jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').width() > jQuery('#<?php print $vs_id_prefix; ?>HierarchyPanelHeader').width()) {
+		if (jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').width() > jQuery('#<?= $id_prefix; ?>HierarchyPanelHeader').width()) {
 			//
 			// The content is wider than the content viewer area so set up the scroll
 			//
 			
-			jQuery('#<?php print $vs_id_prefix; ?>NextPrevControls').show(); // show controls
+			jQuery('#<?= $id_prefix; ?>NextPrevControls').show(); // show controls
 			
-			var hierarchyHeaderContentWidth = jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').width();
-			var hierarchyPanelHeaderWidth = jQuery('#<?php print $vs_id_prefix; ?>HierarchyPanelHeader').width();
+			var hierarchyHeaderContentWidth = jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').width();
+			var hierarchyPanelHeaderWidth = jQuery('#<?= $id_prefix; ?>HierarchyPanelHeader').width();
 			
 			if (hierarchyHeaderContentWidth > hierarchyPanelHeaderWidth) {
-				jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left', ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1) + "px"); // start at right side
+				jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left', ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1) + "px"); // start at right side
 			}
 			
 			//
 			// Handle click on "specific" button
 			//
-			jQuery('#<?php print $vs_id_prefix; ?>NextControl').click(function() {		
-				if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) >  ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
+			jQuery('#<?= $id_prefix; ?>NextControl').click(function() {		
+				if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) >  ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
 					//
 					// If we're not already at the right boundary then scroll right
 					//
-					var dl = (parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left')) - hierarchyPanelHeaderWidth);
+					var dl = (parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left')) - hierarchyPanelHeaderWidth);
 					if (dl < ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) { dl = ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1); }
-					jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').stop().animate({'left': dl + "px" }, { duration: 300, easing: 'swing', queue: false, complete: function() {			
-						if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) <=  ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
-							jQuery('#<?php print $vs_id_prefix; ?>NextControl').hide();
+					jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').stop().animate({'left': dl + "px" }, { duration: 300, easing: 'swing', queue: false, complete: function() {			
+						if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) <=  ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
+							jQuery('#<?= $id_prefix; ?>NextControl').hide();
 						}
-						if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) < 0) {
-							jQuery('#<?php print $vs_id_prefix; ?>PrevControl').show();
+						if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) < 0) {
+							jQuery('#<?= $id_prefix; ?>PrevControl').show();
 						} 
 					}}); 
 				}
@@ -176,42 +184,42 @@
 			//
 			// Handle click on "broader" button
 			// 
-			jQuery('#<?php print $vs_id_prefix; ?>PrevControl').click(function() {			
-				if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) < 0) {
+			jQuery('#<?= $id_prefix; ?>PrevControl').click(function() {			
+				if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) < 0) {
 					//
 					// Only scroll if we're not showing the extreme left side of the content area already.
 					//
-					var dl = parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left')) + hierarchyPanelHeaderWidth;
+					var dl = parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left')) + hierarchyPanelHeaderWidth;
 					if (dl > 0) { dl = 0; }
-					jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').stop().animate({'left': dl + "px"}, { duration: 300, easing: 'swing', queue: false, complete: function() {
-						if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) >= 0) {
-							jQuery('#<?php print $vs_id_prefix; ?>PrevControl').hide();
+					jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').stop().animate({'left': dl + "px"}, { duration: 300, easing: 'swing', queue: false, complete: function() {
+						if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) >= 0) {
+							jQuery('#<?= $id_prefix; ?>PrevControl').hide();
 						} 
-						if ((parseInt(jQuery('#<?php print $vs_id_prefix; ?>HierarchyHeaderContent').css('left'))) > ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
-							jQuery('#<?php print $vs_id_prefix; ?>NextControl').show();
+						if ((parseInt(jQuery('#<?= $id_prefix; ?>HierarchyHeaderContent').css('left'))) > ((hierarchyHeaderContentWidth - hierarchyPanelHeaderWidth) * -1)) {
+							jQuery('#<?= $id_prefix; ?>NextControl').show();
 						}
 					}}); 
 				}
 				return false;
 			});
-			jQuery('#<?php print $vs_id_prefix; ?>NextControl').hide();
+			jQuery('#<?= $id_prefix; ?>NextControl').hide();
 		} else {
 			// 
 			// Everything can fit without scrolling so hide the controls
 			//
-			jQuery('#<?php print $vs_id_prefix; ?>NextPrevControls').hide();
+			jQuery('#<?= $id_prefix; ?>NextPrevControls').hide();
 		}
 	});
 </script>
 <?php
 	if ($vb_batch) {
-		print caBatchEditorIntrinsicModeControl($t_subject, $vs_id_prefix);
+		print caBatchEditorIntrinsicModeControl($t_subject, $id_prefix);
 	} else {
-		print caEditorBundleShowHideControl($this->request, $vs_id_prefix, $pa_bundle_settings, false, $vs_bundle_preview);
+		print caEditorBundleShowHideControl($this->request, $id_prefix, $pa_bundle_settings, false, $vs_bundle_preview);
 	}
-	print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix, $va_settings);
+	print caEditorBundleMetadataDictionary($this->request, $id_prefix, $va_settings);
 ?>
-<div id="<?php print $vs_id_prefix; ?>">
+<div id="<?= $id_prefix; ?>">
 	<div class="bundleContainer">
 <?php	
 	if (!$vb_batch) {
@@ -226,47 +234,47 @@
 ?>
 				<div class="hierarchyCountDisplay"><?php if($vn_items_in_hier > 0) { print _t("Number of %1 in hierarchy: %2", caGetTableDisplayName($t_subject->tableName(), true), $vn_items_in_hier); } ?></div>
 				<div class="buttonPosition">
-					<a href="#" id="<?php print $vs_id_prefix; ?>browseToggle" class="form-button"><span class="form-button"><?php print _t('Show Hierarchy'); ?></span></a>
+					<a href="#" id="<?= $id_prefix; ?>browseToggle" class="form-button"><span class="form-button"><?= _t('Show Hierarchy'); ?></span></a>
 				</div>			
 <?php	
 			}
 
-				print '<div id="'.$vs_id_prefix.'HierarchyPanelHeader" class="hierarchyPanelHeader"><div id="'.$vs_id_prefix.'HierarchyHeaderContent" class="hierarchyHeaderContent">';
+				print '<div id="'.$id_prefix.'HierarchyPanelHeader" class="hierarchyPanelHeader"><div id="'.$id_prefix.'HierarchyHeaderContent" class="hierarchyHeaderContent">';
 			
 				
 				print join(' ➔ ', $va_path);
 				print '</div></div>';
 ?>
-				<div id="<?php print $vs_id_prefix; ?>HierarchyHeaderScrollButtons" class="hierarchyHeaderScrollButtons">
-					<div id="<?php print $vs_id_prefix; ?>NextPrevControls" class="nextPrevControls"><a href="#" id="<?php print $vs_id_prefix; ?>PrevControl" class="prevControl">&larr;</a> <a href="#" id="<?php print $vs_id_prefix; ?>NextControl" class="nextControl">&rarr;</a></div>
+				<div id="<?= $id_prefix; ?>HierarchyHeaderScrollButtons" class="hierarchyHeaderScrollButtons">
+					<div id="<?= $id_prefix; ?>NextPrevControls" class="nextPrevControls"><a href="#" id="<?= $id_prefix; ?>PrevControl" class="prevControl">&larr;</a> <a href="#" id="<?= $id_prefix; ?>NextControl" class="nextControl">&rarr;</a></div>
 				</div>
 	</div><!-- end hiernav -->
 <?php
 	}
 	if ($pn_id > 0) {
 ?>
-		<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserContainer" class="editorHierarchyBrowserContainer">		
-			<div  id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs">
+		<div id="<?= $id_prefix; ?>HierarchyBrowserContainer" class="editorHierarchyBrowserContainer">		
+			<div  id="<?= $id_prefix; ?>HierarchyBrowserTabs">
 				<ul>
 <?php
 	if (!$vb_batch) {
 ?>
-					<li><a href="#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-explore" onclick='_init<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser();'><span><?php print _t('Explore'); ?></span></a></li>
+					<li><a href="#<?= $id_prefix; ?>HierarchyBrowserTabs-explore" onclick='_init<?= $id_prefix; ?>ExploreHierarchyBrowser();'><span><?= _t('Explore'); ?></span></a></li>
 <?php	
 	}
 	if ($show_move) {
 ?>
-					<li><a href="#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-move" onclick='_init<?php print $vs_id_prefix; ?>MoveHierarchyBrowser();'><span><?php print _t('Move'); ?></span></a></li>
+					<li><a href="#<?= $id_prefix; ?>HierarchyBrowserTabs-move" onclick='_init<?= $id_prefix; ?>MoveHierarchyBrowser();'><span><?= _t('Move'); ?></span></a></li>
 <?php
 	}
 	if ($show_add) {
 ?>
-					<li><a href="#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-add" onclick='_init<?php print $vs_id_prefix; ?>AddHierarchyBrowser();'><span><?php print ($vb_objects_x_collections_hierarchy_enabled && ($t_subject->tableName() == 'ca_collections')) ? _t('Add level') : _t('Add'); ?></span></a></li>
+					<li><a href="#<?= $id_prefix; ?>HierarchyBrowserTabs-add" onclick='_init<?= $id_prefix; ?>AddHierarchyBrowser();'><span><?= ($vb_objects_x_collections_hierarchy_enabled && ($t_subject->tableName() == 'ca_collections')) ? _t('Add level') : _t('Add'); ?></span></a></li>
 <?php
 	}
 	if ($show_add_object) {
 ?>
-					<li><a href="#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-addObject" onclick='_init<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser();'><span><?php print _t('Add object'); ?></span></a></li>
+					<li><a href="#<?= $id_prefix; ?>HierarchyBrowserTabs-addObject" onclick='_init<?= $id_prefix; ?>AddObjectHierarchyBrowser();'><span><?= _t('Add object'); ?></span></a></li>
 <?php
 	}
 ?>
@@ -274,15 +282,15 @@
 <?php
 	if (!$vb_batch) {
 ?>
-				<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-explore" class="hierarchyBrowseTab">	
+				<div id="<?= $id_prefix; ?>HierarchyBrowserTabs-explore" class="hierarchyBrowseTab">	
 					<div class="hierarchyBrowserFind">
-						<?php print _t('Find'); ?>: <input type="text" id="<?php print $vs_id_prefix; ?>ExploreHierarchyBrowserSearch" name="search" value="" size="25"/>
+						<?= _t('Find'); ?>: <input type="text" id="<?= $id_prefix; ?>ExploreHierarchyBrowserSearch" name="search" value="" size="25"/>
 					</div>
 					<div class="hierarchyBrowserMessageContainer">
-							<?php print _t('Click %1 names to explore. Click on an arrow icon to open a %1 for editing.', $t_subject->getProperty('NAME_SINGULAR')); ?>
+							<?= _t('Click %1 names to explore. Click on an arrow icon to open a %1 for editing.', $t_subject->getProperty('NAME_SINGULAR')); ?>
 					</div>
 					<div class="clear"><!-- empty --></div>
-					<div id="<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser" class="hierarchyBrowserSmall" <?php print $hier_browser_dim_style; ?>>
+					<div id="<?= $id_prefix; ?>ExploreHierarchyBrowser" class="hierarchyBrowserSmall" <?= $hier_browser_dim_style; ?>>
 						<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 					</div><!-- end hierbrowser -->
 				</div>
@@ -290,16 +298,16 @@
 	}
 	if ($show_move) {
 ?>
-				<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-move" class="hierarchyBrowseTab">
+				<div id="<?= $id_prefix; ?>HierarchyBrowserTabs-move" class="hierarchyBrowseTab">
 					<div class="hierarchyBrowserFind">
-						<?php print _t('Find'); ?>: <input type="text" id="<?php print $vs_id_prefix; ?>MoveHierarchyBrowserSearch" name="search" value="" size="25"/>
+						<?= _t('Find'); ?>: <input type="text" id="<?= $id_prefix; ?>MoveHierarchyBrowserSearch" name="search" value="" size="25"/>
 					</div>
 					<div class="hierarchyBrowserMessageContainer">
-						<?php print _t('Click on an arrow to choose the location to move this record under.', $t_subject->getProperty('NAME_SINGULAR')); ?>
-						<div id='<?php print $vs_id_prefix; ?>HierarchyBrowserSelectionMessage' class='hierarchyBrowserNewLocationMessage'><!-- Message specifying move destination is dynamically inserted here by ca.hierbrowser --></div>	
+						<?= _t('Click on an arrow to choose the location to move this record under.', $t_subject->getProperty('NAME_SINGULAR')); ?>
+						<div id='<?= $id_prefix; ?>HierarchyBrowserSelectionMessage' class='hierarchyBrowserNewLocationMessage'><!-- Message specifying move destination is dynamically inserted here by ca.hierbrowser --></div>	
 					</div>
 					<div class="clear"><!-- empty --></div>
-					<div id="<?php print $vs_id_prefix; ?>MoveHierarchyBrowser" class="hierarchyBrowserSmall" <?php print $hier_browser_dim_style; ?>>
+					<div id="<?= $id_prefix; ?>MoveHierarchyBrowser" class="hierarchyBrowserSmall" <?= $hier_browser_dim_style; ?>>
 						<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 					</div><!-- end hierbrowser -->				
 <?php
@@ -315,8 +323,8 @@
 				// Add movement form
 				//
 ?>
-			<div id="<?php print $vs_id_prefix; ?>StorageLocationMovementForm" style="width: 98%; margin: 5px 0px 2px 6px;">
-				<h3><?php print _t('Movement details'); ?></h3>
+			<div id="<?= $id_prefix; ?>StorageLocationMovementForm" style="width: 98%; margin: 5px 0px 2px 6px;">
+				<h3><?= _t('Movement details'); ?></h3>
 <?php
 				$va_nav = $t_ui->getScreensAsNavConfigFragment($this->request, null, $this->request->getModulePath(), $this->request->getController(), $this->request->getAction(),
 					[],
@@ -326,17 +334,17 @@
 				$t_movement = new ca_movements();
 				$va_form_elements = $t_movement->getBundleFormHTMLForScreen($va_nav['defaultScreen'], array(
 						'request' => $this->request, 
-						'formName' => $vs_id_prefix.'StorageLocationMovementForm',
+						'formName' => $id_prefix.'StorageLocationMovementForm',
 						'omit' => ['ca_storage_locations', 'ca_objects']
 				));
-				print caHTMLHiddenInput($vs_id_prefix.'_movement_screen', array('value' => $va_nav['defaultScreen']));
-				print caHTMLHiddenInput($vs_id_prefix.'_movement_form_name', array('value' => $vs_id_prefix.'StorageLocationMovementForm'));
+				print caHTMLHiddenInput($id_prefix.'_movement_screen', array('value' => $va_nav['defaultScreen']));
+				print caHTMLHiddenInput($id_prefix.'_movement_form_name', array('value' => $id_prefix.'StorageLocationMovementForm'));
 			
 				print join("\n", $va_form_elements);
 ?>
 			</div>
 			<script type="text/javascript">
-				jQuery("#<?php print $vs_id_prefix; ?>StorageLocationMovementForm textarea, #<?php print $vs_id_prefix; ?>StorageLocationMovementForm input").css("max-width", "600px");
+				jQuery("#<?= $id_prefix; ?>StorageLocationMovementForm textarea, #<?= $id_prefix; ?>StorageLocationMovementForm input").css("max-width", "600px");
 			</script>
 <?php
 			}
@@ -348,12 +356,12 @@
 	
 	if ($show_add) {
 ?>
-			<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-add"  class="hierarchyBrowseTab">
+			<div id="<?= $id_prefix; ?>HierarchyBrowserTabs-add"  class="hierarchyBrowseTab">
 				<div class="hierarchyBrowserMessageContainer">
-					<?php print _t('Use the controls below to create new %1 relative to this record in the hierarchy.', $t_subject->getProperty('NAME_PLURAL'), $vs_subject_label); ?>
+					<?= _t('Use the controls below to create new %1 relative to this record in the hierarchy.', $t_subject->getProperty('NAME_PLURAL'), $vs_subject_label); ?>
 				</div>
 				
-				<div id='<?php print $vs_id_prefix; ?>HierarchyBrowseTypeMenu' style="margin-top: 15px;">
+				<div id='<?= $id_prefix; ?>HierarchyBrowseTypeMenu' style="margin-top: 15px;">
 					<div style="float: left; width: 700px">
 <?php
 						$va_add_types = array(_t('under (child)') => 'under');
@@ -363,20 +371,20 @@
 						
 						if ($vs_type_selector) {
 							// for items that take types
-							print "<div id='{$vs_id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 %2 <em>%3</em>", $vs_type_selector, caHTMLSelect('add_type', $va_add_types, array('id' => "{$vs_id_prefix}addType"), ['value' => Session::getVar('default_hierarchy_add_mode')]), $vs_subject_label);
+							print "<div id='{$id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 %2 <em>%3</em>", $vs_type_selector, caHTMLSelect('add_type', $va_add_types, array('id' => "{$id_prefix}addType"), ['value' => Session::getVar('default_hierarchy_add_mode')]), $vs_subject_label);
 		
-							// Note the jQuery(\"#{$vs_id_prefix}childTypeList\").val() which grabs the value of the type
-							print " <a href='#' onclick='_navigateToNewForm(jQuery(\"#{$vs_id_prefix}typeList\").val(), jQuery(\"#{$vs_id_prefix}addType\").val(), (jQuery(\"#{$vs_id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).",".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
+							// Note the jQuery(\"#{$id_prefix}childTypeList\").val() which grabs the value of the type
+							print " <a href='#' onclick='_navigateToNewForm(jQuery(\"#{$id_prefix}typeList\").val(), jQuery(\"#{$id_prefix}addType\").val(), (jQuery(\"#{$id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).",".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
 						} else {
 							// for items without types
-							print "<div id='{$vs_id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 %2 <em>%3</em>",  $t_subject->getProperty('NAME_SINGULAR'), caHTMLSelect('add_type', $va_add_types, array('id' => "{$vs_id_prefix}addType"), ['value' => Session::getVar('default_hierarchy_add_mode')]), $vs_subject_label);
-							print " <a href='#' onclick='_navigateToNewForm(0, jQuery(\"#{$vs_id_prefix}addType\").val(), (jQuery(\"#{$vs_id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
+							print "<div id='{$id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 %2 <em>%3</em>",  $t_subject->getProperty('NAME_SINGULAR'), caHTMLSelect('add_type', $va_add_types, array('id' => "{$id_prefix}addType"), ['value' => Session::getVar('default_hierarchy_add_mode')]), $vs_subject_label);
+							print " <a href='#' onclick='_navigateToNewForm(0, jQuery(\"#{$id_prefix}addType\").val(), (jQuery(\"#{$id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
 						}
 ?>
 					</div>
 				</div>
 				<div class="clear"><!-- empty --></div>
-				<div id="<?php print $vs_id_prefix; ?>AddHierarchyBrowser" class="hierarchyBrowserSmall" <?php print $hier_browser_dim_style; ?>>
+				<div id="<?= $id_prefix; ?>AddHierarchyBrowser" class="hierarchyBrowserSmall" <?= $hier_browser_dim_style; ?>>
 					<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 				</div><!-- end hierbrowser -->
 		</div>
@@ -384,23 +392,23 @@
 	}
 	if ($show_add_object) {
 ?>
-			<div id="<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-addObject"  class="hierarchyBrowseTab">
+			<div id="<?= $id_prefix; ?>HierarchyBrowserTabs-addObject"  class="hierarchyBrowseTab">
 				<div class="hierarchyBrowserMessageContainer">
-					<?php print _t('Use the controls below to create new %1 relative to this %2 in the hierarchy.', $t_object->getProperty('NAME_PLURAL'), mb_strtolower($t_subject->getTypeName())); ?>
+					<?= _t('Use the controls below to create new %1 relative to this %2 in the hierarchy.', $t_object->getProperty('NAME_PLURAL'), mb_strtolower($t_subject->getTypeName())); ?>
 				</div>
 				
-				<div id='<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowseTypeMenu' style="margin-top: 15px;">
+				<div id='<?= $id_prefix; ?>AddObjectHierarchyBrowseTypeMenu' style="margin-top: 15px;">
 					<div style="float: left; width: 700px">
 <?php
-							print "<div id='{$vs_id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 under <em>%2</em>", $this->getVar('objectTypeList'), $vs_subject_label);
+							print "<div id='{$id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 under <em>%2</em>", $this->getVar('objectTypeList'), $vs_subject_label);
 		
-							// Note the jQuery(\"#{$vs_id_prefix}childTypeList\").val() which grabs the value of the type
-							print " <a href='#' onclick='_navigateToNewObjectForm(jQuery(\"#{$vs_id_prefix}objectTypeList\").val(), ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";				
+							// Note the jQuery(\"#{$id_prefix}childTypeList\").val() which grabs the value of the type
+							print " <a href='#' onclick='_navigateToNewObjectForm(jQuery(\"#{$id_prefix}objectTypeList\").val(), ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";				
 ?>
 					</div>
 				</div>
 				<div class="clear"><!-- empty --></div>
-				<div id="<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser" class="hierarchyBrowserSmall" <?php print $hier_browser_dim_style; ?>>
+				<div id="<?= $id_prefix; ?>AddObjectHierarchyBrowser" class="hierarchyBrowserSmall" <?= $hier_browser_dim_style; ?>>
 					<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 				</div><!-- end hierbrowser -->
 		</div>
@@ -409,7 +417,7 @@
 ?>
 		</div>
 	</div>
-	<input type='hidden' name='<?php print $vs_id_prefix; ?>_new_parent_id' id='<?php print $vs_id_prefix; ?>_new_parent_id' value='<?php print $pn_parent_id; ?>'/>
+	<input type='hidden' name='<?= $id_prefix; ?>_new_parent_id' id='<?= $id_prefix; ?>_new_parent_id' value='<?= $pn_parent_id; ?>'/>
 
 <script type="text/javascript">
 	jQuery(document).ready(function() {	
@@ -417,16 +425,16 @@
 	if ($show_move) {
 ?>
 		// Set up "move" hierarchy browse search
-		jQuery('#<?php print $vs_id_prefix; ?>MoveHierarchyBrowserSearch').autocomplete(
+		jQuery('#<?= $id_prefix; ?>MoveHierarchyBrowserSearch').autocomplete(
 			{ 
-				source: '<?php print $va_lookup_urls_for_move['search']; ?>', minLength: 3, delay: 800, html: true,
+				source: '<?= $va_lookup_urls_for_move['search']; ?>', minLength: 3, delay: 800, html: true,
 				select: function( event, ui ) {
 					if (ui.item.id) {
-						jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserContainer").slideDown(350);
-						o<?php print $vs_id_prefix; ?>MoveHierarchyBrowser.setUpHierarchy(ui.item.id);	// jump browser to selected item
+						jQuery("#<?= $id_prefix; ?>HierarchyBrowserContainer").slideDown(350);
+						o<?= $id_prefix; ?>MoveHierarchyBrowser.setUpHierarchy(ui.item.id);	// jump browser to selected item
 					}
 					event.preventDefault();
-					jQuery('#<?php print $vs_id_prefix; ?>MoveHierarchyBrowserSearch').val('');
+					jQuery('#<?= $id_prefix; ?>MoveHierarchyBrowserSearch').val('');
 				}
 			}
 		).click(function() { this.select() });
@@ -434,11 +442,11 @@
 	}
 ?>
 
-		jQuery("#<?php print $vs_id_prefix; ?>browseToggle").click(function(e, opts) {
-			_init<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser();
+		jQuery("#<?= $id_prefix; ?>browseToggle").click(function(e, opts) {
+			_init<?= $id_prefix; ?>ExploreHierarchyBrowser();
 			var delay = (opts && opts.delay && (parseInt(opts.delay) >= 0)) ? opts.delay :  250;
-			jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserContainer").slideToggle(delay, function() { 
-				jQuery("#<?php print $vs_id_prefix; ?>browseToggle").html((this.style.display == 'block') ? '<?php print '<span class="form-button">'._t('Close browser').'</span>';?>' : '<?php print '<span class="form-button">'._t('Show Hierarchy').'</span>';?>');
+			jQuery("#<?= $id_prefix; ?>HierarchyBrowserContainer").slideToggle(delay, function() { 
+				jQuery("#<?= $id_prefix; ?>browseToggle").html((this.style.display == 'block') ? '<?= '<span class="form-button">'._t('Close browser').'</span>';?>' : '<?= '<span class="form-button">'._t('Show Hierarchy').'</span>';?>');
 			}); 
 			return false;
 		});
@@ -447,28 +455,28 @@
 	if (!$vb_batch) {
 ?>
 		// Set up "explore" hierarchy browse search
-		jQuery('#<?php print $vs_id_prefix; ?>ExploreHierarchyBrowserSearch').autocomplete(
+		jQuery('#<?= $id_prefix; ?>ExploreHierarchyBrowserSearch').autocomplete(
 			{
-				source: '<?php print $va_lookup_urls['search']; ?>', minLength: 3, delay: 800, html: true,
+				source: '<?= $va_lookup_urls['search']; ?>', minLength: 3, delay: 800, html: true,
 				select: function( event, ui ) {
 					if (ui.item.id) {
-						jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserContainer").slideDown(350);
-						o<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser.setUpHierarchy(ui.item.id);	// jump browser to selected item
+						jQuery("#<?= $id_prefix; ?>HierarchyBrowserContainer").slideDown(350);
+						o<?= $id_prefix; ?>ExploreHierarchyBrowser.setUpHierarchy(ui.item.id);	// jump browser to selected item
 					}
 					event.preventDefault();
-					jQuery('#<?php print $vs_id_prefix; ?>ExploreHierarchyBrowserSearch').val('');
+					jQuery('#<?= $id_prefix; ?>ExploreHierarchyBrowserSearch').val('');
 				}
 			}
 		).click(function() { this.select() });
 		
 		// Disable form change warnings to add type drop-downs
-		jQuery('#<?php print $vs_id_prefix; ?>HierarchyBrowseAddUnder select').unbind('change');
-		jQuery('#<?php print $vs_id_prefix; ?>HierarchyBrowseAddNextTo select').unbind('change');		
+		jQuery('#<?= $id_prefix; ?>HierarchyBrowseAddUnder select').unbind('change');
+		jQuery('#<?= $id_prefix; ?>HierarchyBrowseAddNextTo select').unbind('change');		
 <?php
 	}
 ?>		
-		jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs").tabs({ selected: 0 });			// Activate tabs
-		jQuery('#<?php print $vs_id_prefix; ?>HierarchyBrowserContainer').hide(0);					// Hide extended options
+		jQuery("#<?= $id_prefix; ?>HierarchyBrowserTabs").tabs({ selected: 0 });			// Activate tabs
+		jQuery('#<?= $id_prefix; ?>HierarchyBrowserContainer').hide(0);					// Hide extended options
 	});
 
 <?php
@@ -478,13 +486,13 @@
 		function _navigateToNewForm(type_id, action, id, after_id) {
 			switch(action) {
 				case 'above':
-					document.location = '<?php print caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/above_id/' + id;
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/above_id/' + id;
 					break;
 				case 'under':
-					document.location = '<?php print caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id;
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id;
 					break;
 				case 'next_to':
-					document.location = '<?php print caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id + '/after_id/' + after_id;
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id + '/after_id/' + after_id;
 					break;
 				default:
 					alert("Invalid action!");
@@ -494,37 +502,37 @@
 	}
 	if (typeof  _navigateToNewObjectForm != 'function') {
 		function _navigateToNewObjectForm(type_id, parent_collection_id) {
-			document.location = '<?php print caEditorUrl($this->request, "ca_objects", 0); ?>/type_id/' + type_id + '/collection_id/' + parent_collection_id;
+			document.location = '<?= caEditorUrl($this->request, "ca_objects", 0); ?>/type_id/' + type_id + '/collection_id/' + parent_collection_id;
 		}
 	}
 	
 	// Set up "explore" hierarchy browser
-	var o<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser = null;
+	var o<?= $id_prefix; ?>ExploreHierarchyBrowser = null;
 	
-	function _init<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser() {
-		if (!o<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser) {
-			o<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser = caUI.initHierBrowser('<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser', {
-				levelDataUrl: '<?php print $va_lookup_urls['levelList']; ?>',
-				initDataUrl: '<?php print $va_lookup_urls['ancestorList']; ?>',
+	function _init<?= $id_prefix; ?>ExploreHierarchyBrowser() {
+		if (!o<?= $id_prefix; ?>ExploreHierarchyBrowser) {
+			o<?= $id_prefix; ?>ExploreHierarchyBrowser = caUI.initHierBrowser('<?= $id_prefix; ?>ExploreHierarchyBrowser', {
+				levelDataUrl: '<?= $va_lookup_urls['levelList']; ?>',
+				initDataUrl: '<?= $va_lookup_urls['ancestorList']; ?>',
 				
-				dontAllowEditForFirstLevel: <?php print (in_array($t_subject->tableName(), array('ca_places', 'ca_storage_locations', 'ca_list_items', 'ca_relationship_types')) ? 'true' : 'false'); ?>,
+				dontAllowEditForFirstLevel: <?= (in_array($t_subject->tableName(), array('ca_places', 'ca_storage_locations', 'ca_list_items', 'ca_relationship_types')) ? 'true' : 'false'); ?>,
 				
-				readOnly: false, //<?php print $vb_read_only ? 1 : 0; ?>,
-				disabledItems: '<?php print $vs_disabled_items_mode; ?>',
+				readOnly: false, //<?= $vb_read_only ? 1 : 0; ?>,
+				disabledItems: '<?= $vs_disabled_items_mode; ?>',
 				
-				editUrl: '<?php print $vs_edit_url; ?>',
-				editButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
-				disabledButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
+				editUrl: '<?= $vs_edit_url; ?>',
+				editButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
+				disabledButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
 				
-				allowDragAndDropSorting: <?php print caDragAndDropSortingForHierarchyEnabled($this->request, $t_subject->tableName(), $t_subject->getPrimaryKey()) ? "true" : "false"; ?>,
-				sortSaveUrl: '<?php print $va_lookup_urls['sortSave']; ?>',
+				allowDragAndDropSorting: <?= caDragAndDropSortingForHierarchyEnabled($this->request, $t_subject->tableName(), $t_subject->getPrimaryKey()) ? "true" : "false"; ?>,
+				sortSaveUrl: '<?= $va_lookup_urls['sortSave']; ?>',
 				dontAllowDragAndDropSortForFirstLevel: true,
 
-				initItemID: '<?php print $vn_init_id; ?>',
-				indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+				initItemID: '<?= $vn_init_id; ?>',
+				indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
 				displayCurrentSelectionOnLoad: false,
-				autoShrink: <?php print (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
-				autoShrinkAnimateID: '<?php print $vs_id_prefix; ?>ExploreHierarchyBrowser'
+				autoShrink: <?= (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
+				autoShrinkAnimateID: '<?= $id_prefix; ?>ExploreHierarchyBrowser'
 			});
 		}
 	}
@@ -534,33 +542,32 @@
 	if ($show_move) {
 ?>
 	// Set up "move" hierarchy browser
-	var o<?php print $vs_id_prefix; ?>MoveHierarchyBrowser = null;
-	
-	function _init<?php print $vs_id_prefix; ?>MoveHierarchyBrowser() {
-		if (!o<?php print $vs_id_prefix; ?>MoveHierarchyBrowser) {
-			o<?php print $vs_id_prefix; ?>MoveHierarchyBrowser = caUI.initHierBrowser('<?php print $vs_id_prefix; ?>MoveHierarchyBrowser', {
-				levelDataUrl: '<?php print $va_lookup_urls['levelList']; ?>',
-				initDataUrl: '<?php print $va_lookup_urls['ancestorList']; ?>',
+	var o<?= $id_prefix; ?>MoveHierarchyBrowser = null;
+	function _init<?= $id_prefix; ?>MoveHierarchyBrowser() {
+		if (!o<?= $id_prefix; ?>MoveHierarchyBrowser) {
+			o<?= $id_prefix; ?>MoveHierarchyBrowser = caUI.initHierBrowser('<?= $id_prefix; ?>MoveHierarchyBrowser', {
+				levelDataUrl: '<?= $va_lookup_urls['levelList']; ?>',
+				initDataUrl: '<?= $va_lookup_urls['ancestorList']; ?>',
 				
-				readOnly: <?php print $vb_read_only ? 1 : 0; ?>,
-				disabledItems: '<?php print $vs_disabled_items_mode; ?>',
+				readOnly: <?= $vb_read_only ? 1 : 0; ?>,
+				disabledItems: '<?= $vs_disabled_items_mode; ?>',
 				
-				initItemID: '<?php print $vn_init_id; ?>',
-				indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
-				editButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
-				disabledButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
+				initItemID: '<?= $vn_init_id; ?>',
+				indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+				editButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
+				disabledButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
 						
-				allowDragAndDropSorting: <?php print caDragAndDropSortingForHierarchyEnabled($this->request, $t_subject->tableName(), $t_subject->getPrimaryKey()) ? "true" : "false"; ?>,
-				sortSaveUrl: '<?php print $va_lookup_urls['sortSave']; ?>',
+				allowDragAndDropSorting: <?= caDragAndDropSortingForHierarchyEnabled($this->request, $t_subject->tableName(), $t_subject->getPrimaryKey()) ? "true" : "false"; ?>,
+				sortSaveUrl: '<?= $va_lookup_urls['sortSave']; ?>',
 				dontAllowDragAndDropSortForFirstLevel: true,
 		
-				currentSelectionIDID: '<?php print $vs_id_prefix; ?>_new_parent_id',
-				currentSelectionDisplayID: '<?php print $vs_id_prefix; ?>HierarchyBrowserSelectionMessage',
-				currentSelectionDisplayFormat: '<?php print addslashes(_t('Will be moved under <em>^current</em> after next save.')); ?>',
+				currentSelectionIDID: '<?= $id_prefix; ?>_new_parent_id',
+				currentSelectionDisplayID: '<?= $id_prefix; ?>HierarchyBrowserSelectionMessage',
+				currentSelectionDisplayFormat: '<?= addslashes(_t('Will be moved under <em>^current</em> after next save.')); ?>',
 				
-				allowExtractionFromHierarchy: <?php print ($t_subject->getProperty('HIERARCHY_TYPE') == __CA_HIER_TYPE_ADHOC_MONO__) ? 'true' : 'false'; ?>,
-				extractFromHierarchyButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_EXTRACT__, 1); ?>",
-				extractFromHierarchyMessage: '<?php print addslashes(_t('Will be placed at the top of its own hierarchy after next save.')); ?>',
+				allowExtractionFromHierarchy: <?= ($t_subject->getProperty('HIERARCHY_TYPE') == __CA_HIER_TYPE_ADHOC_MONO__) ? 'true' : 'false'; ?>,
+				extractFromHierarchyButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_EXTRACT__, 1); ?>",
+				extractFromHierarchyMessage: '<?= addslashes(_t('Will be placed at the top of its own hierarchy after next save.')); ?>',
 				
 				onSelection: function(id, parent_id, name, formattedDisplay) {
 					// Update "move" status message
@@ -568,20 +575,20 @@
 	if (($t_subject->tableName() == 'ca_collections')) {
 ?>
 					if (id.substr(0, 10) == 'ca_objects') {
-						formattedDisplay = '<?php print addslashes(_t("Cannot move collection under object")); ?>';
-						jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserSelectionMessage").html(formattedDisplay);
+						formattedDisplay = '<?= addslashes(_t("Cannot move collection under object")); ?>';
+						jQuery("#<?= $id_prefix; ?>HierarchyBrowserSelectionMessage").html(formattedDisplay);
 						return;
 					}
 <?php
 	}
 ?>
-					jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserSelectionMessage").html(formattedDisplay);
+					jQuery("#<?= $id_prefix; ?>HierarchyBrowserSelectionMessage").html(formattedDisplay);
 					if (caUI.utils.showUnsavedChangesWarning) { caUI.utils.showUnsavedChangesWarning(true); }
 				},
 				
 				displayCurrentSelectionOnLoad: false,
-				autoShrink: <?php print (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
-				autoShrinkAnimateID: '<?php print $vs_id_prefix; ?>MoveHierarchyBrowser'
+				autoShrink: <?= (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
+				autoShrinkAnimateID: '<?= $id_prefix; ?>MoveHierarchyBrowser'
 			});
 		}
 	}
@@ -591,23 +598,23 @@
 	if ($show_add) {
 ?>
 	// Set up "add" hierarchy browser
-	var o<?php print $vs_id_prefix; ?>AddHierarchyBrowser = null;
+	var o<?= $id_prefix; ?>AddHierarchyBrowser = null;
 	
-	function _init<?php print $vs_id_prefix; ?>AddHierarchyBrowser() {
-		if (!o<?php print $vs_id_prefix; ?>AddHierarchyBrowser) {
-			o<?php print $vs_id_prefix; ?>AddHierarchyBrowser = caUI.initHierBrowser('<?php print $vs_id_prefix; ?>AddHierarchyBrowser', {
-				levelDataUrl: '<?php print $va_lookup_urls['levelList']; ?>',
-				initDataUrl: '<?php print $va_lookup_urls['ancestorList']; ?>',
+	function _init<?= $id_prefix; ?>AddHierarchyBrowser() {
+		if (!o<?= $id_prefix; ?>AddHierarchyBrowser) {
+			o<?= $id_prefix; ?>AddHierarchyBrowser = caUI.initHierBrowser('<?= $id_prefix; ?>AddHierarchyBrowser', {
+				levelDataUrl: '<?= $va_lookup_urls['levelList']; ?>',
+				initDataUrl: '<?= $va_lookup_urls['ancestorList']; ?>',
 				
 				readOnly: true,
 				allowSelection: false,
-				disabledItems: '<?php print $vs_disabled_items_mode; ?>',
+				disabledItems: '<?= $vs_disabled_items_mode; ?>',
 				
-				initItemID: '<?php print $vn_init_id; ?>',
-				indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+				initItemID: '<?= $vn_init_id; ?>',
+				indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
 				displayCurrentSelectionOnLoad: true,
-				autoShrink: <?php print (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
-				autoShrinkAnimateID: '<?php print $vs_id_prefix; ?>AddHierarchyBrowser'
+				autoShrink: <?= (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
+				autoShrinkAnimateID: '<?= $id_prefix; ?>AddHierarchyBrowser'
 			});
 		}
 	}
@@ -617,22 +624,22 @@
 	if ($show_add_object) {
 ?>
 	// Set up "add object" hierarchy browser
-	var o<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser = null;
+	var o<?= $id_prefix; ?>AddObjectHierarchyBrowser = null;
 	
-	function _init<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser() {
-		if (!o<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser) {
-			o<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser = caUI.initHierBrowser('<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser', {
-				levelDataUrl: '<?php print $va_lookup_urls['levelList']; ?>',
-				initDataUrl: '<?php print $va_lookup_urls['ancestorList']; ?>',
+	function _init<?= $id_prefix; ?>AddObjectHierarchyBrowser() {
+		if (!o<?= $id_prefix; ?>AddObjectHierarchyBrowser) {
+			o<?= $id_prefix; ?>AddObjectHierarchyBrowser = caUI.initHierBrowser('<?= $id_prefix; ?>AddObjectHierarchyBrowser', {
+				levelDataUrl: '<?= $va_lookup_urls['levelList']; ?>',
+				initDataUrl: '<?= $va_lookup_urls['ancestorList']; ?>',
 				
 				readOnly: true,
 				allowSelection: false,
 				
-				initItemID: '<?php print $vn_init_id; ?>',
-				indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+				initItemID: '<?= $vn_init_id; ?>',
+				indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
 				displayCurrentSelectionOnLoad: true,
-				autoShrink: <?php print (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
-				autoShrinkAnimateID: '<?php print $vs_id_prefix; ?>AddObjectHierarchyBrowser'
+				autoShrink: <?= (caGetOption('auto_shrink', $pa_bundle_settings, false) ? 'true' : 'false'); ?>,
+				autoShrinkAnimateID: '<?= $id_prefix; ?>AddObjectHierarchyBrowser'
 			});
 		}
 	}
@@ -651,18 +658,18 @@
 		// Remove "unsaved changes" warnings from search boxes
 		jQuery(".hierarchyBrowserFind input").unbind("change");
 		// Remove "unsaved changes" warnings from drop-downs in "add" tab
-		jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserTabs-add select").unbind("change");
+		jQuery("#<?= $id_prefix; ?>HierarchyBrowserTabs-add select").unbind("change");
 		
 <?php
 	if ($vb_batch) {
 ?>
-		jQuery("#<?php print $vs_id_prefix; ?>HierarchyBrowserContainer").show();
-		jQuery("#<?php print $vs_id_prefix; ?>").hide();
-		_init<?php print $vs_id_prefix; ?>MoveHierarchyBrowser();
+		jQuery("#<?= $id_prefix; ?>HierarchyBrowserContainer").show();
+		jQuery("#<?= $id_prefix; ?>").hide();
+		_init<?= $id_prefix; ?>MoveHierarchyBrowser();
 <?php
 	} elseif (isset($pa_bundle_settings['open_hierarchy']) && (bool)$pa_bundle_settings['open_hierarchy']) {
 ?>
-		jQuery("#<?php print $vs_id_prefix; ?>browseToggle").trigger("click", { "delay" : 0 });
+		jQuery("#<?= $id_prefix; ?>browseToggle").trigger("click", { "delay" : 0 });
 <?php
 	}
 ?>


### PR DESCRIPTION
PR resolves issue where forms that include the "Location in hierarchy" bundle (hierarchy_location) for records that allow ad-hoc hierarchies (such as ca_objects, ca_collections, ca_entities) throw javascript errors in batch editing mode, disabling the entire form in some browsers.