### PR TITLE
PROV-2788 Fix quoting of sort fields in find()

### DIFF
--- a/app/lib/LabelableBaseModelWithAttributes.php
+++ b/app/lib/LabelableBaseModelWithAttributes.php
@@ -610,10 +610,10 @@
 			// ... and in sort list
 			$vs_sort_proc = null;
 			if ((preg_match("!^{$vs_table}.preferred_labels[\.]{0,1}(.*)!", $ps_sort, $va_matches)) || (preg_match("!^{$vs_table}.nonpreferred_labels[\.]{0,1}(.*)!", $ps_sort, $va_matches))) { 
-				$vs_sort_proc = ($va_matches[1] && ($t_label->hasField($va_matches[1]))) ? "{$vs_label_table}.".$va_matches[1] : "{$vs_label_table}.".$t_label->getDisplayField();
+				$vs_sort_proc = ($va_matches[1] && ($t_label->hasField($va_matches[1]))) ? "{$vs_label_table}.`".$va_matches[1].'`' : "{$vs_label_table}.`".$t_label->getDisplayField().'`';
 				$vb_has_label_fields = true; 
 			} elseif(preg_match("!^{$vs_table}\.([A-Za-z0-9_]+)!", $ps_sort, $va_matches) && $t_instance->hasField($va_matches[1])) {
-			    $vs_sort_proc = $ps_sort;
+			    $vs_sort_proc = "{$vs_table}.`{$va_matches[1]}`";
 			}
 			
 			// Check for attributes in value list
@@ -992,7 +992,7 @@
 					break;
 			}
 		
-            $vs_sql = "SELECT DISTINCT {$vs_table}.{$select_flds}".($vs_sort_proc ? ", `{$vs_sort_proc}`" : "")." FROM {$vs_table}";
+            $vs_sql = "SELECT DISTINCT {$vs_table}.{$select_flds}".($vs_sort_proc ? ", {$vs_sort_proc}" : "")." FROM {$vs_table}";
             $vs_sql .= join("\n", $va_joins);
             $vs_sql .= ((sizeof($va_sql) > 0) ? " WHERE (".join(" AND ", $va_sql).")" : "");
 			


### PR DESCRIPTION
PR corrects incorrect quoting of sort fields in find() method. Issue was introduced by code quoting fields for compatibility with MySQL 8.