### PR TITLE
PROV-3098 Resolve issues in object representation bundle

### DIFF
--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -2243,9 +2243,9 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	 */
 	static function mediaExists($ps_filepath) {
 		if (!file_exists($ps_filepath) || !is_readable($ps_filepath)) { return null; }
-		$vs_md5 = md5_file($ps_filepath);
+		$vs_md5 = @md5_file($ps_filepath);
 		$t_rep = new ca_object_representations();
-		if ($t_rep->load(array('md5' => $vs_md5, 'deleted' => 0))) { 
+		if ($vs_md5 && ($t_rep->load(array('md5' => $vs_md5, 'deleted' => 0)))) { 
 			return $t_rep;
 		}
 		

--- a/themes/default/views/bundles/ca_object_representations.php
+++ b/themes/default/views/bundles/ca_object_representations.php
@@ -89,7 +89,7 @@
  	if (is_array($bundles_to_edit_order) && sizeof($bundles_to_edit_order)) {
  		$bundles_to_edit_sorted = [];
  		foreach($bundles_to_edit_order as $o) {
- 			if (!($t = array_pop(explode('.', $o)))) { continue; }
+ 			if (!($t = join('.', array_slice(explode('.', $o), 1)))) { continue; }
  			if (in_array($t, $bundles_to_edit_proc)) { $bundles_to_edit_sorted[] = $t; }
  		}
  		foreach($bundles_to_edit_proc as $t) {


### PR DESCRIPTION
PR resolves several issues in the object representation bundle:

1. Remove regression preventing all media upload in "classic" version of object representation bundle (some users are still using this interface)
2. When checking for existing media with the same MD5 checksum, filter deleted media
3. Honor editable bundle sort setting for all fields in "new" object representation bundle interface