### PR TITLE
Validate existence of parameter

### DIFF
--- a/app/lib/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch.php
@@ -623,7 +623,7 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 			}
 		}
 
-		if(sizeof($va_bulk_params['body'])) {
+		if(isset($va_bulk_params['body']) && sizeof($va_bulk_params['body'])) {
 			$this->getClient()->bulk($va_bulk_params);
 
 			// we usually don't need indexing to be available *immediately* unless we're running automated tests of course :-)


### PR DESCRIPTION
After transition to ElasticSearch before  full  reindexing 
by running ./support/bin/caUtils  purge-deleted    to remove stale records, i am getting 
lot of  errors:
PHP Warning:  sizeof(): Parameter must be an array or an object that implements Countable in /var/www/providence/app/lib/Plugins/SearchEngine/ElasticSearch.php on line 626







