### PR TITLE
NOJIRA Make any service membership enough for auth action

### DIFF
--- a/app/conf/access_restrictions.conf
+++ b/app/conf/access_restrictions.conf
@@ -1447,6 +1447,7 @@ access_restrictions = {
 	},
     /AuthController = {
     	default = {
+    		operator = OR,
     		actions = { can_use_json_find_service, can_use_json_item_service, can_use_json_browse_service, can_use_json_model_service, can_use_xml_config_updater, can_use_json_simple_service, can_use_json_replication_service, can_view_system_statistics }
     	}
     },


### PR DESCRIPTION
PR makes possession of any json service priv enough for access to the auth endpoint. Currently user must have access to all services to be able to login, which doesn't make sense.