### PR TITLE
NOJIRA Add check to prevent attempted indexing of metadata elements with codes that match intrinsic names

### DIFF
--- a/app/lib/Search/SearchBase.php
+++ b/app/lib/Search/SearchBase.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2019 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -190,7 +190,7 @@ require_once(__CA_LIB_DIR__."/Db.php");
                         if (
                         	((substr($vs_f, 0, 14) === '_ca_attribute_') && preg_match('!^_ca_attribute_([A-Za-z]+[A-Za-z0-9_]*)$!', $vs_f, $va_matches) && ($element_id = ca_metadata_elements::getElementID($va_matches[1])))
                         	||
-                        	($element_id = ca_metadata_elements::getElementID($vs_f))
+                        	(!$t_subject->hasField($vs_f) && ($element_id = ca_metadata_elements::getElementID($vs_f)))
                         ) {
                             unset($field_list[$vs_f]);
                             


### PR DESCRIPTION
PR resolves potential indexing issue with systems where a metadata element is defined with a code identical to an intrinsic. The metadata element will be pulled for indexing, even if it isn't bound to the record being indexed. PR introduces a check to use intrinsic when present.