### PR TITLE
PROV-3131 Add media importer options controlling format and content of labels on newly created target records

### DIFF
--- a/app/controllers/batch/MediaImportController.php
+++ b/app/controllers/batch/MediaImportController.php
@@ -255,6 +255,8 @@
  				'setCreateName' => $this->request->getParameter('set_create_name', pString),
  				'set_id' => $this->request->getParameter('set_id', pInteger),
  				'idnoMode' => $this->request->getParameter('idno_mode', pString),
+ 				'labelMode' => $this->request->getParameter('label_mode', pString),
+ 				'labelText' => $this->request->getParameter('label_text', pString),
  				'idno' => $this->request->getParameter('idno', pString),
 				'representationIdnoMode' => $this->request->getParameter('representation_idno_mode', pString),
 				'representation_idno' => $this->request->getParameter('idno_representation_number', pString),

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -590,6 +590,8 @@ class BatchProcessor {
 		$vn_object_representation_mapping_id= $pa_options['ca_object_representations_mapping_id'];
 
 		$vs_idno_mode 						= $pa_options['idnoMode'];
+		$vs_label_mode 						= $pa_options['labelMode'];
+		$label_text		 					= $pa_options['labelText'];
 		$vs_idno 							= $pa_options['idno'];
 
 		$vs_representation_idno_mode		= $pa_options['representationIdnoMode'];
@@ -1048,14 +1050,41 @@ class BatchProcessor {
 						//$o_trans->rollback();
 						continue;
 					}
+					
+					switch(strtolower($vs_label_mode)) {
+						case 'idno':
+							$vs_label_value = $vs_idno_value;
+							break;
+						case 'blank':
+							// Use blank placeholder text
+							$vs_label_value = '['.caGetBlankLabelText($vs_import_target).']';
+							break;
+						case 'filename_no_ext':
+							// use filename without extension as identifier
+							$f_no_ext = preg_replace(self::REGEXP_FILENAME_NO_EXT, '', $f);
+							$vs_label_value = $f_no_ext;
+							break;
+						case 'directory_and_filename':
+							// use the directory + filename as identifier
+							$vs_label_value = $d.'/'.$f;
+							break;
+						case 'user':
+							$vs_label_value = $label_text;
+							break;
+						case 'filename':
+						default:
+							// use the filename as label
+							$vs_label_value = $f;
+							break;
+					}
 
 					if($t_instance->tableName() == 'ca_entities') { // entity labels deserve special treatment
 						$t_instance->addLabel(
-							array('surname' => $f), $vn_locale_id, null, true
+							array('surname' => $vs_label_value), $vn_locale_id, null, true
 						);
 					} else {
 						$t_instance->addLabel(
-							array($t_instance->getLabelDisplayField() => $f), $vn_locale_id, null, true
+							array($t_instance->getLabelDisplayField() => $vs_label_value), $vn_locale_id, null, true
 						);
 					}
 

--- a/themes/default/views/batch/mediaimport/import_options_html.php
+++ b/themes/default/views/batch/mediaimport/import_options_html.php
@@ -292,6 +292,84 @@
 		</div>
 
 		<div class='bundleLabel'>
+			<span class="formLabelText"><?= _t('%1 title', ucfirst(caGetTableDisplayName($t_instance->tableName(), false))); ?></span>
+			<div class="bundleContainer">
+				<div class="caLabelList" id="caMediaImportLabelControls">
+					<div style='padding:10px 0px 10px 10px;'>
+						<table>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'blank', 'checked' => 1, 'id' => 'caLabelBlankMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'blank')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+								?></td>
+								<td class='formLabel'><?= _t('Set %1 title to %2', caGetTableDisplayName($t_instance->tableName(), false), '['.caGetBlankLabelText($t_instance->tableName()).']'); ?></td>
+							</tr>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'user', 'id' => 'caLabelUserMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'user')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+								?></td>
+								<td class='formLabel'><?= _t('Set %1 title to %2', caGetTableDisplayName($t_instance->tableName(), false), caHTMLTextInput('label_text', ['id' => 'caLabelUserModeText', 'value' => $va_last_settings['labelText']], ['width' => '400px'])); ?></td>
+							</tr>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'form', 'id' => 'caLabelIdnoMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'idno')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+								?></td>
+								<td class='formLabel' id='caIdnoFormModeForm'><?= _t('Set %1 title to identifier', caGetTableDisplayName($t_instance->tableName(), false)); ?></td>
+							</tr>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'filename', 'id' => 'caLabelFilenameMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'filename')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+								?></td>
+								<td class='formLabel'><?= _t('Set %1 title to file name', caGetTableDisplayName($t_instance->tableName(), false)); ?></td>
+							</tr>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'filename_no_ext', 'id' => 'caLabelFilenameNoExtMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'filename_no_ext')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+									?></td>
+								<td class='formLabel'><?= _t('Set %1 title to file name without extension', caGetTableDisplayName($t_instance->tableName(), false)); ?></td>
+							</tr>
+							<tr>
+								<td><?php
+									$va_attrs = array('value' => 'directory_and_filename', 'id' => 'caLabelDirectoryAndFilenameMode');
+									if (isset($va_last_settings['labelMode']) && ($va_last_settings['labelMode'] == 'directory_and_filename')) { $va_attrs['checked'] = 1; }
+									print caHTMLRadioButtonInput('label_mode', $va_attrs);
+								?></td>
+								<td class='formLabel'><?= _t('Set %1 title to directory and file name', caGetTableDisplayName($t_instance->tableName(), false)); ?></td>
+							</tr>
+						</table>
+						<script type="text/javascript">
+							jQuery(document).ready(function() {
+								jQuery("#caIdnoFormMode").click(function() {
+									jQuery("#caIdnoFormModeForm input").prop('disabled', false);
+								});
+								jQuery("#caIdnoFilenameMode").click(function() {
+									jQuery("#caIdnoFormModeForm input").prop('disabled', true);
+								});
+								jQuery("#caIdnoFilenameNoExtMode").click(function() {
+									jQuery("#caIdnoFormModeForm input").prop('disabled', true);
+								});
+								jQuery("#caIdnoDirectoryAndFilenameMode").click(function() {
+									jQuery("#caIdnoFormModeForm input").prop('disabled', true);
+								});
+
+								jQuery("#caMediaImportIdnoControls").find("input:checked").click();
+							});
+
+						</script>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class='bundleLabel'>
 			<span class="formLabelText"><?= (($this->getVar('ca_object_representations_mapping_list_count') > 0) || ($this->getVar($t_instance->tableName().'_mapping_list_count') > 0)) ? _t('Status, access &amp; metadata extraction') : _t('Status &amp; access'); ?></span>
 				<div class="bundleContainer">
 					<div class="caLabelList" >


### PR DESCRIPTION
PR adds options to control labels on newly created target records in media importer. Options include:

1. Set label to identifier
2. Set label to user-entered text
3. Set label to file name
4. Set label to file name without extension
5. Set label to directory + file name
6. Set label to "blank" value (as configured)