### PR TITLE
NOJIRA Fix set batch editing when opening set from search results.

### DIFF
--- a/themes/default/views/find/Search/search_sets_html.php
+++ b/themes/default/views/find/Search/search_sets_html.php
@@ -214,7 +214,7 @@
 					msg = msg.replace('^set_name', res['set_name']);
 					
 					if (jQuery('#caCreateSetBatchEdit').prop('checked')) {
-						window.location = '<?php print caNavUrl($this->request, 'batch', 'Editor', 'Edit', array()); ?>/set_id/' + res['set_id'];
+						window.location = '<?php print caNavUrl($this->request, 'batch', 'Editor', 'Edit', array()); ?>/id/ca_sets:' + res['set_id'];
 					} else {
 						jQuery.jGrowl(msg, { header: '<?php print addslashes(_t('Create set')); ?>' }); 
 						// add new set to "add to set" list


### PR DESCRIPTION
* Previously the set id parameter passed didn't match the url pattern
used in 1b30f3d5ba37489f95c8331d294ef43a6739aae9
* Fixes an issue where if you click onto a different screen other than
the default screen in the batch edit UI you get an
ApplicationException::('Invalid target')