### PR TITLE
Resolves #955 - add parent_id entries

### DIFF
--- a/app/conf/search_indexing.conf
+++ b/app/conf/search_indexing.conf
@@ -754,6 +754,7 @@ ca_places = {
 			type_id = { STORE, DONT_TOKENIZE },
 			_metadata = { },
 			hierarchy_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
 			access = { STORE, DONT_TOKENIZE },
 			status = { STORE, DONT_TOKENIZE },
 			deleted = { STORE, DONT_TOKENIZE }
@@ -847,6 +848,7 @@ ca_occurrences = {
 			type_id = { STORE, DONT_TOKENIZE },
 			_metadata = { },
 			hier_occurrence_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
 			access = { STORE, DONT_TOKENIZE },
 			status = { STORE, DONT_TOKENIZE },
 			deleted = { STORE, DONT_TOKENIZE }
@@ -968,6 +970,7 @@ ca_collections = {
 			type_id = { STORE, DONT_TOKENIZE },
 			_metadata = { },
 			hier_collection_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
 			access = { STORE, DONT_TOKENIZE },
 			status = { STORE, DONT_TOKENIZE },
 			deleted = { STORE, DONT_TOKENIZE }
@@ -1189,6 +1192,7 @@ ca_list_items = {
 		fields = {
 			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100 },
 			list_id = { STORE, DONT_TOKENIZE },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
 			deleted = { STORE, DONT_TOKENIZE }
 		}
 	}
@@ -1283,6 +1287,7 @@ ca_storage_locations = {
 			type_id = { },
 			idno = { STORE, DONT_TOKENIZE, INDEX_AS_IDNO, BOOST = 100, INDEX_ANCESTORS, INDEX_ANCESTORS_START_AT_LEVEL = 0, INDEX_ANCESTORS_MAX_NUMBER_OF_LEVELS = 10  },
 			_metadata = { },
+			parent_id = {STORE, DONT_TOKENIZE, DONT_INCLUDE_IN_SEARCH_FORM },
 			is_enabled = { STORE, DONT_TOKENIZE },
 			deleted = { STORE, DONT_TOKENIZE }
 		}


### PR DESCRIPTION
The stock search_indexing.conf file indexes parent_id for ca_objects only. PR indexes parent_id on other common hierarchical tables, including ca_places, ca_collections, ca_occurrences, ca_list_items and ca_storage_locations.