### PR TITLE
Resolves #958 Type-specific entries in "find" menu don't honor list sort order

### DIFF
--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -340,11 +340,7 @@
  			$t_subject = Datamodel::getInstanceByTableName($this->ops_tablename, true);
  			
  			$t_list = new ca_lists();
- 			$t_list->load(array('list_code' => $t_subject->getTypeListCode()));
- 			
- 			$t_list_item = new ca_list_items();
- 			$t_list_item->load(array('list_id' => $t_list->getPrimaryKey(), 'parent_id' => null));
- 			$va_hier = caExtractValuesByUserLocale($t_list_item->getHierarchyWithLabels());
+ 			$va_hier = caExtractValuesByUserLocale($t_list->getItemsForList($t_subject->getTypeListCode()));
  			
  			$va_restrict_to_types = null;
  			if ($t_subject->getAppConfig()->get('perform_type_access_checking')) {
@@ -352,9 +348,9 @@
  			}
  			
 			$limit_to_types = $this->getRequest()->config->getList($this->ops_tablename.'_navigation_find_menu_limit_types_to');
-			$exclude_types = $this->getRequest()->config->getList($z=$this->ops_tablename.'_navigation_find_menu_exclude_types');
+			$exclude_types = $this->getRequest()->config->getList($this->ops_tablename.'_navigation_find_menu_exclude_types');
  	
- 			$va_types = array();
+ 			$va_types = [];
  			if (is_array($va_hier)) {
  				
  				$va_types_by_parent_id = array();


### PR DESCRIPTION
When broken out by type, "find" menu entries do not follow the declared type list sort order. The same list in the "new" menu do honor the specified sort. PR changes menu code to use list functions to grab types rather than generic hierarchy functions, which gets us correct sorting without extra work.