### PR TITLE
Add NL2BR modifier to convert line breaks to HTML

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2523,6 +2523,9 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 				case 'UPPER':
 					$ps_value = strtoupper($ps_value);
 					break;
+				case 'NL2BR':
+					$ps_value = nl2br($ps_value);
+					break;
 			}
 		}
 


### PR DESCRIPTION
PR added "NL2BR" template placeholder modifier that runs PHP nl2br() function on tag value prior to output. This provides a convenient way to ensure text line breaks display in HTML output from within the display template or import mapping template.