### PR TITLE
Resolves #966 declare explicit units in default display templates

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1623,17 +1623,17 @@ ca_item_tags_lookup_sort = _natural
 # -----------------------------------
 # Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in displays **
 # -----------------------------------
-ca_objects_default_bundle_display_template = <ifdef code='ca_objects.preferred_labels.name'><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</ifdef>
-ca_entities_default_bundle_display_template = <ifdef code='ca_entities.preferred_labels.displayname'><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</ifdef>
-ca_collections_default_bundle_display_template = <l>^ca_collections.preferred_labels.name</l> (^relationship_typename)
-ca_places_default_bundle_display_template = <l>^ca_places.preferred_labels.name</l> (^relationship_typename)
-ca_occurrences_default_bundle_display_template = <l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)
-ca_object_lots_default_bundle_display_template = <l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)
-ca_storage_locations_default_bundle_display_template = <l>^ca_storage_locations.preferred_labels.name</l> (^relationship_typename)
-ca_loans_default_bundle_display_template = <l>^ca_loans.preferred_labels.name</l> (^relationship_typename)
-ca_movements_default_bundle_display_template = <l>^ca_movements.preferred_labels.name</l> (^relationship_typename)
-ca_object_representations_default_bundle_display_template = <l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l> (^relationship_typename)
-ca_list_items_default_bundle_display_template = <l>^ca_list_items.preferred_labels.name_plural</l> (^relationship_typename)
+ca_objects_default_bundle_display_template = "<ifdef code='ca_objects.preferred_labels.name'><unit relativeTo='ca_objects'><l>^ca_objects.preferred_labels.name</l> (^relationship_typename)</unit></ifdef>"
+ca_entities_default_bundle_display_template = "<ifdef code='ca_entities.preferred_labels.displayname'><unit relativeTo='ca_entities'><l>^ca_entities.preferred_labels.displayname</l> (^relationship_typename)</unit></ifdef>"
+ca_collections_default_bundle_display_template = "<unit relativeTo='ca_collections'><l>^ca_collections.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_places_default_bundle_display_template = "<unit relativeTo='ca_places'><l>^ca_places.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_occurrences_default_bundle_display_template = "<unit relativeTo='ca_occurrences'><l>^ca_occurrences.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_object_lots_default_bundle_display_template = "<unit relativeTo='ca_object_lots'><l>^ca_object_lots.preferred_labels.name</l> (^ca_object_lots.idno_stub)</unit>"
+ca_storage_locations_default_bundle_display_template = "<unit relativeTo='ca_storage_locations'><l>^ca_storage_locations.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_loans_default_bundle_display_template = "<unit relativeTo='ca_loans'><l>^ca_loans.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_movements_default_bundle_display_template = "<unit relativeTo='ca_movements'><l>^ca_movements.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_object_representations_default_bundle_display_template = "<unit relativeTo='ca_object_representations'><l>^ca_object_representations.media.thumbnail</l><br/><l>^ca_object_representations.preferred_labels.name</l> (^relationship_typename)</unit>"
+ca_list_items_default_bundle_display_template = "<unit relativeTo='ca_list_items'><l>^ca_list_items.preferred_labels.name_plural</l> (^relationship_typename)</unit>"
 
 # -----------------------------------
 # Default display templates for related bundles (Eg. ca_entities, ca_occurrences, etc.) ** in user interfaces **


### PR DESCRIPTION
PR resolves issue where displays used in summaries linked to related records point to the record being viewed when the placement does not define an output template. This due to the default templates defined in app.conf lacking explicit units to force resolution of links relative to the related record.

Reported by Peter B: https://collectiveaccess.org/support/index.php?p=/discussion/comment/323733#Comment_323733