### PR TITLE
PR Fix incorrect editor inspector related record counts  

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -2150,7 +2150,7 @@
 		} else {
 			$parsed = $search;
 		}
-			
+		if(!is_object($parsed)) { return []; }
 		$terms = [];
 		switch(get_class($parsed)) {
 			case 'Zend_Search_Lucene_Search_Query_Boolean':

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -6747,7 +6747,7 @@ if (!$vb_batch) {
 				return null;
 				break;
 			case 'count':
-				return sizeof($va_rels);
+				return sizeof(array_unique($va_rels));
 				break;
 			case 'searchresult':
 				if (sizeof($va_rels) > 0) {


### PR DESCRIPTION
When <table>_show_related_counts_in_inspector_for option is set, related record counts do not match the number of records returned when the linked search is executed when. related records have multiple relationships. This is due to the returned count being number of relationships rather than number of related items.

PR corrects potentially incorrect related record counts due to multiple relationships between edited record and related record by changing returned count to that for unique related records.