### PR TITLE
Resolves #973 Add options to control behavior when duplicate entries are created in containers

### DIFF
--- a/app/lib/Attributes/Values/CollectionsAttributeValue.php
+++ b/app/lib/Attributes/Values/CollectionsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/ColorAttributeValue.php
+++ b/app/lib/Attributes/Values/ColorAttributeValue.php
@@ -81,6 +81,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSearchForm' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/ContainerAttributeValue.php
+++ b/app/lib/Attributes/Values/ContainerAttributeValue.php
@@ -50,6 +50,22 @@ $_ca_attribute_settings['ContainerAttributeValue'] = array(		// global
 		'label' => _t('Does not use locale setting'),
 		'description' => _t('Check this option if you don\'t want your compound attributes to be locale-specific. (The default is to be.)')
 	),
+	'allowDuplicateValues' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Allow duplicate values?'),
+		'description' => _t('Check this option if you want to allow duplicate values to be set when element is repeating.')
+	),
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
 	'lineBreakAfterNumberOfElements' => array(
 		'formatType' => FT_NUMBER,
 		'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/Attributes/Values/CurrencyAttributeValue.php
@@ -105,6 +105,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/DateRangeAttributeValue.php
+++ b/app/lib/Attributes/Values/DateRangeAttributeValue.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2020 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -88,6 +88,14 @@
 			'width' => 1, 'height' => 1,
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
+		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
 		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
@@ -535,4 +543,3 @@
         }
  		# ------------------------------------------------------------------
 	}
- ?>

--- a/app/lib/Attributes/Values/EntitiesAttributeValue.php
+++ b/app/lib/Attributes/Values/EntitiesAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/FilesizeAttributeValue.php
+++ b/app/lib/Attributes/Values/FilesizeAttributeValue.php
@@ -82,6 +82,14 @@ $_ca_attribute_settings['FilesizeAttributeValue'] = [		// global
 		'label' => _t('Allow duplicate values?'),
 		'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 	],
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
     'canBeUsedInSort' => [
         'formatType' => FT_NUMBER,
         'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/GeoNamesAttributeValue.php
+++ b/app/lib/Attributes/Values/GeoNamesAttributeValue.php
@@ -78,6 +78,14 @@
 		'label' => _t('Allow duplicate values?'),
 		'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 	),
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
 	'canBeUsedInSort' => array(
 		'formatType' => FT_NUMBER,
 		'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/GeocodeAttributeValue.php
+++ b/app/lib/Attributes/Values/GeocodeAttributeValue.php
@@ -192,6 +192,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,
@@ -553,4 +561,3 @@
 		}
  		# ------------------------------------------------------------------
 	}
- ?>

--- a/app/lib/Attributes/Values/InformationServiceAttributeValue.php
+++ b/app/lib/Attributes/Values/InformationServiceAttributeValue.php
@@ -86,6 +86,14 @@ $_ca_attribute_settings['InformationServiceAttributeValue'] = array(		// global
 		'label' => _t('Allow duplicate values?'),
 		'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 	),
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
 	'canBeUsedInSort' => array(
 		'formatType' => FT_NUMBER,
 		'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/IntegerAttributeValue.php
+++ b/app/lib/Attributes/Values/IntegerAttributeValue.php
@@ -114,6 +114,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,
@@ -348,4 +356,3 @@
 		}
  		# ------------------------------------------------------------------
 	}
- ?>

--- a/app/lib/Attributes/Values/LCSHAttributeValue.php
+++ b/app/lib/Attributes/Values/LCSHAttributeValue.php
@@ -76,6 +76,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/LengthAttributeValue.php
+++ b/app/lib/Attributes/Values/LengthAttributeValue.php
@@ -82,6 +82,14 @@ $_ca_attribute_settings['LengthAttributeValue'] = array(		// global
 		'label' => _t('Allow duplicate values?'),
 		'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 	),
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
     'canBeUsedInSort' => array(
         'formatType' => FT_NUMBER,
         'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/ListAttributeValue.php
+++ b/app/lib/Attributes/Values/ListAttributeValue.php
@@ -82,6 +82,14 @@ $_ca_attribute_settings['ListAttributeValue'] = array(		// global
 		'label' => _t('Allow duplicate values?'),
 		'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 	),
+	'raiseErrorOnDuplicateValue' => array(
+		'formatType' => FT_NUMBER,
+		'displayType' => DT_CHECKBOXES,
+		'default' => 0,
+		'width' => 1, 'height' => 1,
+		'label' => _t('Show error message for duplicate values?'),
+		'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+	),
 	'implicitNullOption' => array(
 		'formatType' => FT_NUMBER,
 		'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/LoansAttributeValue.php
+++ b/app/lib/Attributes/Values/LoansAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/MovementsAttributeValue.php
+++ b/app/lib/Attributes/Values/MovementsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/NumericAttributeValue.php
+++ b/app/lib/Attributes/Values/NumericAttributeValue.php
@@ -113,6 +113,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,
@@ -324,4 +332,3 @@
 		}
  		# ------------------------------------------------------------------
 	}
- ?>

--- a/app/lib/Attributes/Values/ObjectLotsAttributeValue.php
+++ b/app/lib/Attributes/Values/ObjectLotsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/ObjectRepresentationsAttributeValue.php
+++ b/app/lib/Attributes/Values/ObjectRepresentationsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/ObjectsAttributeValue.php
+++ b/app/lib/Attributes/Values/ObjectsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/OccurrencesAttributeValue.php
+++ b/app/lib/Attributes/Values/OccurrencesAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/PlacesAttributeValue.php
+++ b/app/lib/Attributes/Values/PlacesAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/StorageLocationsAttributeValue.php
+++ b/app/lib/Attributes/Values/StorageLocationsAttributeValue.php
@@ -55,6 +55,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/lib/Attributes/Values/TextAttributeValue.php
+++ b/app/lib/Attributes/Values/TextAttributeValue.php
@@ -105,6 +105,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/TimeCodeAttributeValue.php
+++ b/app/lib/Attributes/Values/TimeCodeAttributeValue.php
@@ -81,6 +81,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/UrlAttributeValue.php
+++ b/app/lib/Attributes/Values/UrlAttributeValue.php
@@ -105,6 +105,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/Attributes/Values/WeightAttributeValue.php
+++ b/app/lib/Attributes/Values/WeightAttributeValue.php
@@ -81,6 +81,14 @@
 			'label' => _t('Allow duplicate values?'),
 			'description' => _t('Check this option if you want to allow duplicate values to be set when element is not in a container and is repeating.')
 		),
+		'raiseErrorOnDuplicateValue' => array(
+			'formatType' => FT_NUMBER,
+			'displayType' => DT_CHECKBOXES,
+			'default' => 0,
+			'width' => 1, 'height' => 1,
+			'label' => _t('Show error message for duplicate values?'),
+			'description' => _t('Check this option to show an error message when value is duplicate and <em>allow duplicate values</em> is not set.')
+		),
 		'canBeUsedInSort' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_CHECKBOXES,

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -357,10 +357,11 @@ class BaseEditorController extends ActionController {
 			}
 		}
 		if(sizeof($va_errors) - sizeof($va_general_errors) > 0) {
-			$va_error_list = array();
+			$va_error_list = [];
 			$vb_no_save_error = false;
 			foreach($va_errors as $o_e) {
-				$va_error_list[$o_e->getErrorDescription()] = "<li>".$o_e->getErrorDescription()."</li>\n";
+				$bundle = array_shift(explode('/', $o_e->getErrorSource()));
+				$va_error_list[] = "<li><u>".$t_subject->getDisplayLabel($bundle).'</u>: '.$o_e->getErrorDescription()."</li>\n";
 
 				switch($o_e->getErrorNumber()) {
 					case 1100:	// duplicate/invalid idno
@@ -371,10 +372,10 @@ class BaseEditorController extends ActionController {
 				}
 			}
 			if ($vb_no_save_error) {
-				$this->notification->addNotification(_t("There are errors preventing <strong>ALL</strong> information from being saved. Correct the problems and click \"save\" again.\n<ul>").join("\n", $va_error_list)."</ul>", __NOTIFICATION_TYPE_ERROR__);
+				$this->notification->addNotification("<span class='heading'>"._t("There are errors preventing <strong>ALL</strong> information from being saved. Correct the problems and click \"save\" again:")."</span><ul class='errorList'>".join("\n", $va_error_list)."</span></ul>", __NOTIFICATION_TYPE_ERROR__);
 			} else {
 				$this->notification->addNotification($vs_message, __NOTIFICATION_TYPE_INFO__);
-				$this->notification->addNotification(_t("There are errors preventing information in specific fields from being saved as noted below.\n<ul>").join("\n", $va_error_list)."</ul>", __NOTIFICATION_TYPE_ERROR__);
+				$this->notification->addNotification("<span class='heading'>"._t("There are errors preventing information in specific fields from being saved:")."</span><ul class='errorList'>".join("\n", $va_error_list)."</ul>", __NOTIFICATION_TYPE_ERROR__);
 			}
 		} else {
 			$this->notification->addNotification($vs_message, __NOTIFICATION_TYPE_INFO__);

--- a/app/lib/BaseModelWithAttributes.php
+++ b/app/lib/BaseModelWithAttributes.php
@@ -103,7 +103,6 @@
 		 * @return bool True on success, false on error or null if attribute was skipped.
 		 */
 		public function addAttribute($pa_values, $pm_element_code_or_id, $ps_error_source=null, $pa_options=null) {
-			require_once(__CA_APP_DIR__.'/models/ca_metadata_elements.php');
 			if(!is_array($pa_options)) { $pa_options = []; }
 			if (!($t_element = ca_metadata_elements::getInstance($pm_element_code_or_id))) { return false; }
 			if ($t_element->get('parent_id') > 0) { return false; }
@@ -145,10 +144,28 @@
 				}	// # attributes is at upper limit
 			}
 			
+			$element_info = ca_metadata_elements::getElementSettingsForId($pm_element_code_or_id);
 			if (caGetOption('skipExistingValues', $pa_options, false) || !caGetOption('allowDuplicateValues', $element_info, false)) {
-				 // filter out any values that already exist on this row
+				// filter out any values that already exist on this row or duplicate a value queued for addition
+				 
+				// queued values 
+				foreach(($this->opa_attributes_to_add + $this->opa_attributes_to_edit) as $a) {
+					foreach($pa_values as $k => $v) {
+						if(!array_key_exists($k, $a['values']) || ($a['values'][$k] !== $v)) {
+							continue(2);
+						}
+					}
+					// is dupe
+					if (caGetOption('raiseErrorOnDuplicateValue', $element_info, false)) {
+						$this->postError(1985, _t('Value already exists'), 'BaseModelWithAttributes->addAttribute()', $ps_error_source);
+					}
+					return null;
+				}
+				 
+				// existing values
 			    if(is_array($va_attrs = $this->getAttributesByElement($pm_element_code_or_id))) {
 			        $vb_already_exists = false;
+			        $vals = [];
 			        foreach($va_attrs as $o_attr) {
 			            foreach($o_attr->getValues() as $o_value) {
 			                $vn_element_id = $o_value->getElementID();
@@ -159,6 +176,7 @@
 			                }
 			                
 			                $pv = $o_value->getDisplayValue(['dateFormat' => 'original']); // need to compare dates as-entered
+			                $vals[] = $o_value->getDisplayValue(['output' => 'text', 'dateFormat' => 'original']);
 			                if (
 			                	(strlen($pa_values[$vn_element_id] && ($pa_values[$vn_element_id] != $pv)))
 			            		||
@@ -171,6 +189,9 @@
 			            break;
 			        }
 			        if ($vb_already_exists) {
+			        	if (caGetOption('raiseErrorOnDuplicateValue', $element_info, false)) {
+							$this->postError(1985, _t('Value <code>%1</code> already exists', join('/', array_filter($vals, 'strlen'))), 'BaseModelWithAttributes->addAttribute()', $ps_error_source.'/'.$o_attr->getAttributeID());
+						}
 			            return null;
 			        }
 			    }
@@ -209,10 +230,13 @@
 		public function editAttribute($pn_attribute_id, $pm_element_code_or_id, $pa_values, $ps_error_source=null, $pa_options=null) {
 			$t_attr = new ca_attributes($pn_attribute_id);
 			$t_attr->purify($this->purify());
+			if (!($t_element = ca_metadata_elements::getInstance($pm_element_code_or_id))) { return false; }
 			if (!$t_attr->getPrimaryKey()) { return false; }
 			$vn_attr_element_id = $t_attr->get('element_id');
 			
 			$element_info = ca_metadata_elements::getElementSettingsForId($pm_element_code_or_id);
+			
+			if (!$ps_error_source) { $ps_error_source = $this->tableName().'.'.$t_element->get('element_code'); }
 			
 			$va_attr_values = $t_attr->getAttributeValues();
 			$element = null;
@@ -222,17 +246,34 @@
 			if(array_key_exists('locale_id', $pa_values)) { $num_values--; }
 			
 			if (caGetOption('skipExistingValues', $pa_options, false) || !caGetOption('allowDuplicateValues', $element_info, false)) {
-			    // filter out any values that already exist on this row
+			    // filter out any values that already exist on this row or match a value already queued for change
+			    
+			    // queued values 
+				foreach(($this->opa_attributes_to_add + $this->opa_attributes_to_edit) as $a) {
+					foreach($pa_values as $k => $v) {
+						if(!array_key_exists($k, $a['values']) || ($a['values'][$k] !== $v)) {
+							continue(2);
+						}
+					}
+					// is dupe
+					if (caGetOption('raiseErrorOnDuplicateValue', $element_info, false)) {
+						$this->postError(1985, _t('Value already exists'), 'BaseModelWithAttributes->editAttribute()', $ps_error_source.'/'.$pn_attribute_id);
+					}
+					return null;
+				}
+				 
+			    // existing values
 			    if(is_array($va_attrs = $this->getAttributesByElement($pm_element_code_or_id))) {
 			        $vb_already_exists = false;
-			        
+			        $vals = [];
 			        foreach($va_attrs as $o_attr) {
 			            if ($o_attr->getAttributeID() == $pn_attribute_id) { continue; }
 			            foreach($o_attr->getValues() as $o_value) {
 			                $vn_element_id = $o_value->getElementID();
 			                $vs_element_code = ca_metadata_elements::getElementCodeForId($vn_element_id);
 			                
-			                $pv = $o_value->getDisplayValue();
+			                $pv = $o_value->getDisplayValue(['dateFormat' => 'original']);
+			                $vals[] = $o_value->getDisplayValue(['output' => 'text', 'dateFormat' => 'original']);
 			                if (
 			                	(
 			                		array_key_exists($vn_element_id, $pa_values)
@@ -253,6 +294,9 @@
 			            break;
 			        }
 			        if ($vb_already_exists) {
+			        	if (caGetOption('raiseErrorOnDuplicateValue', $element_info, false)) {
+							$this->postError(1985, _t('Value <code>%1</code> already exists', join('/', array_filter($vals, 'strlen'))), 'BaseModelWithAttributes->editAttribute()', $ps_error_source.'/'.$pn_attribute_id);
+						}
 			            return null;
 			        }
 			    }
@@ -582,7 +626,7 @@
 		# ------------------------------------------------------------------
 		public function load($pm_id=null, $pb_use_cache=true) {
 			$this->init();
-			$this->setFieldValuesArray(array());
+			$this->setFieldValuesArray([]);
 			if ($vn_c = parent::load($pm_id, $pb_use_cache)) {
 				// Copy attributes into field values array in BaseModel
 				//$this->setFieldValuesArray($this->addAttributesToFieldValuesArray());
@@ -912,7 +956,7 @@
 			$t_instance = $this;
 			if ((sizeof($va_tmp) >= 2) && (!$this->hasField($va_tmp[2]))) {
 				if (($va_tmp[1] == 'parent') && ($this->isHierarchical()) && ($vn_parent_id = $this->get($this->getProperty('HIERARCHY_PARENT_ID_FLD')))) {
-					$t_instance = Datamodel::getInstanceByTableNum($this->tableNum());
+					$t_instance = Datamodel::getInstanceByTableNum($this->tableNum(), true);
 					if (!$t_instance->load($vn_parent_id)) {
 						$t_instance = $this;
 					} else {
@@ -928,7 +972,7 @@
 						$va_data = array();
 						$va_children_ids = $this->getHierarchyChildren(null, array('idsOnly' => true));
 						
-						$t_instance = Datamodel::getInstanceByTableNum($this->tableNum());
+						$t_instance = Datamodel::getInstanceByTableNum($this->tableNum(), true);
 						
 						foreach($va_children_ids as $vn_child_id) {
 							if ($t_instance->load($vn_child_id)) {
@@ -1301,8 +1345,15 @@
 		 * @return string - idno (aka "item code") for current row's type or null if no row is loaded or model does not support types
 		 */
 		public function getTypeCode($pn_type_id=null) {
+			if (!$pn_type_id) { $pn_type_id = $this->get($this->ATTRIBUTE_TYPE_ID_FLD); }
+			if (!$pn_type_id) { return null; }
+			if (MemoryCache::contains($pn_type_id, 'baseModelTypeCodes')) {
+				return MemoryCache::fetch($pn_type_id, 'baseModelTypeCodes');
+			}
 			if ($t_list_item = $this->getTypeInstance($pn_type_id)) {
-				return $t_list_item->get('idno');
+				$v = $t_list_item->get('idno');
+				MemoryCache::save($pn_type_id, $v, 'baseModelTypeCodes');
+				return $v;
 			}
 			return null;
 		}
@@ -1376,14 +1427,26 @@
 		 * @return array List of types
 		 */ 
 		public function getTypeList($pa_options=null) {
-			$t_list = new ca_lists();
+			$ids_only = $pa_options['idsOnly'];
 			if (isset($pa_options['childrenOfCurrentTypeOnly']) && $pa_options['childrenOfCurrentTypeOnly']) {
 				$pa_options['item_id'] = $this->get('type_id');
 			}
+			$type_list_code = $this->getTypeListCode();
+			$key = caMakeCacheKeyFromOptions($pa_options, $type_list_code);
 			
-			$va_list = $t_list->getItemsForList($this->getTypeListCode(), $pa_options);
-			if (caGetOption('idsOnly', $pa_options, false)) { return $va_list; }
-			return is_array($va_list) ? caExtractValuesByUserLocale($va_list): array();
+			if (CompositeCache::contains($key, 'typeListCodes')) {
+				return CompositeCache::fetch($key, 'typeListCodes');
+			}
+			$t_list = new ca_lists();
+			
+			$va_list = $t_list->getItemsForList($type_list_code, $pa_options);
+			if ($ids_only) { 
+				CompositeCache::save($key, $va_list, 'typeListCodes');
+				return $va_list; 
+			}
+			$va_list = is_array($va_list) ? caExtractValuesByUserLocale($va_list) : [];
+			CompositeCache::save($key, $va_list, 'typeListCodes');
+			return $va_list;
 		}
 		# ------------------------------------------------------------------
 		/**
@@ -1396,8 +1459,11 @@
 			} else {
 				if (!($vn_type_id = $this->get($this->ATTRIBUTE_TYPE_ID_FLD))) { return null; }
 			}
+			if (MemoryCache::contains($vn_type_id, 'baseModelTypeInstances')) {
+				return MemoryCache::fetch($vn_type_id, 'baseModelTypeInstances');
+			}
 			
-			$t_list_item = new ca_list_items($vn_type_id);
+			MemoryCache::save($vn_type_id, $t_list_item = new ca_list_items($vn_type_id), 'baseModelTypeInstances');
 			return ($t_list_item->getPrimaryKey()) ? $t_list_item : null;
 		}
 		# ------------------------------------------------------------------
@@ -1830,7 +1896,7 @@
 			$o_view->setVar('request', $po_request);
 			$o_view->setVar('id_prefix', $ps_form_name.'_attribute_'.$t_element->get('element_id'));
 			$o_view->setVar('elements', $va_elements_by_container);
-			$o_view->setVar('error_source_code', 'ca_attribute_'.$t_element->get('element_code'));
+			$o_view->setVar('error_source_code', $this->tableName().'.'.$t_element->get('element_code'));
 			$o_view->setVar('element_ids', $va_element_ids);
 			$o_view->setVar('element_info', $va_element_info);
 			$o_view->setVar('element_set_label', $this->getAttributeLabel($t_element->get('element_id')));
@@ -1961,6 +2027,10 @@
 				
 				if (caGetOption('forSimpleForm', $pa_options, false)) { 
 					unset($va_element_opts['nullOption']);
+					
+					if (!strlen($vm_values) && is_array($va_element['settings']) && isset($va_element['settings']['default_text'])) {
+						$vm_values = $va_element['settings']['default_text'];
+					}
 				}
 				
 				// We don't want to pass the entire set of values to ca_attributes::attributeHtmlFormElement() since it'll treat it as a simple list

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -186,8 +186,10 @@
  					}
  					
 					$vo_result = $po_search->getResults($va_search_opts);
-					
-					if ($vn_page_num > ceil($vo_result->numHits() / $vn_items_per_page)) { 
+			
+					$n = (isset($pa_options['result']) && is_a($pa_options['result'], 'SearchResult')) ? $pa_options['result']->numHits() : $vo_result->numHits();
+				
+					if ($vn_page_num > ceil($n / $vn_items_per_page)) { 
 						$this->opo_result_context->setCurrentResultsPageNumber($vn_page_num = 1);	// reset page count if out of bounds
 					}
 					

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -3545,6 +3545,8 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			}
 		}
 		
+		$va_errors = [];
+			
 		$vb_read_only_because_deaccessioned = ($this->hasField('is_deaccessioned') && (bool)$this->getAppConfig()->get('deaccession_dont_allow_editing') && (bool)$this->get('is_deaccessioned'));
 
 		BaseModel::setChangeLogUnitID();
@@ -3749,7 +3751,9 @@ if (!$vb_batch) {
 				// do inserts
 				foreach($va_attributes_to_insert as $va_attribute_to_insert) {
 					$this->clearErrors();
-					$this->addAttribute($va_attribute_to_insert, $vn_element_id, $vs_f, ['batch' => $vb_batch]);
+					if(!$this->addAttribute($va_attribute_to_insert, $vn_element_id, null, ['batch' => $vb_batch])) {
+						$po_request->addActionErrors($this->errors);
+					}
 				}
 				
 if (!$vb_batch) {					
@@ -3807,7 +3811,9 @@ if (!$vb_batch) {
 						if (!$isset) { continue; }
 						
 						$this->clearErrors();
-						$this->editAttribute($vn_attribute_id, $vn_element_set_id, $va_attr_update, $vs_f, ['batch' => $vb_batch]);
+						if(!$this->editAttribute($vn_attribute_id, $vn_element_set_id, $va_attr_update, null, ['batch' => $vb_batch])) {
+							$po_request->addActionErrors($this->errors);
+						}
 					}
 				}
 			}
@@ -3881,7 +3887,6 @@ if (!$vb_batch) {
 			$vb_is_insert = true;
 		}
 		if ($this->numErrors() > 0) {
-			$va_errors = array();
 			foreach($this->errors() as $o_e) {
 				switch($o_e->getErrorNumber()) {
 					case 2010:

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -162,6 +162,7 @@
 1972 = Can't delete attribute
 1980 = Can't add element to restriction list
 1981 = Can't remove element from restriction list
+1985 = Value already exists
 
 # --- Hierarchical processing errors
 2010 = Circular reference

--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -2690,7 +2690,7 @@ class SearchResult extends BaseObject {
 								}
 							}
 						
-							if(!$pa_options['returnAsArray']) {
+							if(!$pa_options['returnAsArray'] && is_array($d)) {
 								$d = join("; ", $d);
 							}
 						}

--- a/app/models/ca_metadata_elements.php
+++ b/app/models/ca_metadata_elements.php
@@ -329,6 +329,7 @@ class ca_metadata_elements extends LabelableBaseModelWithAttributes implements I
 				CompositeCache::delete($vs_cache_key, 'ElementList');
 			}
 		}
+		CompositeCache::flush('ElementSettings');
 		CompositeCache::flush('SearchBuilder');
 		$this->resetElasticSearchMappingRefresh();
 	}

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -1109,7 +1109,7 @@ div.notification-info-box {
 }
 
 div.notification-error-box {
-    background:	url('../graphics/icons/warning_sign.png') no-repeat 10px 5px;
+    background:	url('../graphics/icons/warning_sign.png') no-repeat 10px 15px;
     text-indent: 32px;
     background-color: #eeeeee;
     padding: 5px;
@@ -1139,7 +1139,7 @@ ul.notification-error-box, ul.notification-warning-box, ul.notification-info-box
 li.notification-info-box {
     font-weight: bold;
     color: #1ab3c8;
-    font-size: 12px;
+    font-size: 13px;
     text-indent: 10px;
     font-family: 'din-regular';
 	padding-top: 2px;
@@ -1150,13 +1150,23 @@ li.notification-warning-box {
     color: #333;
     font-size: 13px;
     text-indent: 10px;
+    font-family: 'din-regular';
 }
 
 li.notification-error-box {
-    font-weight: bold;
+    font-weight: normal;
     color: #cc0000;
-    font-size: 12px;
+    font-size: 13px;
     text-indent: 10px;
+    font-family: 'din-regular';
+}
+
+li.notification-error-box .heading {
+    font-weight: bold;
+}
+
+li.notification-error-box ul.errorList {
+    margin-top: 8px;
 }
 
 div.hint {

--- a/themes/default/views/mediaViewers/pdfjs.php
+++ b/themes/default/views/mediaViewers/pdfjs.php
@@ -394,7 +394,7 @@
  	window.pdfjsPath = '<?= $this->request->getBaseUrlPath(); ?>/assets';
  	window.pdfjsContentURL = '<?= $this->getVar('display_media_url') ? $this->getVar('display_media_url') : $this->getVar('original_media_url'); ?>';
  	window.pdfjsContainerID = 'caMediaOverlayContent';
- 	window.pdfjsSearch = <?= json_encode($this->getVar('search')); ?>;
+ 	window.pdfjsSearch = <?= json_encode(preg_replace("![+\-\*\?]+!", "", $this->getVar('search'))); ?>;
  </script>
  <script src="<?= $this->request->getBaseUrlPath(); ?>/assets/pdfjs/viewer/viewer.js"></script>
  


### PR DESCRIPTION
The current implementation includes duplication prevention for metadata elements via the element-level allowDuplicateValues option. When set to false (the default) any duplicate values for an element are silently rejected. In the contexts for which CA is designed this is desirable: a value is a value and duplicates should be condensed down to a single instance as repetition has no meaning.

As currently implemented, containers are not fully supported and duplication is only checked against existing values on the record. Duplication prevention can be bypassed by adding multiple instances of a new value to a record. On the initial save of those values, they don't exist until the save transaction is complete, allowing dupes to slip in.

PR makes the following changes:

1. Containers now more consistently support duplication checking
2. Added option to display error message on duplication
3. Minor reformatting of error message display
4. Fixed issue in some configurations where element-level error messages would only show at top of form, but not adjacent to errored field.
5. Duplication is now checked against existing and queued values