### PR TITLE
Resolves #977 Allow OR's between multiple expressions

### DIFF
--- a/app/lib/Parsers/ExpressionParser/ExpressionGrammar.pp
+++ b/app/lib/Parsers/ExpressionParser/ExpressionGrammar.pp
@@ -6,7 +6,7 @@
 // ----------------------------------------------------------------------
 //
 // Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
-// Copyright 2015-2020 Whirl-i-Gig
+// Copyright 2015-2021 Whirl-i-Gig
 //
 // For more information visit http://www.CollectiveAccess.org
 //
@@ -98,6 +98,7 @@ expression:
 
 expr:
     factor() (::bool_and:: expr() #bool_and )?
+  | factor() (::bool_or:: expr() #bool_or )?
   | ( ::bracket_:: expr() ::_bracket:: #group )
 
 factor:


### PR DESCRIPTION
The expression parser will throw a parse error when > 2 expressions are strung together with boolean OR's. Eg:

`(length(^/locfield1) > 0) OR (length(^/locfield2) > 0) OR (length(^/locfield3) > 0) OR (length(^/locfield4) > 0)`

PR extends the expression grammar to resolve this.