### PR TITLE
Feature/configure sets per page

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1753,6 +1753,10 @@ items_per_page_options_for_ca_storage_locations_search = [15,30,45]
 items_per_page_default_for_ca_storage_locations_search = 30
 view_default_for_ca_storage_locations_search = list
 
+items_per_page_options_for_ca_sets_search = [15,30,45]
+items_per_page_default_for_ca_sets_search = 30
+view_default_for_ca_sets_search = list
+
 items_per_page_options_for_ca_objects_browse = [12,24,36,48]
 items_per_page_default_for_ca_objects_browse = 24
 view_default_for_ca_objects_browse = list
@@ -1784,6 +1788,10 @@ enable_full_thumbnail_result_views_for_ca_collections_browse = 0
 items_per_page_options_for_ca_storage_locations_browse = [15,30,45]
 items_per_page_default_for_ca_storage_locations_browse = 30
 view_default_for_ca_storage_locations_browse = list
+
+items_per_page_options_for_ca_sets_browse = [15,30,45]
+items_per_page_default_for_ca_sets_browse = 30
+view_default_for_ca_sets_browse = list
 
 items_per_page_options_for_ca_loans_browse = [15,30,45]
 items_per_page_default_for_ca_loans_browse = 30

--- a/app/controllers/manage/SetController.php
+++ b/app/controllers/manage/SetController.php
@@ -44,8 +44,8 @@
  		public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
  			parent::__construct($po_request, $po_response, $pa_view_paths);
  			$o_result_context = new ResultContext($this->request, 'ca_sets', 'basic_search');
- 			
- 			$this->opn_items_per_page = 20;
+
+		    $this->opn_items_per_page = ((int) $this->request->config->get('items_per_page_default_for_ca_sets_search') ?: 20);
  			$this->view->setVar('items_per_page', $this->opn_items_per_page);
  			
  			$this->opn_list_set_type_id = $this->request->getParameter('list_set_type_id', pInteger);


### PR DESCRIPTION
opn_items_per_page was still a static value in the SetController. Changed to a configurable setting, where I tried to mimic the other items_per_page_default_for_[concept]_search in app.conf that existed already for the other concepts but not ca_sets.