### PR TITLE
Add date_part setting for date metadata alerts

### DIFF
--- a/app/lib/MetadataAlerts/TriggerTypes/Date.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Date.php
@@ -50,7 +50,7 @@ class Date extends Base {
 				'suffix' => _t('date'),
 				'description' => _t('Set an interval before or after an event in which to trigger a notification. Note that if the event is a date range, the trigger will fire before the beginning of the range or after the end of the range.')
 			],
-			'date_part' => array(
+			'datePart' => array(
 				'formatType' => FT_TEXT,
 				'displayType' => DT_SELECT,
 				'height' => 1,

--- a/app/lib/MetadataAlerts/TriggerTypes/Date.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Date.php
@@ -41,7 +41,7 @@ class Date extends Base {
 	 */
 	public function getTypeSpecificSettings() {
 		return [
-			'offset' => array(
+			'offset' => [
 				'formatType' => FT_TEXT,
 				'displayType' => DT_INTERVAL,
 				'width' => 5, 'height' => 1,
@@ -49,6 +49,20 @@ class Date extends Base {
 				'label' => _t('Notify user'),
 				'suffix' => _t('date'),
 				'description' => _t('Set an interval before or after an event in which to trigger a notification. Note that if the event is a date range, the trigger will fire before the beginning of the range or after the end of the range.')
+			],
+			'date_part' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_SELECT,
+				'height' => 1,
+				'default' => '',
+				'label' => _t('Date part'),
+				'nullOption' => _t('Both'),
+				'options' => [
+					_t('Both') => 'both',
+					_t('Start') => 'start',
+					_t('End') => 'end',
+					],
+				'description' => _t('Specify which part of the data range the alert applies to. Defaults to both dates in a range'),
 			),
 		];
 	}
@@ -72,7 +86,8 @@ class Date extends Base {
 		$va_spec = $this->_getSpec($t_instance);
 		$vs_element_code = $va_spec['element_code'];
 		$vs_get_spec = $va_spec['spec'];
-		
+		$vs_date_part = $this->getTriggerValues()['settings']['date_part'] ?: 'both';
+
 		if (is_array($va_filters = $va_values['element_filters']) && !sizeof($va_filters)) { $va_filters = null; }
 
 		if(\ca_metadata_elements::getDataTypeForElementCode($vs_element_code) !== __CA_ATTRIBUTE_VALUE_DATERANGE__) {
@@ -81,12 +96,19 @@ class Date extends Base {
 		
 		foreach($t_instance->get($vs_get_spec, ['returnAsArray' => true, 'dateFormat' => 'iso8601', 'filters' => $va_filters]) as $vs_val) {
 			$o_tep->parse($vs_val);
-			
+
 			// offset should be in seconds
 			$vn_offset = self::offsetToSeconds($this->getTriggerValues()['settings']['offset']);
-			if(($vn_offset <= 0) && (time() > (($o_tep->getUnixTimestamps()['start']) - abs($vn_offset)))) {
+			if(
+				($vn_offset <= 0) &&
+				in_array($vs_date_part, ['both', 'start'])
+				&& (time() > (($o_tep->getUnixTimestamps()['start']) - abs($vn_offset)))
+			) {
 				return true;
-			} elseif(time() >= ($o_tep->getUnixTimestamps()['end'] + abs($vn_offset))) {
+			} elseif(
+				in_array($vs_date_part, ['both', 'end'])
+				&& time() >= ( $o_tep->getUnixTimestamps()['end'] + abs($vn_offset))
+			) {
 				return true;
 			}
 		}


### PR DESCRIPTION
* Previously date alerts would trigger at both the start and the end
date of a date range.
* This change retains that as a default but also makes it possible to
specify whether the alert gets triggered on the start or the end of the
 date range