### PR TITLE
Dev/movement based tracking improvements

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1269,6 +1269,27 @@ public_access_settings = [1]
 #	}
 #}
 
+# Disable delete for specific records for all users (including admins) no matter what access the user has
+#
+# Can be set on a per-table and per-type basis. Use the format <table>_<type_code>_disable_delete 
+# for type-specific settings
+#
+ca_objects_disable_delete = 0
+ca_entities_disable_delete = 0
+ca_places_disable_delete = 0
+ca_occurrences_disable_delete = 0
+ca_collections_disable_delete = 0
+ca_object_lots_disable_delete = 0
+ca_object_representations_disable_delete = 0
+ca_lists_disable_delete = 0
+ca_list_items_disable_delete = 0
+ca_storage_locations_disable_delete = 0
+ca_loans_disable_delete = 0
+ca_movements_disable_delete = 0
+ca_tours_disable_delete = 0
+ca_tour_stops_disable_delete = 0
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 #    _____ _         _ _             
@@ -2637,6 +2658,16 @@ default_action = /Dashboard/Index
 service_controllers_directory = <ca_app_dir>/service/controllers
 service_default_action = /search/rest/doSearch
 service_view_path = <ca_app_dir>/service/views
+
+# -----------------------------------
+# Filtering of text input
+#
+# Set to filter all entered data through HTMLPurifier
+# removing any potentially dangerous markup. This is generally 
+# a good thing, but significantly impacts performance and is
+# left disabled by default.
+# -----------------------------------
+purify_all_text_input = 0
 
 
 # -----------------------------------

--- a/app/controllers/lookup/ListItemController.php
+++ b/app/controllers/lookup/ListItemController.php
@@ -167,7 +167,7 @@
 				foreach($va_list_items as $vn_item_id => $va_item) {
 					$va_list_items_sortable[caSortableValue(mb_strtolower(preg_replace('![^A-Za-z0-9]!', '_', caRemoveAccents($va_item['name'])))).'_'.$vn_item_id] = $va_item;
 				}
-				ksort($va_list_items_sortable);
+				//ksort($va_list_items_sortable);
 				$va_list_items = $va_list_items_sortable;
  				$va_list_items['_sortOrder'] = array_keys($va_list_items);
 

--- a/app/controllers/manage/WatchedItemsController.php
+++ b/app/controllers/manage/WatchedItemsController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2015 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -25,111 +25,108 @@
  *
  * ----------------------------------------------------------------------
  */
- 	require_once(__CA_LIB_DIR__."/Controller/ActionController.php");
- 	require_once(__CA_MODELS_DIR__."/ca_metadata_elements.php");
- 	require_once(__CA_MODELS_DIR__."/ca_watch_list.php");
-	require_once(__CA_MODELS_DIR__.'/ca_sets.php');
- 	
- 	class WatchedItemsController extends ActionController {
- 		# -------------------------------------------------------
- 		public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
- 			parent::__construct($po_request, $po_response, $pa_view_paths);
- 		 
- 			AssetLoadManager::register('tableList');
- 		}
- 		# -------------------------------------------------------
- 		public function ListItems() {
- 			$t_watch_list = new ca_watch_list();
-			$va_watched_items = $t_watch_list->getWatchedItems($this->request->user->get("user_id"));
-			$this->view->setVar("watched_items", $va_watched_items);
- 			if(sizeof($va_watched_items) == 0) {
- 				$this->notification->addNotification(_t("There are no watched items"), __NOTIFICATION_TYPE_INFO__);
- 			}
- 			$this->render('watched_items_list_html.php');
- 		}
- 		# -------------------------------------------------------
- 		public function Delete() {
- 			$ps_mode = $this->request->getParameter('mode', pString);
- 			$va_errors = array();
- 			$pa_watch_ids = $this->request->getParameter('watch_id', pArray);
- 			$va_errors = array();
- 			if(is_array($pa_watch_ids) && (sizeof($pa_watch_ids) > 0)){
-				$t_watch_list = new ca_watch_list();
-				foreach($pa_watch_ids as $vn_watch_id){
-					if($t_watch_list->load(array('watch_id' => $vn_watch_id))){
-						$t_watch_list->setMode(ACCESS_WRITE);
-						$t_watch_list->delete();
-						if ($t_watch_list->numErrors()) {
-							$va_errors = $t_item->errors;
-						}
-					}
-				
-					
-				
-				}
-				if(sizeof($va_errors) > 0){
-					$this->notification->addNotification(implode("; ", $va_errors), __NOTIFICATION_TYPE_ERROR__);
-				}else{
-					$this->notification->addNotification(_t("Your watched items have been deleted"), __NOTIFICATION_TYPE_INFO__);
-				}
-			}else{
-				$this->notification->addNotification(_t("Please use the checkboxes to select items to remove from your watch list"), __NOTIFICATION_TYPE_WARNING__);
-			}
- 			if($ps_mode == "dashboard"){
- 				$this->response->setRedirect(caNavUrl($this->request, "", "Dashboard", "Index"));
- 			}else{
- 				$this->ListItems();
- 			}
- 		}
- 		# -------------------------------------------------------
- 		/**
- 		 * 
- 		 */
- 		public function Info() {
-			$this->getView()->setVar('t_watch_list', new ca_watch_list());
- 			return $this->render('widget_watched_items_info_html.php', true);
- 		}
- 		# -------------------------------------------------------
-		public function CreateSet() {
-			global $g_ui_locale_id;
+require_once(__CA_LIB_DIR__."/Controller/ActionController.php");
 
-			$ps_table = $this->getRequest()->getParameter('set_table', pString);
-			if(!($t_instance = Datamodel::getInstance($ps_table, true))) {
-				$this->opo_notification_manager->addNotification(_t("Invalid table"), __NOTIFICATION_TYPE_ERROR__);
-				$this->ListItems();
-				return;
-			}
-
-			$ps_set_name = $this->getRequest()->getParameter('set_name', pString);
+class WatchedItemsController extends ActionController {
+	# -------------------------------------------------------
+	public function __construct(&$po_request, &$po_response, $pa_view_paths=null) {
+		parent::__construct($po_request, $po_response, $pa_view_paths);
+	 
+		AssetLoadManager::register('tableList');
+	}
+	# -------------------------------------------------------
+	public function ListItems() {
+		$t_watch_list = new ca_watch_list();
+		$va_watched_items = $t_watch_list->getWatchedItems($this->request->user->get("user_id"));
+		$this->view->setVar("watched_items", $va_watched_items);
+		if(sizeof($va_watched_items) == 0) {
+			$this->notification->addNotification(_t("There are no watched items"), __NOTIFICATION_TYPE_INFO__);
+		}
+		$this->render('watched_items_list_html.php');
+	}
+	# -------------------------------------------------------
+	public function Delete() {
+		$ps_mode = $this->request->getParameter('mode', pString);
+		$va_errors = array();
+		$pa_watch_ids = $this->request->getParameter('watch_id', pArray);
+		$va_errors = array();
+		if(is_array($pa_watch_ids) && (sizeof($pa_watch_ids) > 0)){
 			$t_watch_list = new ca_watch_list();
-			$va_items = $t_watch_list->getWatchedItems($this->getRequest()->getUserID(), $t_instance->tableNum());
-
-			$va_row_ids = [];
-			foreach($va_items as $va_item) {
-				$va_row_ids[] = $va_item['row_id'];
+			foreach($pa_watch_ids as $vn_watch_id){
+				if($t_watch_list->load(array('watch_id' => $vn_watch_id))){
+					$t_watch_list->setMode(ACCESS_WRITE);
+					$t_watch_list->delete();
+					if ($t_watch_list->numErrors()) {
+						$va_errors = $t_item->errors;
+					}
+				}
+			
+				
+			
 			}
-
-			$t_set = new ca_sets();
-			$t_set->setMode(ACCESS_WRITE);
-			$t_set->set('type_id', $this->getRequest()->getAppConfig()->get('ca_sets_default_type'));
-			$t_set->set('user_id', $this->getRequest()->getUserID());
-			$t_set->set('table_num', $t_instance->tableNum());
-			$t_set->set('set_code', $vs_set_code = mb_substr(preg_replace("![^A-Za-z0-9_\-]+!", "_", $ps_set_name), 0, 100));
-
-			$t_set->insert();
-
-			if ($t_set->numErrors()) {
-				$this->opo_notification_manager->addNotification(join(': ', $t_set->getErrors()), __NOTIFICATION_TYPE_ERROR__);
-				$this->ListItems();
-				return;
+			if(sizeof($va_errors) > 0){
+				$this->notification->addNotification(implode("; ", $va_errors), __NOTIFICATION_TYPE_ERROR__);
+			}else{
+				$this->notification->addNotification(_t("Your watched items have been deleted"), __NOTIFICATION_TYPE_INFO__);
 			}
-
-			$t_set->addLabel(array('name' => $ps_set_name), $g_ui_locale_id, null, true);
-
-			$vn_added_items_count = $t_set->addItems($va_row_ids);
-
-			$this->opo_notification_manager->addNotification(_t("Added set '%1' with %2 items", $ps_set_name, $vn_added_items_count), __NOTIFICATION_TYPE_INFO__);
+		}else{
+			$this->notification->addNotification(_t("Please use the checkboxes to select items to remove from your watch list"), __NOTIFICATION_TYPE_WARNING__);
+		}
+		if($ps_mode == "dashboard"){
+			$this->response->setRedirect(caNavUrl($this->request, "", "Dashboard", "Index"));
+		}else{
 			$this->ListItems();
 		}
-		# -------------------------------------------------------
- 	}
+	}
+	# -------------------------------------------------------
+	/**
+	 * 
+	 */
+	public function Info() {
+		$this->getView()->setVar('t_watch_list', new ca_watch_list());
+		return $this->render('widget_watched_items_info_html.php', true);
+	}
+	# -------------------------------------------------------
+	public function CreateSet() {
+		global $g_ui_locale_id;
+
+		$ps_table = $this->getRequest()->getParameter('set_table', pString);
+		if(!($t_instance = Datamodel::getInstance($ps_table, true))) {
+			$this->opo_notification_manager->addNotification(_t("Invalid table"), __NOTIFICATION_TYPE_ERROR__);
+			$this->ListItems();
+			return;
+		}
+
+		$ps_set_name = $this->getRequest()->getParameter('set_name', pString);
+		$t_watch_list = new ca_watch_list();
+		$va_items = $t_watch_list->getWatchedItems($this->getRequest()->getUserID(), $t_instance->tableNum());
+
+		$va_row_ids = [];
+		foreach($va_items as $va_item) {
+			$va_row_ids[] = $va_item['row_id'];
+		}
+
+		$t_set = new ca_sets();
+		$t_set->setMode(ACCESS_WRITE);
+		$t_set->set('type_id', $this->getRequest()->getAppConfig()->get('ca_sets_default_type'));
+		$t_set->set('user_id', $this->getRequest()->getUserID());
+		$t_set->set('table_num', $t_instance->tableNum());
+		$t_set->set('set_code', $vs_set_code = mb_substr(preg_replace("![^A-Za-z0-9_\-]+!", "_", $ps_set_name), 0, 100));
+
+		$t_set->insert();
+
+		if ($t_set->numErrors()) {
+			$this->opo_notification_manager->addNotification(join(': ', $t_set->getErrors()), __NOTIFICATION_TYPE_ERROR__);
+			$this->ListItems();
+			return;
+		}
+
+		$t_set->addLabel(array('name' => $ps_set_name), $g_ui_locale_id, null, true);
+
+		$vn_added_items_count = $t_set->addItems($va_row_ids);
+
+		$this->opo_notification_manager->addNotification(_t("Added set '%1' with %2 items", $ps_set_name, $vn_added_items_count), __NOTIFICATION_TYPE_INFO__);
+		$this->ListItems();
+	}
+	# -------------------------------------------------------
+}

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -2329,6 +2329,9 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 	 * @return array An array of tags, or an array of arrays when parseOptions option is set.
 	 */
 	function caGetTemplateTags($ps_template, $pa_options=null) {
+		$key = caMakeCacheKeyFromOptions($pa_options, $ps_template);
+		if(MemoryCache::contains($key, 'DisplayTemplateParserUtils')) { return MemoryCache::fetch($key, 'DisplayTemplateParserUtils'); }
+		
 		$va_tags = caExtractTagsFromTemplate($ps_template, $pa_options);
 
 		if (caGetOption('firstPartOnly', $pa_options, false)) {
@@ -2351,6 +2354,7 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 			}
 		}
 
+		MemoryCache::save($key, $va_tags, 'DisplayTemplateParserUtils');
 		return $va_tags;
 	}
 	# ------------------------------------------------------------------------------------------------
@@ -2368,7 +2372,13 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 	 * @return string Output of processed template
 	 */
 	function caProcessTemplate($ps_template, $pa_values, $pa_options=null) {
-		return DisplayTemplateParser::processTemplate($ps_template, $pa_values, $pa_options);
+		$key = caMakeCacheKeyFromOptions(['options' => $pa_options, 'values' => $pa_values], $ps_template);
+		if(MemoryCache::contains($key, 'DisplayTemplateParserUtils')) { return MemoryCache::fetch($key, 'DisplayTemplateParserUtils'); }
+		
+		$ret = DisplayTemplateParser::processTemplate($ps_template, $pa_values, $pa_options);
+		MemoryCache::save($key, $ret, 'DisplayTemplateParserUtils');
+		
+		return $ret;
 	}
 	# ------------------------------------------------------------------------------------------------
 	/**
@@ -2392,6 +2402,9 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 	function caProcessTemplateTagDirectives($ps_value, $pa_directives, $pa_options=null) {
 	    global $g_ui_locale;
 		if (!is_array($pa_directives) || !sizeof($pa_directives)) { return $ps_value; }
+		
+		$key = caMakeCacheKeyFromOptions(['options' => $pa_options, 'directives' => $pa_directives], $ps_value);
+		if(MemoryCache::contains($key, 'DisplayTemplateParserUtils')) { return MemoryCache::fetch($key, 'DisplayTemplateParserUtils'); }
 
 		$pb_omit_units = caGetOption('omitUnits', $pa_options, false);
 		$force_english_units = caGetOption('forceEnglishUnits', $pa_options, null, ['validValues' => ['ft', 'in']]);
@@ -2530,6 +2543,7 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 		}
 
 		ini_set('precision', $vn_precision);
+		MemoryCache::save($key, $ps_value, 'DisplayTemplateParserUtils');
 		return $ps_value;
 	}
 	# ------------------------------------------------------------------------------------------------

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -3414,11 +3414,11 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 		$default_sorts = $config->getAssoc("{$related_table}_default_bundle_display_sorts");
 	
 		if(!is_array($default_sorts) || !is_array($default_sort_options = caGetOption('options', $default_sorts, null))) { $default_sort_options = []; }
-		if(is_array($rel_types = caGetOption(['restrict_to_relationship_types', 'restrictToRelationshipTypes'], $settings, null)) && sizeof($rel_types)) {
+		if(is_array($rel_types = caGetOption(['restrict_to_types', 'restrictToTypes'], $settings, null)) && sizeof($rel_types)) {
 			$path = array_keys(Datamodel::getPath($table, $related_table));
-			if(is_array($type_codes = caMakeRelationshipTypeCodeList($path[1], $rel_types))) {
+			if(is_array($type_codes = caMakeTypeList($related_table, $rel_types))) {
 				foreach($type_codes as $t) {
-					if(is_array($type_specific_sorts = $config->get("{$ps_table}_{$t}_bundle_display_sorts")) && is_array($type_specific_sort_options = caGetOption('options', $type_specific_sorts, null))) {
+					if(is_array($type_specific_sorts = $config->get("{$related_table}_{$t}_bundle_display_sorts")) && is_array($type_specific_sort_options = caGetOption('options', $type_specific_sorts, null))) {
 						$default_sort_options = array_merge($default_sort_options, $type_specific_sort_options);
 					}
 				}
@@ -3448,7 +3448,12 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 		$sort = caGetOption('sort', $pa_options, null);
 		$sort_direction = caGetOption('sortDirection', $pa_options, null);
 		
-		if (!is_array($va_sort_fields = caGetAvailableSortFields($ps_table, null, array_merge(['request' => $po_request], $pa_options, ['naturalSortLabel' => _t('default'), 'includeInterstitialSortsFor' => $ps_related_table]))) || !sizeof($va_sort_fields)) { return ''; }
+		$type_id = null;
+		if($type_ids = caGetOption(['restrict_to_types', 'restrictToTypes'], $pa_options, null)) {
+			$type_id = is_array($type_ids) ? array_shift($type_ids) : $type_ids;
+		}
+		
+		if (!is_array($va_sort_fields = caGetAvailableSortFields($ps_table, $type_id, array_merge(['request' => $po_request], $pa_options, ['naturalSortLabel' => _t('default'), 'includeInterstitialSortsFor' => $ps_related_table]))) || !sizeof($va_sort_fields)) { return ''; }
 	
 		$allowed_sorts = caGetOption('allowedSorts', $pa_options, null);
 		
@@ -3477,6 +3482,10 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 				}
 			}
 			
+			if(is_array($type_specific_sorts) ) {
+				$default_sort_options = $type_specific_sorts['options'];
+			}
+			
 			// Expand global sort list to include parents when sort is on container field
 			$default_sort_options = array_merge(['_natural' => false], array_reduce($default_sort_options, function($carry, $item) use ($sort_field_trans) { 
 				if(array_key_exists($item, $sort_field_trans)) { $item = $sort_field_trans[$item]; }	// rewrite truncated fields 
@@ -3494,7 +3503,7 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 			if(is_array($default_sort_options) && sizeof($default_sort_options)) {
 				$va_sort_fields = array_filter(
 					$va_sort_fields,
-					function ($v) use ($default_sort_options, $sort_field_trans) {
+					function ($v) use ($default_sort_options) {
 						return array_key_exists($v, $default_sort_options);
 					},
 					ARRAY_FILTER_USE_KEY
@@ -3598,6 +3607,7 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 		if (!($pt_related = Datamodel::getInstance($pconfig['table'], true))) {  return null; }
 
 		$target = $pt_related->tableName();
+		if(!$pt_related->getAppConfig()->get("{$target}_enable_home_location")) { return null; }
 		$policies = array_filter(ca_objects::getHistoryTrackingCurrentValuePoliciesForTable($target), function($v) { return array_key_exists('ca_storage_locations', $v['elements']); });
 		if(!is_array($policies) || !sizeof($policies)) { return ''; }
 		if (!$ps_policy) { $ps_policy = $target::getDefaultHistoryTrackingCurrentValuePolicy(); }

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4007,7 +4007,7 @@ function caFileIsIncludable($ps_file) {
 				$vs_display_value = str_replace($va_matches[$i], $vs_padded, $vs_display_value);
 			}
 		}
-		return mb_substr($vs_display_value, 0, $max_length);
+		return mb_substr($vs_display_value, 0, $max_length, 'UTF-8');
 	}
 	# ----------------------------------------
 	/**

--- a/app/lib/ApplicationChangeLog.php
+++ b/app/lib/ApplicationChangeLog.php
@@ -61,8 +61,9 @@ require_once(__CA_LIB_DIR__."/Db.php");
  	/**
  	 *
  	 */
-	public function getChangeLogForRowForDisplay($t_item, $ps_css_id=null, $pn_user_id=null) {
-		return $this->_getLogDisplayOutputForRow($this->getChangeLogForRow($t_item, array('user_id' => $pn_user_id)), array('id' => $ps_css_id));
+	public function getChangeLogForRowForDisplay($t_item, $ps_css_id=null, $pn_user_id=null, $options=null) {
+		if(!is_array($options)) { $options = []; }
+		return $this->_getLogDisplayOutputForRow($this->getChangeLogForRow($t_item, array_merge($options, ['user_id' => $pn_user_id])), ['id' => $ps_css_id]);
 	}
 	# ----------------------------------------
 	/**

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -224,6 +224,8 @@ class BaseEditorController extends ActionController {
 	    	return;
 	    }
 	    
+		$vb_no_save_error = false;
+	    
 		list($vn_subject_id, $t_subject, $t_ui, $vn_parent_id, $vn_above_id, $vn_after_id, $vs_rel_table, $vn_rel_type_id, $vn_rel_id) = $this->_initView($pa_options);
 		/** @var $t_subject BundlableLabelableBaseModelWithAttributes */
 		if (!is_array($pa_options)) { $pa_options = array(); }
@@ -294,6 +296,8 @@ class BaseEditorController extends ActionController {
 		if ($this->_beforeSave($t_subject, $vb_is_insert)) {
 			if ($vb_save_rc = $t_subject->saveBundlesForScreen($this->request->getActionExtra(), $this->request, $va_opts)) {
 				$this->_afterSave($t_subject, $vb_is_insert);
+			} elseif($t_subject->hasErrorNum(3600)) {
+				$vb_no_save_error = true;
 			}
 		}
 		$this->view->setVar('t_ui', $t_ui);
@@ -358,7 +362,6 @@ class BaseEditorController extends ActionController {
 		}
 		if(sizeof($va_errors) - sizeof($va_general_errors) > 0) {
 			$va_error_list = [];
-			$vb_no_save_error = false;
 			foreach($va_errors as $o_e) {
 				$bundle = array_shift(explode('/', $o_e->getErrorSource()));
 				$va_error_list[] = "<li><u>".$t_subject->getDisplayLabel($bundle).'</u>: '.$o_e->getErrorDescription()."</li>\n";
@@ -368,6 +371,9 @@ class BaseEditorController extends ActionController {
 						if (!$vn_subject_id) {		// can't save new record if idno is not valid (when updating everything but idno is saved if it is invalid)
 							$vb_no_save_error = true;
 						}
+						break;
+					case 3600:	// failed to create movement for storage location
+						$vb_no_save_error = true;;
 						break;
 				}
 			}

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -332,7 +332,7 @@ class BaseModel extends BaseObject {
 	/**
 	 * If set, all field values passed through BaseModel::set() are run through HTML Purifier before being stored
 	 */
-	private $opb_purify_input = true;
+	private $opb_purify_input = false;
 	
 	/**
 	 * Array of model definitions, keyed on table name
@@ -360,6 +360,8 @@ class BaseModel extends BaseObject {
 	 */
 	protected $opn_instantiated_at = 0;
 	
+	static $field_list_for_load = [];
+	
 	/**
 	 * Constructor
 	 * In general you should not call this constructor directly. Any table in your database
@@ -376,6 +378,19 @@ class BaseModel extends BaseObject {
 		if (!$this->FIELDS =& BaseModel::$s_ca_models_definitions[$vs_table_name]['FIELDS']) {
 			die("Field definitions not found for {$vs_table_name}");
 		}
+		if (!is_array(self::$field_list_for_load)) { self::$field_list_for_load = []; }
+		if (!self::$field_list_for_load[$vs_table_name]) {
+			self::$field_list_for_load[$vs_table_name] = [];
+			foreach($this->FIELDS as $f => $info) {
+				if(isset($info['START']) && isset($info['END'])) {
+					self::$field_list_for_load[$vs_table_name][] = "`{$info['START']}`";
+					self::$field_list_for_load[$vs_table_name][] = "`{$info['END']}`";
+				} else {
+					self::$field_list_for_load[$vs_table_name][] = "`{$f}`";
+				}
+			}
+		}
+		
 		$this->NAME_SINGULAR =& BaseModel::$s_ca_models_definitions[$vs_table_name]['NAME_SINGULAR'];
 		$this->NAME_PLURAL =& BaseModel::$s_ca_models_definitions[$vs_table_name]['NAME_PLURAL'];
 		
@@ -971,6 +986,10 @@ class BaseModel extends BaseObject {
 				$vs_prop = isset($this->_FIELD_VALUES[$ps_field]) ? $this->_FIELD_VALUES[$ps_field] : null;
 				if (isset($pa_options["FILTER_HTML_SPECIAL_CHARS"]) && ($pa_options["FILTER_HTML_SPECIAL_CHARS"])) {
 					$vs_prop = htmlentities(html_entity_decode($vs_prop));
+				}
+				
+				if(($ps_field_type == FT_NUMBER) && isset($vs_prop) && is_numeric($vs_prop)) {
+					$vs_prop = ((float)$vs_prop != (int)$vs_prop) ? (float)$vs_prop : (int)$vs_prop;
 				}
 				
 				//
@@ -1918,7 +1937,6 @@ class BaseModel extends BaseObject {
 		if (is_null($pm_id)) {
 			return false;
 		}
-
 		$o_db = $this->getDb();
 
 		if (!is_array($pm_id)) {
@@ -1928,7 +1946,8 @@ class BaseModel extends BaseObject {
 				$pm_id = intval($pm_id);
 			}
 
-			$vs_sql = "SELECT * FROM ".$this->tableName()." WHERE ".$this->primaryKey()." = ".$pm_id;
+			$vs_sql = "SELECT ".join(',', self::$field_list_for_load[$this->tableName()])." FROM ".$this->tableName()." WHERE ".$this->primaryKey()." = ".$pm_id;
+
 		} else {
 			$va_sql_wheres = array();
 			foreach ($pm_id as $vs_field => $vm_value) {
@@ -1965,17 +1984,18 @@ class BaseModel extends BaseObject {
 					if ($vm_value === '') { continue; }
 					$va_sql_wheres[] = "($vs_field = $vm_value)";
 				}
+				
 			}
-			$vs_sql = "SELECT * FROM ".$this->tableName()." WHERE ".join(" AND ", $va_sql_wheres). " LIMIT 1";
+			$vs_sql = "SELECT ".join(',', self::$field_list_for_load[$this->tableName()])." FROM ".$this->tableName()." WHERE ".join(" AND ", $va_sql_wheres). " LIMIT 1";	
 		}
 
 		try {
 			$qr_res = $o_db->query($vs_sql);
 		} catch (DatabaseException $e) {
 			$this->_processDatabaseException($e, $o_db);
-			return false;
-			
+			return false;	
 		}
+
 		if ($qr_res->nextRow()) {
 			foreach($this->FIELDS as $vs_field => $va_attr) {
 				$vs_cur_value = isset($this->_FIELD_VALUES[$vs_field]) ? $this->_FIELD_VALUES[$vs_field] : null;
@@ -2015,6 +2035,7 @@ class BaseModel extends BaseObject {
 				BaseModel::$s_instance_cache[$vs_table_name][(int)$vn_id] = $this->_FIELD_VALUES; 
 			}
 			$this->opn_instantiated_at = time();
+			
 			return true;
 		} else {
 			if (!is_array($pm_id)) {
@@ -2220,7 +2241,7 @@ class BaseModel extends BaseObject {
 	 * Use this method to insert new record using supplied values
 	 * (assuming that you've constructed your BaseModel object as empty record)
 	 * @param $pa_options array optional associative array of options. Supported options include: 
-	 *		dont_do_search_indexing = if set to true then no search indexing on the inserted record is performed
+	 *		dontDoSearchIndexing = if set to true then no search indexing on the inserted record is performed. [Default is false]
 	 *		dontLogChange = don't log change in change log. [Default is false]
 	 * @return int primary key of the new record, false on error
 	 */
@@ -2667,7 +2688,7 @@ class BaseModel extends BaseObject {
 				#
 				$vn_id = $this->getPrimaryKey();
 				
-				if ((!isset($pa_options['dont_do_search_indexing']) || (!$pa_options['dont_do_search_indexing'])) && !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
+				if (!caGetOption(['dont_do_search_indexing', 'dontDoSearchIndexing'], $pa_options, false) && !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
 					$va_index_options = array('isNewRow' => true);
 					if(caGetOption('queueIndexing', $pa_options, true)) {
 						$va_index_options['queueIndexing'] = true;
@@ -2743,10 +2764,14 @@ class BaseModel extends BaseObject {
 	 *		force = if set field values are not verified prior to performing the update
 	 *		dontLogChange = don't log change in change log. [Default is false]
 	 *      dontUpdateHistoryCurrentValueTracking = Skip updating current value tracking caches. Used internally when deleting rows. [Default is false]
+	 *		dontDoSearchIndexing = if set to true then no search indexing on the inserted record is performed. [Default is false]
 	 * @return bool success state
 	 */
 	public function update($pa_options=null) {
 		if (!is_array($pa_options)) { $pa_options = array(); }
+		
+		// Clear any cached display template values for this record
+		MemoryCache::delete($this->tableName()."/".$this->getPrimaryKey(), 'DisplayTemplateParserValues');
 		
 		$we_set_change_log_unit_id = BaseModel::setChangeLogUnitID();
 		
@@ -3192,7 +3217,7 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
                     if ($table::isHistoryTrackingCriterion($table)) { $this->updateDependentHistoryTrackingCurrentValues(); }
                 }
 				
-				if ((!isset($pa_options['dont_do_search_indexing']) || (!$pa_options['dont_do_search_indexing'])) &&  !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
+				if (!caGetOption(['dont_do_search_indexing', 'dontDoSearchIndexing'], $pa_options, false) &&  !defined('__CA_DONT_DO_SEARCH_INDEXING__')) {
 					# update search index
 					$va_index_options = array();
 					if(caGetOption('queueIndexing', $pa_options, true)) {
@@ -3310,6 +3335,9 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 	 */
 	public function delete ($pb_delete_related=false, $pa_options=null, $pa_fields=null, $pa_table_list=null) {
 		if(!is_array($pa_options)) { $pa_options = array(); }
+		
+		// Clear any cached display template values for this record
+		MemoryCache::delete($this->tableName()."/".$this->getPrimaryKey(), 'DisplayTemplateParserValues');
 		
 		$we_set_change_log_unit_id = BaseModel::setChangeLogUnitID();
 		
@@ -5848,13 +5876,13 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 				$max_length = $va_attr["BOUNDS_LENGTH"][1];
 			}
 
-			if ((isset($min_length)) && (strlen($value) < $min_length)) {
+			if ((isset($min_length)) && (mb_strlen($value) < $min_length)) {
 				$this->postError(1102, _t("%1 must be at least %2 characters", $va_attr["LABEL"], $min_length),"BaseModel->verifyFieldValue()", $this->tableName().'.'.$field);
 				return false;
 			}
 
 
-			if ((isset($max_length)) && (strlen($value) > $max_length)) {
+			if ((isset($max_length)) && (mb_strlen($value) > $max_length)) {
 				$this->postError(1102,_t("%1 must not be more than %2 characters long", $va_attr["LABEL"], $max_length),"BaseModel->verifyFieldValue()", $this->tableName().'.'.$field);
 				return false;
 			}
@@ -5863,16 +5891,14 @@ if (!isset($pa_options['dontSetHierarchicalIndexing']) || !$pa_options['dontSetH
 			if (isset($va_attr['LIST']) && $va_attr['LIST']) {
 				$t_list = new ca_lists();
 				$t_list->setTransaction($this->getTransaction());
-				if ($t_list->load(array('list_code' => $va_attr['LIST']))) {
-					$va_items = caExtractValuesByUserLocale($t_list->getItemsForList($va_attr['LIST']));
-					$va_list = array();
-					$vs_list_default = null;
-					foreach($va_items as $vn_item_id => $va_item_info) {
-						if(is_null($vs_list_default) || (isset($va_item_info['is_default']) && $va_item_info['is_default'])) { $vs_list_default = $va_item_info['item_value']; }
-						$va_list[$va_item_info['name_singular']] = $va_item_info['item_value'];
-					}
-					$va_attr['DEFAULT'] = $vs_list_default;
+				$va_items = caExtractValuesByUserLocale($t_list->getItemsForList($va_attr['LIST']));
+				$va_list = [];
+				$vs_list_default = null;
+				foreach($va_items as $vn_item_id => $va_item_info) {
+					if(is_null($vs_list_default) || (isset($va_item_info['is_default']) && $va_item_info['is_default'])) { $vs_list_default = $va_item_info['item_value']; }
+					$va_list[$va_item_info['name_singular']] = $va_item_info['item_value'];
 				}
+				$va_attr['DEFAULT'] = $vs_list_default;
 			}
 			if ((in_array($data_type, array(FT_NUMBER, FT_TEXT))) && (isset($va_list)) && (is_array($va_list)) && (count($va_list) > 0)) { # string; check choice list
 				if (isset($va_attr['DEFAULT']) && !strlen($value)) { 

--- a/app/lib/BaseObject.php
+++ b/app/lib/BaseObject.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2007-2009 Whirl-i-Gig
+ * Copyright 2007-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -122,6 +122,15 @@
 				$o_notification->addNotification("[{$pn_num}] {$ps_message} ({$ps_context}".($ps_source ? "; {$ps_source}" : '').$vs_stacktrace);
 			}
 			return true;
+		}
+		# ------------------------------------------------------------------
+		public function hasErrorNum(int $error_num, ?string $source=null) : bool {
+			$errors = $this->errors($source);
+			
+			foreach($errors as $e) {
+				if($e->getErrorNumber() == $error_num) { return true; }
+			}
+			return false;
 		}
 		# ------------------------------------------------------------------
 		public function __destruct() {

--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -4369,7 +4369,7 @@
 						while($qr_res->nextRow()) {
 							if (!($current_table_num = trim($qr_res->get('current_table_num')))) { continue; }
 							if (!($current_row_id = trim($qr_res->get('current_row_id')))) { continue; }
-							if (!($current_type_id = trim($qr_res->get('current_type_id')))) { continue; }
+							//if (!($current_type_id = trim($qr_res->get('current_type_id')))) { continue; }
 							$vs_val = "{$current_table_num}:{$current_type_id}:{$current_row_id}";
 							if ($va_criteria[$vs_val]) { continue; }		// skip items that are used as browse critera - don't want to browse on something you're already browsing on
 

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -285,6 +285,9 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			}
 		}
 		
+		if(caGetOption('hooks', $pa_options, true)) {
+			$this->opo_app_plugin_manager->hookInsertItem(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'is_insert' => true));
+		}
 		return $vn_rc;
 	}
 	# ------------------------------------------------------
@@ -351,6 +354,9 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 						
 		SearchResult::clearResultCacheForRow($this->tableName(), $this->getPrimaryKey());
 
+		if(caGetOption('hooks', $pa_options, true)) {
+			$this->opo_app_plugin_manager->hookUpdateItem(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this, 'is_insert' => false));
+		}
 		return $vn_rc;
 	}	
 	# ------------------------------------------------------------------
@@ -1013,39 +1019,8 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		// Create instance of idno numbering plugin (if table supports it)
 		if ($vs_field = $this->getProperty('ID_NUMBERING_ID_FIELD')) {
 			if (!$vn_type_id) { $vn_type_id = null; }
-			$va_types = array();
-			$o_db = $this->getDb();		// have to do direct query here... if we use ca_list_items model we'll just endlessly recurse
-			
-			if ($vn_type_id) {
-				
-				$qr_res = $o_db->query("
-					SELECT idno, list_id, hier_left, hier_right 
-					FROM ca_list_items 
-					WHERE 
-						item_id = ?"
-					, (int)$vn_type_id);
-					
-				if ($qr_res->nextRow()) {
-					if ($vn_list_id = $qr_res->get('list_id')) {
-						$vn_hier_left 		= $qr_res->get('hier_left');
-						$vn_hier_right 		= $qr_res->get('hier_right');
-						$vs_idno 			= $qr_res->get('idno');
-						$qr_res = $o_db->query("
-							SELECT idno, parent_id
-							FROM ca_list_items 
-							WHERE 
-								(list_id = ? AND hier_left < ? AND hier_right > ?)", 
-						(int)$vn_list_id, (int)$vn_hier_left, (int)$vn_hier_right);
-						
-						while($qr_res->nextRow()) {
-							if (!$qr_res->get('parent_id')) { continue; }
-							$va_types[] = $qr_res->get('idno');
-						}
-						$va_types[] = $vs_idno;
-						$va_types = array_reverse($va_types);
-					}
-				}
-			}
+			//$va_types = array();
+			$va_types = $vn_type_id ? caMakeTypeList($this->tableName(), [$vn_type_id]) : null;
 			$this->opo_idno_plugin_instance = IDNumbering::newIDNumberer($this->tableName(), $va_types, null, $o_db);
 		} else {
 			$this->opo_idno_plugin_instance = null;
@@ -1167,24 +1142,30 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
  		// Is row loaded?
  		if (!$this->getPrimaryKey()) { return false; }
  		
+ 		$table = $this->tableName();
+ 		$config = $this->getAppConfig();
+ 		
+ 		if($config->get("{$table}_disable_delete")) { return false; }
+ 		if($config->get("{$table}_".$this->getTypeCode()."_disable_delete")) { return false; }
+ 		
  		// Check type restrictions
- 		if ((bool)$this->getAppConfig()->get('perform_type_access_checking')) {
-			$vn_type_access = $t_user->getTypeAccessLevel($this->tableName(), $this->getTypeID());
+ 		if ((bool)$config->get('perform_type_access_checking')) {
+			$vn_type_access = $t_user->getTypeAccessLevel($table, $this->getTypeID());
 			if ($vn_type_access != __CA_BUNDLE_ACCESS_EDIT__) {
 				return false;
 			}
 		}
 		
 		// Check source restrictions
- 		if ((bool)$this->getAppConfig()->get('perform_source_access_checking')) {
-			$vn_source_access = $t_user->getSourceAccessLevel($this->tableName(), $this->getSourceID());
+ 		if ((bool)$config->get('perform_source_access_checking')) {
+			$vn_source_access = $t_user->getSourceAccessLevel($table, $this->getSourceID());
 			if ($vn_source_access < __CA_BUNDLE_ACCESS_EDIT__) {
 				return false;
 			}
 		}
 		
 		// Check item level restrictions
-		if ((bool)$this->getAppConfig()->get('perform_item_level_access_checking') && $this->getPrimaryKey()) {
+		if ((bool)$config->get('perform_item_level_access_checking') && $this->getPrimaryKey()) {
 			$vn_item_access = $this->checkACLAccessForUser($t_user);
 			if ($vn_item_access < __CA_ACL_EDIT_DELETE_ACCESS__) {
 				return false;
@@ -1192,7 +1173,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		}
 		
  		// Check actions
- 		if (!$this->getPrimaryKey() || !$t_user->canDoAction('can_delete_'.$this->tableName())) {
+ 		if (!$this->getPrimaryKey() || !$t_user->canDoAction("can_delete_{$table}")) {
  			return false;
  		}
  		
@@ -1420,7 +1401,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		
 		
 		// Bundle names for attributes are element codes. They may be prefixed with 'ca_attribute_' in older installations.
-		// Since various functions tak straight element codes we have to strip the prefix here
+		// Since various functions take straight element codes we have to strip the prefix here
 		$ps_bundle_name_proc = str_replace("ca_attribute_", "", $ps_bundle_name);
 		$va_violations = null;
 		
@@ -3214,6 +3195,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 			$o_view->setVar('relationship_types', $t_item_rel->getRelationshipTypes(null, null,  array_merge($pa_options, $pa_bundle_settings)));
 			$o_view->setVar('relationship_types_by_sub_type', $t_item_rel->getRelationshipTypesBySubtype($this->tableName(), $this->get('type_id'),  array_merge($pa_options, $pa_bundle_settings)));
 		}
+
 		$o_view->setVar('t_subject', $this);
 		$va_initial_values = $this->getRelatedBundleFormValues($po_request, $ps_form_name, $ps_related_table, $ps_placement_code, $pa_bundle_settings, $pa_options);
 
@@ -4929,7 +4911,7 @@ if (!$vb_batch) {
 					        Session::setVar("{$vs_f}_showChildHistory", (bool)$pb_show_child_history);
 					    }
 					    
-					    $policy = caGetOption('policy', $va_bundle_settings, null);
+					    $policy = caGetOption('policy', $va_bundle_settings, $this::getDefaultHistoryTrackingCurrentValuePolicyForTable());
 					    
 					    $change_has_been_made = false;
 					    
@@ -5737,8 +5719,7 @@ if (!$vb_batch) {
  	 * @return array List of related items
  	 */
 	public function getRelatedItems($pm_rel_table_name_or_num, $pa_options=null, &$pn_count=null) {
-		global $AUTH_CURRENT_USER_ID;
-				        
+		global $AUTH_CURRENT_USER_ID;    
 		$vn_user_id = (isset($pa_options['user_id']) && $pa_options['user_id']) ? $pa_options['user_id'] : (int)$AUTH_CURRENT_USER_ID;
 		$vb_show_if_no_acl = (bool)($this->getAppConfig()->get('default_item_access_level') > __CA_ACL_NO_ACCESS__);
 
@@ -5768,7 +5749,6 @@ if (!$vb_batch) {
 		if (($pa_options['restrictToLists'] = caGetOption(array('restrictToLists', 'restrict_to_lists'), $pa_options, null)) && !is_array($pa_options['restrictToLists'])) {
 			$pa_options['restrictToLists'] = preg_split("![;,]{1}!", $pa_options['restrictToLists']);
 		}
-		
 		$pb_group_fields = isset($pa_options['groupFields']) ? $pa_options['groupFields'] : false;
 		$pa_primary_ids = (isset($pa_options['primaryIDs']) && is_array($pa_options['primaryIDs'])) ? $pa_options['primaryIDs'] : null;
 		$pb_show_current_only = caGetOption('showCurrentOnly', $pa_options, caGetOption('currentOnly', $pa_options, false));
@@ -5820,22 +5800,25 @@ if (!$vb_batch) {
 		
 		$vs_subject_table_name = $this->tableName();
 		$vs_item_rel_table_name = $vs_rel_item_table_name = null;
+		
 		switch(sizeof($va_path = array_keys(Datamodel::getPath($vs_subject_table_name, $vs_related_table_name)))) {
 			case 3:
-				$t_item_rel = Datamodel::getInstance($va_path[1]);
-				$vs_item_rel_table_name = $t_item_rel->tableName();
+			
+				$t_item_rel = Datamodel::getInstance($va_path[1], true);
+				$vs_item_rel_table_name = $va_path[1];
 				
-				$t_rel_item = Datamodel::getInstance($va_path[2]);
-				$vs_rel_item_table_name = $t_rel_item->tableName();
+				$t_rel_item = Datamodel::getInstance($va_path[2], true);
+				$vs_rel_item_table_name = $va_path[2];
 				
 				$vs_key = $t_item_rel->primaryKey(); //'relation_id';
+				
 				break;
 			case 2:
 				$t_item_rel = $this->isRelationship() ? $this : null;
 				$vs_item_rel_table_name = $t_item_rel ? $t_item_rel->tableName() : null;
 				
-				if (!($t_rel_item = Datamodel::getInstance($va_path[1]))) { return null; }
-				$vs_rel_item_table_name = $t_rel_item->tableName();
+				if (!($t_rel_item = Datamodel::getInstance($va_path[1], true))) { return null; }
+				$vs_rel_item_table_name = $va_path[1];
 				
 				$vs_key = $t_rel_item->primaryKey();
 				break;
@@ -5845,17 +5828,17 @@ if (!$vb_batch) {
 					$va_path = [$this->tableName(), 'ca_items_x_tags', 'ca_item_tags'];
 					$vb_is_combo_key_relation = true;
 					
-					$t_item_rel = Datamodel::getInstance($va_path[1]);
-					$vs_item_rel_table_name = $t_item_rel->tableName();
-					$t_rel_item = Datamodel::getInstance($va_path[2]);
-					$vs_rel_item_table_name = $t_rel_item->tableName();
+					$t_item_rel = Datamodel::getInstance($va_path[1], true);
+					$vs_item_rel_table_name = $va_path[1];
+					$t_rel_item = Datamodel::getInstance($va_path[2], true);
+					$vs_rel_item_table_name = $va_path[2];
 					$vs_key = $t_item_rel->primaryKey();
 					break;
 				}
 				
 				
 				if (
-					($t_rel_item = Datamodel::getInstance($vs_related_table_name))
+					($t_rel_item = Datamodel::getInstance($vs_related_table_name, true))
 					&&
 					$t_rel_item->hasField('table_num') && $t_rel_item->hasField('row_id')
 				) {
@@ -5875,16 +5858,16 @@ if (!$vb_batch) {
 		$vb_self_relationship = false;
 		if($vs_subject_table_name == $vs_related_table_name) {
 			$vb_self_relationship = true;
-			$t_item_rel = Datamodel::getInstance($va_path[1]);
-			$vs_item_rel_table_name = $t_item_rel->tableName();
+			$t_item_rel = Datamodel::getInstance($va_path[1], true);
+			$vs_item_rel_table_name = $va_path[1];
 			
-			$t_rel_item = Datamodel::getInstance($va_path[0]);
-			$vs_rel_item_table_name = $t_rel_item->tableName();
+			$t_rel_item = Datamodel::getInstance($va_path[0], true);
+			$vs_rel_item_table_name = $va_path[0];
 		}
 
-		$va_wheres = array();
-		$va_selects = array();
-		$va_joins_post_add = array();
+		$va_wheres = [];
+		$va_selects = [];
+		$va_joins_post_add = [];
 
 		$vs_related_table = $vs_rel_item_table_name;
 		if ($t_rel_item->hasField('type_id')) { $va_selects[] = "{$vs_related_table}.type_id item_type_id"; }
@@ -5892,7 +5875,7 @@ if (!$vb_batch) {
 
 		// TODO: get these field names from models
 		if (($t_tmp = $t_item_rel) || ($t_rel_item->isRelationship() && ($t_tmp = $t_rel_item))) {
-			//define table names
+			// define table names
 			$vs_linking_table = $t_tmp->tableName();
 
 			$va_selects[] = "{$vs_related_table}.".$t_rel_item->primaryKey();
@@ -7017,16 +7000,17 @@ $pa_options["display_form_field_tips"] = true;
 	 *		sort = field or attribute to sort on in <table name>.<field or attribute name> format (eg. ca_objects.idno); default is to sort on relevance (aka. sort='_natural')
 	 *		sortDirection = direction to sort results by, either 'asc' for ascending order or 'desc' for descending order; default is 'asc'
 	 *		instance = An instance of the model for $pm_rel_table_name_or_num; if passed makeSearchResult can use it to directly extract model information potentially saving time [Default is null]
+	 *		returnIndex = Return array with result instance (key "result") and list of sorted primary key values (key "index"). [Default is false]
+	 *
 	 * @return SearchResult A search result of for the specified table
 	 */
 	public function makeSearchResult($pm_rel_table_name_or_num, $pa_ids, $pa_options=null) {
 		if (!is_array($pa_ids)) { return null; }
 		
 		if (!isset($pa_options['instance']) || !($t_instance = $pa_options['instance'])) {
-			$pn_table_num = Datamodel::getTableNum($pm_rel_table_name_or_num);
-			if (!($t_instance = Datamodel::getInstanceByTableNum($pn_table_num, true))) { return null; }
+			if (!($t_instance = Datamodel::getInstance($pm_rel_table_name_or_num, true))) { return null; }
 		}
-		$va_ids = array();
+		$va_ids = [];
 		foreach($pa_ids as $vn_k => $vn_id) {
 			if (is_numeric($vn_id)) { 
 				$va_ids[$vn_k] = $vn_id;
@@ -7034,20 +7018,19 @@ $pa_options["display_form_field_tips"] = true;
 		}
 		// sort?
 		if ($pa_sort = caGetOption('sort', $pa_options, null)) {
-			if (!is_array($pa_sort)) { $pa_sort = array($pa_sort); }
+			if (!is_array($pa_sort)) { $pa_sort = [$pa_sort]; }
 			
 			$vo_sort = new BaseFindEngine($this->getDb());
 			$va_ids = $vo_sort->sortHits($va_ids, $t_instance->tableName(), join(';', $pa_sort), caGetOption('sortDirection', $pa_options, 'asc'), $pa_options);
 		}
 		if (!($vs_search_result_class = $t_instance->getProperty('SEARCH_RESULT_CLASSNAME'))) { return null; }
-		if (!class_exists($vs_search_result_class)) { include(__CA_LIB_DIR__.'/Search/'.$vs_search_result_class.'.php'); }
 		$o_data = new WLPlugSearchEngineCachedResult($va_ids, $t_instance->tableNum());
 		/** @var BaseSearchResult $o_res */
 		$o_res = new $vs_search_result_class($t_instance->tableName());	// we pass the table name here so generic multi-table search classes such as InterstitialSearch know what table they're operating over
-		$o_res->init($o_data, array(), $pa_options);
+		$o_res->init($o_data, [], $pa_options);
 
 		if(caGetOption('returnIndex', $pa_options, false)) {
-			return array('result' => $o_res, 'index' => $va_ids);
+			return ['result' => $o_res, 'index' => $va_ids];
 		}
 
 		return $o_res;

--- a/app/lib/Controller/Request/Session.php
+++ b/app/lib/Controller/Request/Session.php
@@ -103,12 +103,8 @@ class Session {
 		# --- Read configuration
 		Session::$name = ($vs_app_name = $o_config->get("app_name")) ? $vs_app_name : $ps_app_name;
 		Session::$domain = $o_config->get("session_domain");
-		Session::$lifetime = (int) $o_config->get("session_lifetime");
+		Session::$lifetime = Session::lifetime();
 		Session::$api_session_lifetime = (int) $service_config->get("api_session_lifetime");
-
-		if(!Session::$lifetime) {
-			Session::$lifetime = 3600 * 24 * 7;
-		}
 		
 		$session_id = self::getSessionID();
 		if (!$pb_dont_create_new_session) {
@@ -326,6 +322,18 @@ class Session {
 			$vars[$k] = Session::$s_session_vars[$k];
 		}
 		ExternalCache::save($session_id, array_merge($va_current_values, $vars), 'SessionVars', $vn_session_lifetime);
+	}
+	# ----------------------------------------
+	/**
+	 * Return session lifetime setting
+	 *
+	 * @return int
+	 */
+	public static function lifetime():int {
+ 		$o_config = Configuration::load();
+ 		if($l = (int) $o_config->get("session_lifetime")) { return $l; }
+		
+		return 3600 * 24 * 7;
 	}
 	# ----------------------------------------
 	# --- Page performance

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -257,3 +257,6 @@
 3500 = Access denied
 3510 = Plugin does not exist
 3520 = Command does not exist
+
+# --- Location tracking errors
+3600 = Cannot create movement

--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -269,6 +269,12 @@
 				foreach(array(
 							'policy', 'displayMode', 'dateMode', 'row_id', 'width', 'height', 'readonly', 'documentation_url', 'expand_collapse',
 							'label', 'description', 'useHierarchicalBrowser', 'hide_add_to_loan_controls', 'hide_add_to_movement_controls', 'hide_update_location_controls', 'hide_return_to_home_location_controls',
+							
+							'update_location_control_label', 'movement_control_label', 'loan_control_label', 'object_control_label',
+							'return_to_home_location_control_label', 'occurrence_control_label', 'collection_control_label', 'entity_control_label',
+							
+							'always_create_new_movement',
+							
 							'hide_add_to_occurrence_controls', 'hide_include_child_history_controls', 'add_to_occurrence_types', 
 							'hide_add_to_collection_controls', 'add_to_collection_types', 'hide_add_to_object_controls', 'hide_add_to_entity_controls', 'add_to_entity_types', 
 							'ca_storage_locations_elements', 'sortDirection', 'setInterstitialElementsOnAdd',
@@ -329,7 +335,8 @@
 		 *
 		 * @return string Policy name
 		 */
-		static public function getDefaultHistoryTrackingCurrentValuePolicyForTable($table) {
+		static public function getDefaultHistoryTrackingCurrentValuePolicyForTable(string $table=null) : ?string {
+			if(is_null($table)) { $table = get_called_class(); }
 			if (is_array($history_tracking_policies = self::getHistoryTrackingCurrentValuePolicyConfig()) && is_array($history_tracking_policies['defaults']) && isset($history_tracking_policies['defaults'][$table])) {
 				return $history_tracking_policies['defaults'][$table];
 			}
@@ -930,9 +937,9 @@
 					}
 					
 					if($linking_table) {
-						$qr_lots = caMakeSearchResult($linking_table, $va_lots, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_object_lots.lot_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+						$qr_lots = caMakeSearchResult($linking_table, $va_lots, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 					} else {
-						$qr_lots = caMakeSearchResult('ca_object_lots', $va_lots, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_object_lots.lot_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+						$qr_lots = caMakeSearchResult('ca_object_lots', $va_lots, ['transaction' => $this->getTransaction(), 'sort' =>  'ca_object_lots.lot_id', 'sortDirection' => 'desc']);
 					}
 					
 					$t_lot = new ca_object_lots();
@@ -1028,7 +1035,7 @@
 					if ($pb_show_child_history) { $va_loans = array_merge($va_loans, $va_child_loans); }
 				}
 				if(is_array($va_loan_types = caGetOption('ca_loans_showTypes', $pa_bundle_settings, null)) && is_array($va_loans)) {	
-					$qr_loans = caMakeSearchResult($linking_table, $va_loans, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_loans.loan_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_loans = caMakeSearchResult($linking_table, $va_loans, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 					require_once(__CA_MODELS_DIR__."/ca_loans.php");
 					$t_loan = new ca_loans();
 					$va_loan_type_info = $t_loan->getTypeList(); 
@@ -1135,7 +1142,7 @@
 					if ($pb_show_child_history) { $va_movements = array_merge($va_movements, $va_child_movements); }
 				}
 				if(is_array($va_movement_types = caGetOption('ca_movements_showTypes', $pa_bundle_settings, null)) && is_array($va_movements)) {	
-					$qr_movements = caMakeSearchResult($linking_table, $va_movements, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_movements.movement_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_movements = caMakeSearchResult($linking_table, $va_movements, ['transaction' => $this->getTransaction(), 'sort' =>  "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 					require_once(__CA_MODELS_DIR__."/ca_movements.php");
 					$t_movement = new ca_movements();
 					$va_movement_type_info = $t_movement->getTypeList(); 
@@ -1253,7 +1260,7 @@
 						}
 					}
 			
-					$qr_occurrences = caMakeSearchResult($linking_table, $va_occurrences, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_occurrences.occurrence_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_occurrences = caMakeSearchResult($linking_table, $va_occurrences, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 			
 					$va_date_elements_by_type = [];
 					foreach($va_occurrence_types as $vn_type_id) {
@@ -1368,7 +1375,7 @@
 						}
 					}
 			
-					$qr_entities = caMakeSearchResult($linking_table, $va_entities, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_entities.entity_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_entities = caMakeSearchResult($linking_table, $va_entities, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 			
 					$va_date_elements_by_type = [];
 					foreach($va_entity_types as $vn_type_id) {
@@ -1475,7 +1482,7 @@
 					if($pb_show_child_history) { $va_collections = array_merge($va_collections, $va_child_collections); }
 				}
 				if(is_array($va_collection_types = caGetOption('ca_collections_showTypes', $pa_bundle_settings, null)) && is_array($va_collections)) {	
-					$qr_collections = caMakeSearchResult($linking_table, $va_collections, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_collections.collection_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_collections = caMakeSearchResult($linking_table, $va_collections, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.collection_id", 'sortDirection' => 'desc']);
 					require_once(__CA_MODELS_DIR__."/ca_collections.php");
 					$t_collection = new ca_collections();
 					$va_collection_type_info = $t_collection->getTypeList(); 
@@ -1584,7 +1591,7 @@
 					if($pb_show_child_history) { $va_objects = array_merge($va_objects, $va_child_objects); }
 				}
 				if(is_array($va_object_types = caGetOption('ca_objects_showTypes', $pa_bundle_settings, null)) && is_array($va_objects)) {	
-					$qr_objects = caMakeSearchResult($linking_table, $va_objects, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_objects.object_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_objects = caMakeSearchResult($linking_table, $va_objects, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 					require_once(__CA_MODELS_DIR__."/ca_objects.php");
 					$t_object = new ca_objects();
 					$va_object_type_info = $t_object->getTypeList(); 
@@ -1703,7 +1710,7 @@
 					$vs_name_singular = $t_location->getProperty('NAME_SINGULAR');
 					$vs_name_plural = $t_location->getProperty('NAME_PLURAL');
 			
-					$qr_locations = caMakeSearchResult($linking_table, $va_locations, ['transaction' => $this->getTransaction(), 'sort' => $pb_date_mode ? 'ca_storage_locations.location_id' : null, 'sortDirection' => $pb_date_mode ? 'desc' : null]);
+					$qr_locations = caMakeSearchResult($linking_table, $va_locations, ['transaction' => $this->getTransaction(), 'sort' => "{$linking_table}.relation_id", 'sortDirection' => 'desc']);
 			
 					$vs_default_display_template = '^ca_storage_locations.parent.preferred_labels.name ➜ ^ca_storage_locations.preferred_labels.name (^ca_storage_locations.idno)';
 					$vs_default_child_display_template = '^ca_storage_locations.parent.preferred_labels.name ➜ ^ca_storage_locations.preferred_labels.name (^ca_storage_locations.idno)<br/>[<em>^ca_objects.preferred_labels.name (^ca_objects.idno)</em>]';
@@ -1976,7 +1983,7 @@
 				return null;
 			}
 			$o_view->setVar('policy', $policy);
-			$o_view->setVar('policy_info', self::getHistoryTrackingCurrentValuePolicy($policy));
+			$o_view->setVar('policy_info', $policy_info = self::getHistoryTrackingCurrentValuePolicy($policy));
 			
 			$o_view->setVar('id_prefix', $ps_form_name);
 			$o_view->setVar('placement_code', $ps_placement_code);
@@ -2079,10 +2086,23 @@
 			//
 			$o_view->setVar('movement_relationship_types', []);
 			$o_view->setVar('movement_relationship_types_by_sub_type', []);
+		
 			if (is_array($path = Datamodel::getPath($this->tableName(), 'ca_movements')) && ($path = array_keys($path)) && (sizeof($path) === 3)) {
 				$linking_table = $path[1];
 				if ($t_movement_rel = Datamodel::getInstance($linking_table, true)) {
-					$o_view->setVar('movement_relationship_types', $t_movement_rel->getRelationshipTypes(null, null,  array_merge($pa_options, $pa_bundle_settings)));
+					$rel_types = $t_movement_rel->getRelationshipTypes(null, null,  array_merge($pa_options, $pa_bundle_settings));
+					
+					if(caGetOption('always_create_new_movement', $pa_bundle_settings, false)) {
+						if(is_array($policy_info['elements']['ca_movements']['__default__']) && isset($policy_info['elements']['ca_movements']['__default__']['trackingRelationshipType'])) {
+							$tracking_rels = caMakeRelationshipTypeIDList($linking_table, [$policy_info['elements']['ca_movements']['__default__']['trackingRelationshipType']]);
+							
+							if(is_array($tracking_rels) && sizeof($tracking_rels)) {
+								$tracking_rel_id = array_shift($tracking_rels);
+								$rel_types = [$tracking_rel_id => $rel_types[$tracking_rel_id]];
+							}
+						}
+					}
+					$o_view->setVar('movement_relationship_types', $rel_types);
 					
 					if(!is_array($bundle_config['ca_movements_showRelationshipTypes'])) { $bundle_config['ca_movements_showRelationshipTypes'] = []; }
 					$o_view->setVar('movement_relationship_types_by_sub_type', $t_movement_rel->getRelationshipTypesBySubtype($this->tableName(), $this->get('type_id'),  array_merge($bundle_config, ['restrictToRelationshipTypes' => $bundle_config['ca_movements_showRelationshipTypes']])));

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -944,7 +944,7 @@ if (!$for_current_value_reindex) {
 							
 							$vn_private = ((!is_array($va_private_rel_types) || !sizeof($va_private_rel_types) || !in_array($vn_rel_type_id, $va_private_rel_types))) ? 0 : 1;
 							
-							if(!$vn_private && $t_rel->hasField('access') && (!in_array((int)$qr_res->get('access'), $public_access, true))) {
+							if(!$vn_private && $t_rel->hasField('access') && (!in_array($t_rel->tableName(), ['ca_sets', 'ca_set_items'], true)) && (!in_array((int)$qr_res->get('access'), $public_access, true))) {
 								$vn_private = 1;
 							}
 				
@@ -1281,6 +1281,8 @@ if (!$for_current_value_reindex) {
 							        }
 						        }
 						    }
+						    
+							$this->_genIndexInheritance(Datamodel::getInstance($va_row_to_reindex['table_num'], true), Datamodel::getInstance($va_row_to_reindex['field_table_num'], true), $va_row_to_reindex['field_num'], $vn_row_id, $va_row_to_reindex['field_row_id'], $va_row_to_reindex['field_values'][$va_row_to_reindex['field_name']], array_merge($va_row_to_reindex['indexing_info'], ['PRIVATE' => $vn_private, 'relationship_type_id' => $vn_rel_type_id]));
 						}
 					} elseif (((isset($va_row_to_reindex['indexing_info']['INDEX_AS_IDNO']) && $va_row_to_reindex['indexing_info']['INDEX_AS_IDNO']) || in_array('INDEX_AS_IDNO', $va_row_to_reindex['indexing_info'], true)) && method_exists($t_rel, "getIDNoPlugInInstance") && ($o_idno = $t_rel->getIDNoPlugInInstance())) {
 						foreach($va_row_to_reindex['row_ids'] as $vn_row_id) {
@@ -1703,7 +1705,7 @@ if (!$for_current_value_reindex) {
 							$this->opo_engine->indexField($pn_subject_table_num, $field_num_prefix.$vn_element_id, $pn_row_id, [$vs_v], $pa_data);
 							$this->_genIndexInheritance($t_inheritance_subject ? $t_inheritance_subject : $pt_subject, $t_inheritance_subject ? $pt_subject : null, $field_num_prefix.$vn_element_id, $pn_inheritance_subject_id ? $pn_inheritance_subject_id : $pn_row_id, $pn_row_id, [$vs_v], $pa_data, $pa_options);
 							
-							foreach(["preferred_labels.".$t_item->getLabelDisplayField(), "nonpreferred_labels.".$t_item->getLabelDisplayField(), $t_item->primaryKey()] as $vs_f) {
+							foreach(["preferred_labels.".$t_item->getLabelDisplayField(), $t_item->primaryKey()] as $vs_f) {
 								if ($va_hier_values = $this->_genHierarchicalPath($vn_item_id, $vs_f, $t_item, $pa_data)) {
 
 									$this->opo_engine->indexField($pn_subject_table_num, $field_num_prefix.$vn_element_id, $pn_row_id, array_merge([$vs_v], $va_hier_values['values']), $pa_data);

--- a/app/models/ca_editor_ui_screens.php
+++ b/app/models/ca_editor_ui_screens.php
@@ -1675,7 +1675,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to loan" controls'),
+										'hideOnSelect' => ['loan_control_label'],
 										'description' => _t('Check this option if you want to hide the "Add to loan" controls in this bundle placement.')
+									),
+									'loan_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to loan" control label text'),
+										'description' => _t('Text to label "Add to loan" control with. If omitted a default label will be used.')
 									),
 									'hide_add_to_movement_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1684,7 +1693,25 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to movement" controls'),
+										'hideOnSelect' => ['movement_control_label', 'always_create_new_movement'],
 										'description' => _t('Check this option if you want to hide the "Add to movement" controls in this bundle placement.')
+									),
+									'always_create_new_movement' => array(
+										'formatType' => FT_NUMBER,
+										'displayType' => DT_CHECKBOXES,
+										'width' => 10, 'height' => 1,
+										'takesLocale' => false,
+										'default' => '0',
+										'label' => _t('Always create new movement?'),
+										'description' => _t('Check this option if you want to only create new movements when recording location. When this option is set linking to existing movements is not possible.')
+									),
+									'movement_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to movement" control label text'),
+										'description' => _t('Text to label "Add to movement" control with. If omitted a default label will be used.')
 									),
 									'hide_update_location_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1693,7 +1720,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Update Location" controls'),
+										'hideOnSelect' => ['update_location_control_label'],
 										'description' => _t('Check this option if you want to hide the "Update Location" controls in this bundle placement.')
+									),
+									'update_location_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Update location" control label text'),
+										'description' => _t('Text to label "Update location" control with. If omitted a default label will be used.')
 									),
 									'hide_return_to_home_location_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1702,7 +1738,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Return to Home Location" controls'),
+										'hideOnSelect' => ['return_to_home_location_control_label'],
 										'description' => _t('Check this option if you want to hide the "Return to Home Location" controls in this bundle placement.')
+									),
+									'return_to_home_location_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Return to home location" control label text'),
+										'description' => _t('Text to label "Return to home location" control with. If omitted a default label will be used.')
 									),
 									'hide_add_to_occurrence_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1711,8 +1756,8 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to" occurrence controls'),
-										'description' => _t('Check this option if you want to hide the "Add to" occurrence controls in this bundle placement.'),
-										'hideOnSelect' => ['add_to_occurrence_types']
+										'description' => _t('Check this option if you want to hide the "Add to occurrence" controls in this bundle placement.'),
+										'hideOnSelect' => ['add_to_occurrence_types', 'occurrence_control_label']
 									),
 									'add_to_occurrence_types' => array(
 										'formatType' => FT_TEXT,
@@ -1722,8 +1767,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'default' => '',
 										'multiple' => true,
 										'width' => "475px", 'height' => "75px",
-										'label' => _t('Show "Add to" occurrence controls for'),
+										'label' => _t('Show "Add to occurrence" controls for'),
 										'description' => ''
+									),
+									'occurrence_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to occurrence" control label text'),
+										'description' => _t('Text to label "Add to occurrence" control with. If omitted a default label will be used.')
 									),
 									'hide_add_to_collection_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1732,6 +1785,7 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to collection" controls'),
+										'hideOnSelect' => ['add_to_collection_types', 'collection_control_label'],
 										'description' => _t('Check this option if you want to hide the "Add to collection" controls in this bundle placement.')
 									),
 									'add_to_collection_types' => array(
@@ -1745,6 +1799,14 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'label' => _t('Show "Add to" collection controls for'),
 										'description' => ''
 									),
+									'collection_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to collection" control label text'),
+										'description' => _t('Text to label "Add to collection" control with. If omitted a default label will be used.')
+									),
 									'hide_add_to_entity_controls' => array(
 										'formatType' => FT_NUMBER,
 										'displayType' => DT_CHECKBOXES,
@@ -1752,6 +1814,7 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to entity" controls'),
+										'hideOnSelect' => ['add_to_entity_types', 'entity_control_label'],
 										'description' => _t('Check this option if you want to hide the "Add to entity" controls in this bundle placement.')
 									),
 									'add_to_entity_types' => array(
@@ -1762,8 +1825,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'default' => '',
 										'multiple' => true,
 										'width' => "475px", 'height' => "75px",
-										'label' => _t('Show "Add to" entity controls for'),
+										'label' => _t('Show "Add to entity" controls for'),
 										'description' => ''
+									),
+									'entity_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to entity" control label text'),
+										'description' => _t('Text to label "Add to entity" control with. If omitted a default label will be used.')
 									),
 									'hide_add_to_object_controls' => array(
 										'formatType' => FT_NUMBER,
@@ -1772,7 +1843,16 @@ class ca_editor_ui_screens extends BundlableLabelableBaseModelWithAttributes {
 										'takesLocale' => false,
 										'default' => '0',
 										'label' => _t('Hide "Add to object" controls'),
+										'hideOnSelect' => ['object_control_label'],
 										'description' => _t('Check this option if you want to hide the "Add to object" controls in this bundle placement.')
+									),
+									'object_control_label' => array(
+										'formatType' => FT_TEXT,
+										'displayType' => DT_FIELD,
+										'default' => '',
+										'width' => "275px", 'height' => 1,
+										'label' => _t('"Add to object" control label text'),
+										'description' => _t('Text to label "Add to object" control with. If omitted a default label will be used.')
 									),
 									'useHierarchicalBrowser' => array(
 										'formatType' => FT_TEXT,

--- a/app/models/ca_movements_x_objects.php
+++ b/app/models/ca_movements_x_objects.php
@@ -210,38 +210,4 @@ class ca_movements_x_objects extends ObjectRelationshipBaseModel {
 		parent::__construct($pn_id);	# call superclass constructor
 	}
 	# ------------------------------------------------------
-	/**
-	 *
-	 */
-	// public function insert($pa_options=null) {
-// 		if (!$this->get('effective_date', array('getDirectDate' => true))) {  
-// 			$this->set('effective_date', $this->_getMovementDate()); 
-// 		}
-// 		return parent::insert($pa_options);
-// 	}
-	# ------------------------------------------------------
-	/**
-	 *
-	 */
-	// public function update($pa_options=null) {
-// 		if (!$this->get('effective_date', array('getDirectDate' => true))) { 
-// 			$this->set('effective_date',  $this->_getMovementDate()); 
-// 		}
-// 		return parent::update($pa_options);
-// 	}
-	# ------------------------------------------------------
-	/**
-	 *
-	 */
-	// private function _getMovementDate() {
-// 	 	$vs_date = null;
-// 	 	if ($vs_movement_storage_element = $this->getAppConfig()->get('movement_storage_location_date_element')) {
-// 			$t_movement = new ca_movements($this->get('movement_id'));
-// 			if ($t_movement->getPrimaryKey()) {
-// 				$vs_date = $t_movement->get("ca_movements.{$vs_movement_storage_element}");
-// 			}
-// 		}
-// 		return ($vs_date) ? $vs_date : _t('now');
-// 	}
-	# ------------------------------------------------------
 }

--- a/app/models/ca_movements_x_storage_locations.php
+++ b/app/models/ca_movements_x_storage_locations.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2011-2019 Whirl-i-Gig
+ * Copyright 2011-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -33,7 +33,6 @@
  /**
    *
    */
-require_once(__CA_LIB_DIR__.'/BaseRelationshipModel.php');
 require_once(__CA_LIB_DIR__."/HistoryTrackingCurrentValueTrait.php");
 
 
@@ -215,10 +214,8 @@ class ca_movements_x_storage_locations extends BaseRelationshipModel {
 	 */
 	public function insert($pa_options=null) {
 		if (!$this->get('effective_date', array('getDirectDate' => true))) {  
-			//$this->set('effective_date', $this->_getMovementDate()); 
-			//$this->set('source_info', $this->_getStorageLocationInfo());
-			
-			$this->set('effective_date', _t('now')); 
+			$this->set('effective_date', $this->_getMovementDate()); 
+			$this->set('source_info', $this->_getStorageLocationInfo());
 		}
 		
 		try {
@@ -234,10 +231,8 @@ class ca_movements_x_storage_locations extends BaseRelationshipModel {
 	 */
 	public function update($pa_options=null) {
 		if (!$this->get('effective_date', array('getDirectDate' => true))) { 
-			//$this->set('effective_date',  $this->_getMovementDate()); 
-			//$this->set('source_info', $this->_getStorageLocationInfo());
-			
-			$this->set('effective_date', _t('now')); 
+			$this->set('effective_date',  $this->_getMovementDate()); 
+			$this->set('source_info', $this->_getStorageLocationInfo());
 		}
 		
 		try {
@@ -251,30 +246,63 @@ class ca_movements_x_storage_locations extends BaseRelationshipModel {
 	/**
 	 *
 	 */
-	// private function _getMovementDate() {
-// 	 	$vs_date = null;
-// 	 	if ($vs_movement_storage_element = $this->getAppConfig()->get('movement_storage_location_date_element')) {
-// 			$t_movement = new ca_movements($this->get('movement_id'));
-// 			if ($t_movement->getPrimaryKey()) {
-// 				$vs_date = $t_movement->get("ca_movements.{$vs_movement_storage_element}");
-// 			}
-// 		}
-// 		return ($vs_date) ? $vs_date : _t('now');
-// 	}
+	private function _getMovementDate() {
+	 	$date = null;
+	 	if ($movement_storage_element = $this->getAppConfig()->get('movement_storage_location_date_element')) {
+	 		$f = explode('.', $movement_storage_element);
+	 		if ((sizeof($f) > 1) && ($f[0] === 'ca_movements')) { array_shift($f); }
+	 		$movement_storage_element = join('.', $f);
+			if ($t_movement = ca_movements::findAsInstance(['movement_id' => $this->get('movement_id')])) {
+				$date = $t_movement->get("ca_movements.{$movement_storage_element}");
+			}
+		}
+		return ($date) ? $date : _t('now');
+	}
 	# ------------------------------------------------------
 	/**
 	 *
 	 */
-	// private function _getStorageLocationInfo() {
-// 		$t_loc = new ca_storage_locations($this->get('location_id'));
-// 		if ($t_loc->getPrimaryKey()) {
-// 			return array(
-// 				'path' => $t_loc->get('ca_storage_locations.hierarchy.preferred_labels.name', array('returnAsArray' => true)),
-// 				'ids' => $t_loc->get('ca_storage_locations.hierarchy.location_id',  array('returnAsArray' => true))
-// 			);
-// 		} else {
-// 			return array('path' => array('?'), 'ids' => array(0));
-// 		}
-// 	}	
+	private function _getStorageLocationInfo() {
+		$t_loc = new ca_storage_locations($this->get('location_id'));
+		if ($t_loc->getPrimaryKey()) {
+			if(!($tmpl = Configuration::load()->get('original_storage_location_path_template'))) { $tmpl = '^ca_storage_locations.hierarchy.preferred_labels.name'; }
+			return [
+				'path' => $t_loc->get('ca_storage_locations.hierarchy.preferred_labels.name', array('returnAsArray' => true)),
+				'display' => $t_loc->getWithTemplate($tmpl),
+				'ids' => $t_loc->get('ca_storage_locations.hierarchy.location_id',  array('returnAsArray' => true))
+			];
+		} else {
+			return ['path' => ['?'], 'display' => '?', 'ids' => [0]];
+		}
+	}	
+	# ------------------------------------------------------
+	/**
+	 * Indicate custom bundles for movement-based location tracking
+	 *
+	 * @param string $bundle_name 
+	 */
+	public function isValidBundle($bundle_name) {
+		switch($bundle_name) {
+			case 'original_path':
+				return true;
+		}
+		return false;
+	}
+	# ------------------------------------------------------
+	/**
+	 * Handle "original_path" value for movement-based location tracking.
+	 */
+	public function renderBundleForDisplay($bundle_name, $row_id, $values, $options=null) {
+		switch($bundle_name) {
+			case 'original_path':
+				$qr = ca_movements_x_storage_locations::findAsSearchResult(['relation_id' => $row_id]);
+				if($qr->nextHit()) {
+					$data = $qr->get('ca_movements_x_storage_locations.source_info', ['returnAsArray' => true]);
+					return $data[0]['display'];
+				}
+				break;
+		}
+		return null;
+	}
 	# ------------------------------------------------------
 }

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -2691,6 +2691,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	 *
 	 */
 	public function renderBundleForDisplay($bundle_name, $row_id, $values, $options=null) {
+		die("X");
 		switch($bundle_name) {
 			case 'transcription_count':
 				return $this->numTranscriptions($row_id);

--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -56,6 +56,19 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		);
 	}
 	# --------------------------------------------------------------------------------------------
+	public function hookInsertItem(&$pa_params) {
+		if($this->opo_plugin_config->get('enabled')) {
+			$this->prepopulateFields($pa_params['instance'], ['hook' => 'save']);
+		}
+		return true;
+	}
+	public function hookUpdateItem(&$pa_params) {
+		if($this->opo_plugin_config->get('enabled')) {
+			$this->prepopulateFields($pa_params['instance'], ['hook' => 'save']);
+		}
+		return true;
+	}
+	# --------------------------------------------------------------------------------------------
 	public function hookSaveItem(&$pa_params) {
 		if($this->opo_plugin_config->get('enabled')) {
 			$this->prepopulateFields($pa_params['instance'], ['hook' => 'save']);
@@ -125,7 +138,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		//$vn_timestamp = $_REQUEST['form_timestamp'];
 		//unset($_REQUEST['form_timestamp']);
 
-		$vb_we_set_transaction = true;
+		$vb_we_set_transaction = false;
 		if (!$t_instance->inTransaction()) {
 			$t_instance->setTransaction(new Transaction($t_instance->getDb()));
 			$vb_we_set_transaction = true;
@@ -318,7 +331,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 							
 							$i = 0;
 							$t_instance->removeAttributes($va_parts[1]);
-							$t_instance->update(['force' => true]);
+							$t_instance->update(['force' => true, 'hooks' => false]);
 							
 							if($t_instance->numErrors()) { 
 								Debug::msg(_t("[prepopulateFields()] error while removing old values during copy of containers: %1", join("; ", $t_instance->getErrors())));
@@ -513,7 +526,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 
 
 		if(isset($_REQUEST['form_timestamp']) && ($_REQUEST['form_timestamp'] > 0)) { $_REQUEST['form_timestamp'] = time(); }
-		$t_instance->update(['force' => true]);
+		$t_instance->update(['force' => true, 'hooks' => false]);
 
 		if($t_instance->numErrors() > 0) {
 			foreach($t_instance->getErrors() as $vs_error) {

--- a/assets/ca/ca.genericbundle.js
+++ b/assets/ca/ca.genericbundle.js
@@ -293,7 +293,7 @@ var caUI = caUI || {};
 					if (typeof(this.initialValues[id][info[1]]) == 'boolean') {
 						this.initialValues[id][info[1]] = (this.initialValues[id][info[1]]) ? '1' : '0';
 					}
-					jQuery(this.container + " #" + element_id + " option[value=" + this.initialValues[id][info[1]] +"]").prop('selected', true);
+					jQuery(this.container + " #" + element_id + " option[value='" + this.initialValues[id][info[1]] +"']").prop('selected', true);
 				}
 			}
 

--- a/assets/ca/ca.hierbrowser.js
+++ b/assets/ca/ca.hierbrowser.js
@@ -548,7 +548,7 @@ var caUI = caUI || {};
 													jQuery(this).attr('facet_item_selected', '1');
 												}
 
-												if (jQuery(".facetItem[facet_item_selected='1']").length > 0) {
+												if (jQuery('#' + newLevelListID).find("a." + that.className."[facet_item_selected='1']").length > 0) {
 													jQuery("#facet_apply").show();
 												} else {
 													jQuery("#facet_apply").hide();

--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -55,6 +55,7 @@ var caUI = caUI || {};
 	 * @returns {String}
 	 */
 	escapeValue = function (value) {
+		if(typeof value !== 'string') return value;
 		return value.replaceAll(/([\-\+&\|!\(\)\{}\[\]\^"'~\*\?:\\])/g, '\\$1');
 	};
 
@@ -214,6 +215,7 @@ var caUI = caUI || {};
 				break;
 			case '*':
 				token = { type: TOKEN_WILDCARD };
+				end = true;
 				break;
 			// Beginning of a quoted phrase, which ends after the next unescaped quote.
 			case '"':

--- a/assets/ca/ca.quickaddform.js
+++ b/assets/ca/ca.quickaddform.js
@@ -157,6 +157,7 @@ var caUI = caUI || {};
 				if(formData['relatedID'] && caBundleUpdateManager) { 
 					caBundleUpdateManager.reloadBundle('ca_objects_location'); 
 					caBundleUpdateManager.reloadBundle('ca_objects_history'); 
+					caBundleUpdateManager.reloadBundle('history_tracking_chronology'); 
 					caBundleUpdateManager.reloadInspector(); 
 				}
 			} else {

--- a/assets/ca/ca.relationbundle.js
+++ b/assets/ca/ca.relationbundle.js
@@ -142,26 +142,7 @@ var caUI = caUI || {};
 						// rather than the item_id
 						if (!options.returnTextValues) {
 							if(!parseInt(ui.item.id) && options.quickaddPanel) {
-								var panelUrl = options.quickaddUrl;
-								if (options && options.types) {
-									if(Object.prototype.toString.call(options.types) === '[object Array]') {
-										options.types = options.types.join(",");
-									}
-									if (options.types.length > 0) {
-										panelUrl += '/types/' + options.types;
-									}
-								}
-								options.quickaddPanel.showPanel(panelUrl, null, null, {q: ui.item._query, field_name_prefix: options.fieldNamePrefix});
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteRawID', id);
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteInputID', autocompleter_id);
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteItemIDID', options.itemID + id + ' #' + options.fieldNamePrefix + 'id' + id);
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteTypeIDID', options.itemID + id + ' #' + options.fieldNamePrefix + 'type_id' + id);
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('panel', options.quickaddPanel);
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('relationbundle', that);
-					
-								jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteInput', jQuery("#" + options.autocompleteInputID + id).val());
-					
-								jQuery("#" + options.autocompleteInputID + id).val('');
+								that.triggerQuickAdd(ui.item._query, id);
 							
 								event.preventDefault();
 								return;
@@ -273,6 +254,30 @@ var caUI = caUI || {};
 		};
 		
 		var that = caUI.initBundle(container, options);
+		
+		that.triggerQuickAdd = function(q, id) {
+			var autocompleter_id = options.fieldNamePrefix + 'autocomplete' + id;
+			var panelUrl = options.quickaddUrl;
+			if (options && options.types) {
+				if(Object.prototype.toString.call(options.types) === '[object Array]') {
+					options.types = options.types.join(",");
+				}
+				if (options.types.length > 0) {
+					panelUrl += '/types/' + options.types;
+				}
+			}
+			options.quickaddPanel.showPanel(panelUrl, null, null, {q: q, field_name_prefix: options.fieldNamePrefix});
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteRawID', id);
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteInputID', autocompleter_id);
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteItemIDID', options.itemID + id + ' #' + options.fieldNamePrefix + 'id' + id);
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteTypeIDID', options.itemID + id + ' #' + options.fieldNamePrefix + 'type_id' + id);
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('panel', options.quickaddPanel);
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('relationbundle', that);
+
+			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteInput', jQuery("#" + options.autocompleteInputID + id).val());
+
+			jQuery("#" + options.autocompleteInputID + id).val('');
+		};
 		
 		return that;
 	};	

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -589,7 +589,7 @@ div.inspectorCheckedOut {
 	margin-bottom: 5px;
 	font-size: 14px;
 }
-.setStats div, .pawtucketStats div, .groupList div, .yourDisplays div, .searchForms div, .comments div, .tags div, .export div, h3.metalist div, h3.relTypes div, .importers div, .savedSearches div, .searchTours div{
+.setStats div, .pawtucketStats div, .groupList div, .yourDisplays div, .watchedItems div, .searchForms div, .comments div, .tags div, .export div, h3.metalist div, h3.relTypes div, .importers div, .savedSearches div, .searchTours div {
 	font-size:12px;
 	line-height:1.7em;
 }

--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -998,7 +998,7 @@ if($show_entity_controls) {
 				}
 			});
 	<?php
-		}s
+		}
 	}
 	?>
 		jQuery('#<?= $vs_id_prefix; ?>SetChildView').on('click', function(e) {

--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -71,45 +71,50 @@
 		$home_location_idno = $t_location ? $t_location->getWithTemplate($this->request->config->get('ca_storage_locations_hierarchy_browser_display_settings')) : null;
 	}
 	
-	if (!($add_label = $this->getVar('add_label'))) { $add_label = _t('Update location'); }
-	
     if (!$this->request->isAjax()) {
 	    print caEditorBundleShowHideControl($this->request, $vs_id_prefix, $settings);
 	}
 	
 	$show_loan_controls = $show_movement_controls = $show_location_controls = $show_object_controls = $show_occurrence_controls = $show_collection_controls = $show_entity_controls = false;
 ?>
-<div id="<?php print $vs_id_prefix; ?>">
+<div id="<?= $vs_id_prefix; ?>">
 	<div class="bundleContainer">
 			<div class="caHistoryTrackingButtonBar labelInfo">
 <?php
             if(!caGetOption('hide_include_child_history_controls', $settings, false) && ($this->getVar('child_count') > 0)) {
 ?>
-                <div style='float: left;' class='button caSetChildViewButton'><a href="#" id="<?php print $vs_id_prefix; ?>SetChildView"><?php print caNavIcon(__CA_NAV_ICON_CHILD__, '15px'); ?> <?php print Session::getVar('ca_objects_history_showChildHistory') ? _t('Hide child history') : _t('Include child history'); ?></a></div>
+                <div style='float: left;' class='button caSetChildViewButton'><a href="#" id="<?= $vs_id_prefix; ?>SetChildView"><?= caNavIcon(__CA_NAV_ICON_CHILD__, '15px'); ?> <?= Session::getVar('ca_objects_history_showChildHistory') ? _t('Hide child history') : _t('Include child history'); ?></a></div>
 <?php
             }
 			if(!$read_only && !caGetOption('hide_add_to_loan_controls', $settings, false) && ($subject_table::historyTrackingPolicyUses($policy, 'ca_loans'))) {
 			    $show_loan_controls = true;
 ?>
-				<div style='float: left;' class='button caAddLoanButton'><a href="#" id="<?php print $vs_id_prefix; ?>AddLoan"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to loan'); ?></a></div>
+				<div style='float: left;' class='button caAddLoanButton'><a href="#" id="<?= $vs_id_prefix; ?>AddLoan"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('loan_control_label', $settings, _t('Add to loan')); ?></a></div>
 <?php
 			}
 			if(!$read_only && !caGetOption('hide_add_to_movement_controls', $settings, false) && ($subject_table::historyTrackingPolicyUses($policy, 'ca_movements'))) {
                 $show_movement_controls = true;
+                
+                if(!caGetOption('always_create_new_movement', $settings, false)) {
 ?>
-				<div style='float: left;' class='button caAddMovementButton'><a href="#" id="<?php print $vs_id_prefix; ?>AddMovement"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to movement'); ?></a></div>
+				<div style='float: left;' class='button caAddMovementButton'><a href="#" id="<?= $vs_id_prefix; ?>AddMovement"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('movement_control_label', $settings, _t('Add to movement')); ?></a></div>
 <?php
+				} else {
+?>
+					<div style='float: left;' class='button caAddMovementButton'><a href="#" id="<?= $vs_id_prefix; ?>AddMovement" onclick='caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd("", "new_0"); return false;'><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('movement_control_label', $settings, _t('Add to movement')); ?></a></div>					
+<?php
+				}
 			}
 			if(!$read_only && !caGetOption('hide_update_location_controls', $settings, false) && ($subject_table::historyTrackingPolicyUses($policy, 'ca_storage_locations'))) {
                 $show_location_controls = true;
 ?>
-				<div style='float: left;'  class='button caChangeLocationButton <?php print $vs_id_prefix; ?>caChangeLocationButton'><a href="#" id="<?php print $vs_id_prefix; ?>ChangeLocation"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Update location'); ?></a></div>
+				<div style='float: left;'  class='button caChangeLocationButton <?= $vs_id_prefix; ?>caChangeLocationButton'><a href="#" id="<?= $vs_id_prefix; ?>ChangeLocation"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('update_location_control_label', $settings, _t('Update location')); ?></a></div>
 <?php
 			}
 			
 			if(!$read_only && $show_return_home_controls && !caGetOption('hide_return_to_home_location_controls', $settings, false) && ($subject_table::historyTrackingPolicyUses($policy, 'ca_storage_locations'))) {
 ?>
-				<div style='float: left;' class='button caReturnToHomeLocationButton <?php print $vs_id_prefix; ?>caReturnToHomeLocationButton'><a href="#" id="<?php print $vs_id_prefix; ?>ReturnToHomeLocation"><?php print caNavIcon(__CA_NAV_ICON_HOME__, '15px'); ?> <?php print _t('Return to home location'); ?></a></div>
+				<div style='float: left;' class='button caReturnToHomeLocationButton <?= $vs_id_prefix; ?>caReturnToHomeLocationButton'><a href="#" id="<?= $vs_id_prefix; ?>ReturnToHomeLocation"><?= caNavIcon(__CA_NAV_ICON_HOME__, '15px'); ?> <?= caGetOption('return_to_home_location_control_label', $settings, _t('Return to home location')); ?></a></div>
 <?php
 			}
 			
@@ -119,7 +124,7 @@
 				foreach($occ_types as $vn_type_id => $va_type_info) {
 					if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_occurrences', $va_type_info['idno'])) { continue; }
 ?>
-				<div style='float: left;'  class='button caAddOccurrenceButton <?php print $vs_id_prefix; ?>caAddOccurrenceButton<?php print $vn_type_id; ?>'><a href="#" id="<?php print $vs_id_prefix; ?>AddOcc<?php print $vn_type_id; ?>"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to %1', $va_type_info['name_singular']); ?></a></div>
+				<div style='float: left;'  class='button caAddOccurrenceButton <?= $vs_id_prefix; ?>caAddOccurrenceButton<?= $vn_type_id; ?>'><a href="#" id="<?= $vs_id_prefix; ?>AddOcc<?= $vn_type_id; ?>"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= _t(caGetOption('occurrence_control_label', $settings, _t('Add to %1')), $va_type_info['name_singular']); ?></a></div>
 <?php		
 				}
 			}
@@ -130,7 +135,7 @@
 				foreach($coll_types as $vn_type_id => $va_type_info) {
 					if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_collections', $va_type_info['idno'])) { continue; }
 ?>
-				<div style='float: left;'  class='button caAddCollectionButton caAddCollectionButton<?php print $vn_type_id; ?>'><a href="#" id="<?php print $vs_id_prefix; ?>AddColl<?php print $vn_type_id; ?>"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to %1', $va_type_info['name_singular']); ?></a></div>
+				<div style='float: left;'  class='button caAddCollectionButton caAddCollectionButton<?= $vn_type_id; ?>'><a href="#" id="<?= $vs_id_prefix; ?>AddColl<?= $vn_type_id; ?>"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= _t(caGetOption('collection_control_label', $settings, _t('Add to %1')), $va_type_info['name_singular']); ?></a></div>
 <?php		
 				}
 			}
@@ -141,7 +146,7 @@
 				foreach($entity_types as $vn_type_id => $va_type_info) {
 					if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_entities', $va_type_info['idno'])) { continue; }
 ?>
-				<div style='float: left;' class='button caAddEntityButton caAddEntityButton<?php print $vn_type_id; ?>'><a href="#" id="<?php print $vs_id_prefix; ?>AddEntity<?php print $vn_type_id; ?>"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to %1', $va_type_info['name_singular']); ?></a></div>
+				<div style='float: left;' class='button caAddEntityButton caAddEntityButton<?= $vn_type_id; ?>'><a href="#" id="<?= $vs_id_prefix; ?>AddEntity<?= $vn_type_id; ?>"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= _t(caGetOption('entity_control_label', $settings, _t('Add to %1')), $va_type_info['name_singular']); ?></a></div>
 <?php		
 				}
 			}
@@ -149,14 +154,14 @@
 			if(!$read_only && !caGetOption('hide_add_to_object_controls', $settings, false) && ($subject_table::historyTrackingPolicyUses($policy, 'ca_objects'))) {
 			    $show_object_controls = true;
 ?>
-				<div style='float: left;' class='button caAddObjectButton'><a href="#" id="<?php print $vs_id_prefix; ?>AddObject"><?php print caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?php print _t('Add to object'); ?></a></div>
+				<div style='float: left;' class='button caAddObjectButton'><a href="#" id="<?= $vs_id_prefix; ?>AddObject"><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('object_control_label', $settings, _t('Add to object')); ?></a></div>
 <?php
 			}
 ?>
 				<br style='clear: both;'/>
 			</div>
 					
-		<div class="<?php print $vs_id_prefix; ?>caLocationList"> </div>
+		<div class="<?= $vs_id_prefix; ?>caLocationList"> </div>
 		<div class="caLoanList"> </div>
 		<div class="caMovementList"> </div>
 		<div class="caObjectList"> </div>
@@ -165,7 +170,7 @@ if($show_occurrence_controls) {
 	foreach($occ_types as $vn_type_id => $va_type_info) {
 		if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_occurrences', $va_type_info['idno'])) { continue; }
 ?>
-		<div class="<?php print $vs_id_prefix; ?>caOccurrenceList<?php print $vn_type_id; ?>"> </div>
+		<div class="<?= $vs_id_prefix; ?>caOccurrenceList<?= $vn_type_id; ?>"> </div>
 <?php
 	}
 }
@@ -173,7 +178,7 @@ if($show_collection_controls) {
 	foreach($coll_types as $vn_type_id => $va_type_info) {
 		if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_collections', $va_type_info['idno'])) { continue; }
 ?>
-		<div class="caCollectionList<?php print $vn_type_id; ?>"> </div>
+		<div class="caCollectionList<?= $vn_type_id; ?>"> </div>
 <?php
 	}
 }
@@ -181,7 +186,7 @@ if($show_entity_controls) {
 	foreach($entity_types as $vn_type_id => $va_type_info) {
 		if (!$subject_table::historyTrackingPolicyUses($policy, 'ca_entities', $va_type_info['idno'])) { continue; }
 ?>
-		<div class="caEntityList<?php print $vn_type_id; ?>"> </div>
+		<div class="caEntityList<?= $vn_type_id; ?>"> </div>
 <?php
 	}
 }
@@ -189,13 +194,13 @@ if($show_entity_controls) {
 switch($display_mode) {
 	case 'tabs':
 ?>
-			<div id="<?php print $vs_id_prefix; ?>Container" class="editorHierarchyBrowserContainer">		
-				<div  id="<?php print $vs_id_prefix; ?>Tabs">
+			<div id="<?= $vs_id_prefix; ?>Container" class="editorHierarchyBrowserContainer">		
+				<div id="<?= $vs_id_prefix; ?>Tabs">
 					<ul>
-						<li><a href="#<?php print $vs_id_prefix; ?>Tabs-location"><span><?php print _t('Current %1', mb_strtolower($policy_info['name'])); ?></span></a></li>
-						<li><a href="#<?php print $vs_id_prefix; ?>Tabs-history"><span><?php print _t('History'); ?></span></a></li>
+						<li><a href="#<?= $vs_id_prefix; ?>Tabs-location"><span><?= _t('Current %1', mb_strtolower($policy_info['name'])); ?></span></a></li>
+						<li><a href="#<?= $vs_id_prefix; ?>Tabs-history"><span><?= _t('History'); ?></span></a></li>
 					</ul>
-					<div id="<?php print $vs_id_prefix; ?>Tabs-location" class="hierarchyBrowseTab">	
+					<div id="<?= $vs_id_prefix; ?>Tabs-location" class="hierarchyBrowseTab">	
 <?php
 						if (($current_value = array_reduce($history, function($c, $v) { 
 						    foreach($v as $e) {
@@ -207,11 +212,11 @@ switch($display_mode) {
 							
                                 if (!$read_only && $allow_value_interstitial_edit && ($current_value['tracked_table_num'] !== $current_value['current_table_num']) && ca_editor_uis::loadDefaultUI($current_value['tracked_table_num'], $this->request)) {
 ?>
-                                    <div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?php print Datamodel::getTableName($current_value['tracked_table_num']); ?>" data-relation_id="<?php print $current_value['tracked_row_id']; ?>"  data-primary="<?php print Datamodel::getTableName($current_value['current_table_num']); ?>" data-primary_id="<?php print $current_value['current_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
+                                    <div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?= Datamodel::getTableName($current_value['tracked_table_num']); ?>" data-relation_id="<?= $current_value['tracked_row_id']; ?>"  data-primary="<?= Datamodel::getTableName($current_value['current_table_num']); ?>" data-primary_id="<?= $current_value['current_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
                                 }
                                 if (!$read_only && $allow_value_delete && !$vb_dont_show_del) {
 ?>
-                                    <div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?php print Datamodel::getTableName($current_value['tracked_table_num']); ?>" data-relation_id="<?php print $current_value['tracked_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
+                                    <div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?= Datamodel::getTableName($current_value['tracked_table_num']); ?>" data-relation_id="<?= $current_value['tracked_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
                                 }
 							
 							print "</div>";	 
@@ -219,12 +224,12 @@ switch($display_mode) {
 							print "<br class=\"clear\"/>\n";
 						} else {
 ?>
-							<?php print _t('No %1 set', mb_strtolower($policy_info['name'])); ?>
+							<?= _t('No %1 set', mb_strtolower($policy_info['name'])); ?>
 <?php
 						}
 ?>
 					</div>
-					<div id="<?php print $vs_id_prefix; ?>Tabs-history" class="hierarchyBrowseTab caHistoryTrackingTab">	
+					<div id="<?= $vs_id_prefix; ?>Tabs-history" class="hierarchyBrowseTab caHistoryTrackingTab">	
 <?php
 						if (is_array($history) && sizeof($history)) {
 							foreach($history as $vs_date => $history_by_date) {
@@ -245,18 +250,18 @@ switch($display_mode) {
                                     print "<div id='caHistoryTrackingEntry{$vs_id_prefix}".Datamodel::getTableName($history_entry['tracked_table_num']).'-'.$history_entry['tracked_row_id']."' class='caHistoryTracking' style='background-color:#{$color}'>".$history_entry['icon'].' '.$history_entry['display']."<div class=\"caHistoryTrackingEntryDate\">{$history_entry['date']}</div>";
                                     if (!$read_only && $allow_value_interstitial_edit && ($history_entry['tracked_table_num'] !== $history_entry['current_table_num']) && ca_editor_uis::loadDefaultUI($history_entry['tracked_table_num'], $this->request)) {
 ?>
-                                        <div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?php print Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?php print $history_entry['tracked_row_id']; ?>"  data-primary="<?php print Datamodel::getTableName($history_entry['current_table_num']); ?>" data-primary_id="<?php print $history_entry['current_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
+                                        <div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?= Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?= $history_entry['tracked_row_id']; ?>"  data-primary="<?= Datamodel::getTableName($history_entry['current_table_num']); ?>" data-primary_id="<?= $history_entry['current_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
                                     }
                                     if (!$read_only && $allow_value_delete && !$vb_dont_show_del) {
 ?>
-                                        <div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?php print Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?php print $history_entry['tracked_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
+                                        <div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?= Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?= $history_entry['tracked_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
                                     }
                                     print "</div>\n";
 								}
 							}
 						} else {
 ?>
-							<?php print _t('No %1 set', mb_strtolower($policy_info['name'])); ?>
+							<?= _t('No %1 set', mb_strtolower($policy_info['name'])); ?>
 <?php
 						}
 ?>
@@ -282,20 +287,20 @@ switch($display_mode) {
 						break;
 				}	
 ?>
-				<div id="caHistoryTrackingEntry<?php print $vs_id_prefix.Datamodel::getTableName($history_entry['tracked_table_num']).'-'.$history_entry['tracked_row_id']; ?>" class="caHistoryTrackingEntry <?php print ($vn_i == 0) ? 'caHistoryTrackingEntryFirst' : ''; ?>" style="background-color:#<?php print $color; ?>">
-					<?php print $history_entry['icon']; ?>
-					<div><?php print $history_entry['display']; ?></div>					
+				<div id="caHistoryTrackingEntry<?= $vs_id_prefix.Datamodel::getTableName($history_entry['tracked_table_num']).'-'.$history_entry['tracked_row_id']; ?>" class="caHistoryTrackingEntry <?= ($vn_i == 0) ? 'caHistoryTrackingEntryFirst' : ''; ?>" style="background-color:#<?= $color; ?>">
+					<?= $history_entry['icon']; ?>
+					<div><?= $history_entry['display']; ?></div>					
 <?php
 					if (!$read_only && $allow_value_interstitial_edit && ($history_entry['tracked_table_num'] !== $history_entry['current_table_num']) && ca_editor_uis::loadDefaultUI($history_entry['tracked_table_num'], $this->request)) {
 ?>
-						<div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?php print Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?php print $history_entry['tracked_row_id']; ?>"  data-primary="<?php print Datamodel::getTableName($history_entry['current_table_num']); ?>" data-primary_id="<?php print $history_entry['current_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
+						<div class="caHistoryTrackingEntryInterstitialEdit"><a href="#" class="caInterstitialEditButton listRelEditButton" data-table="<?= Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?= $history_entry['tracked_row_id']; ?>"  data-primary="<?= Datamodel::getTableName($history_entry['current_table_num']); ?>" data-primary_id="<?= $history_entry['current_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_INTERSTITIAL_EDIT_BUNDLE__, "16px"); ?></a></div><?php
 					}
 					if (!$read_only && $allow_value_delete && !$vb_dont_show_del) {
 ?>
-						<div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?php print Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?php print $history_entry['tracked_row_id']; ?>"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
+						<div class="caHistoryTrackingEntryDelete"><a href="#" class="caDeleteItemButton listRelDeleteButton"  data-table="<?= Datamodel::getTableName($history_entry['tracked_table_num']); ?>" data-relation_id="<?= $history_entry['tracked_row_id']; ?>"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div><?php
 					}
 ?>
-					<div class="caHistoryTrackingEntryDate"><?php print $history_entry['date']; ?></div>
+					<div class="caHistoryTrackingEntryDate"><?= $history_entry['date']; ?></div>
 					<br class="clear"/>
 				</div>
 <?php
@@ -311,55 +316,55 @@ switch($display_mode) {
 	//
 	if($show_return_home_controls) {
 ?>
-		<textarea class='<?php print $vs_id_prefix; ?>caHistoryTrackingReturnToHomeLocationTemplate' style='display: none;'>
+		<textarea class='<?= $vs_id_prefix; ?>caHistoryTrackingReturnToHomeLocationTemplate' style='display: none;'>
 			<div class="clear"><!-- empty --></div>
-			<div id="<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_{n}" class="labelInfo caRelatedLocation <?php print $vs_id_prefix; ?>caRelatedLocation">
-				<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteReturnToHomeLocationButton <?php print $vs_id_prefix; ?>caDeleteReturnToHomeLocationButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+			<div id="<?= $vs_id_prefix; ?>_ca_storage_locations_return_home_{n}" class="labelInfo caRelatedLocation <?= $vs_id_prefix; ?>caRelatedLocation">
+				<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteReturnToHomeLocationButton <?= $vs_id_prefix; ?>caDeleteReturnToHomeLocationButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			
-				<h2 id="<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_heading"></h2>
+				<h2 id="<?= $vs_id_prefix; ?>_ca_storage_locations_return_home_heading"></h2>
 			
-				<?php print ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
+				<?= ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
 
-				<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home{n}" id="<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home{n}" value="0"/>
+				<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_storage_locations_return_home{n}" id="<?= $vs_id_prefix; ?>_ca_storage_locations_return_home{n}" value="0"/>
 			</div>
 		</textarea>
 <?php
 	}
     if ($show_location_controls || $show_return_home_controls) {
 ?>	
-	<textarea class='<?php print $vs_id_prefix; ?>caHistoryTrackingSetLocationTemplate' style='display: none;'>
+	<textarea class='<?= $vs_id_prefix; ?>caHistoryTrackingSetLocationTemplate' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
-		<div id="<?php print $vs_id_prefix; ?>_ca_storage_locations_{n}" class="labelInfo caRelatedLocation <?php print $vs_id_prefix; ?>caRelatedLocation">
-			<h2 class="caHistoryTrackingSetLocationHeading"><?php print _t('Update location'); ?></h2>
+		<div id="<?= $vs_id_prefix; ?>_ca_storage_locations_{n}" class="labelInfo caRelatedLocation <?= $vs_id_prefix; ?>caRelatedLocation">
+			<h2 class="caHistoryTrackingSetLocationHeading"><?= caGetOption('update_location_control_label', $settings, _t('Update location')); ?></h2>
 <?php
 	if (!(bool)$settings['useHierarchicalBrowser']) {
 ?>
-		<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLocationButton <?php print $vs_id_prefix; ?>caDeleteLocationButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+		<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLocationButton <?= $vs_id_prefix; ?>caDeleteLocationButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			
-		<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_storage_locations_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_storage_locations_autocomplete{n}" class="lookupBg"/>
-		<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_storage_locations_id{n}" id="<?php print $vs_id_prefix; ?>_ca_storage_locations_id{n}" value="{id}"/>
+		<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_storage_locations_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_storage_locations_autocomplete{n}" class="lookupBg"/>
+		<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_storage_locations_id{n}" id="<?= $vs_id_prefix; ?>_ca_storage_locations_id{n}" value="{id}"/>
 	
-		<?php print ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
+		<?= ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
 <?php
 	} else {
 ?>
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLocationButton <?php print $vs_id_prefix; ?>caDeleteLocationButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLocationButton <?= $vs_id_prefix; ?>caDeleteLocationButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			
 			<div style='width: 700px; height: 200px;'>				
 				<div style="float: right;">
-					<div class='hierarchyBrowserSearchBar'><?php print _t('Search'); ?>: <input type='text' id='<?php print $vs_id_prefix; ?>_hierarchyBrowserSearch{n}' class='hierarchyBrowserSearchBar' name='search' value='' size='40'/></div>
+					<div class='hierarchyBrowserSearchBar'><?= _t('Search'); ?>: <input type='text' id='<?= $vs_id_prefix; ?>_hierarchyBrowserSearch{n}' class='hierarchyBrowserSearchBar' name='search' value='' size='40'/></div>
 				</div>
 				
 				<div class="clear"><!-- empty --></div>
 				
-				<div id='<?php print $vs_id_prefix; ?>_hierarchyBrowser{n}' style='width: 100%; height: 165px;' class='hierarchyBrowser'>
+				<div id='<?= $vs_id_prefix; ?>_hierarchyBrowser{n}' style='width: 100%; height: 165px;' class='hierarchyBrowser'>
 					<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 				</div><!-- end hierarchyBrowser -->	
 				
 				<div class="hierarchyBrowserCurrentSelectionText">
-					<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_storage_locations_id{n}" id="<?php print $vs_id_prefix; ?>_ca_storage_locations_id{n}" value="{id}"/>
+					<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_storage_locations_id{n}" id="<?= $vs_id_prefix; ?>_ca_storage_locations_id{n}" value="{id}"/>
 				
-					<span class="hierarchyBrowserCurrentSelectionText" id="<?php print $vs_id_prefix; ?>_browseCurrentSelectionText{n}"> </span>
+					<span class="hierarchyBrowserCurrentSelectionText" id="<?= $vs_id_prefix; ?>_browseCurrentSelectionText{n}"> </span>
 				</div>
 				
 				<div style="clear: both; width: 1px; height: 5px;"><!-- empty --></div>
@@ -367,16 +372,16 @@ switch($display_mode) {
 			
 			<div class="clear" style="height: 20px;"><!-- empty --></div>
 
-			<?php print ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
+			<?= ca_storage_locations::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['placement_code' => $vs_id_prefix]); ?>	
 
 			<div class="clear"><!-- empty --></div>
 		
 			<script type='text/javascript'>
 				jQuery(document).ready(function() { 
-					var <?php print $vs_id_prefix; ?>oHierBrowser{n} = caUI.initHierBrowser('<?php print $vs_id_prefix; ?>_hierarchyBrowser{n}', {
+					var <?= $vs_id_prefix; ?>oHierBrowser{n} = caUI.initHierBrowser('<?= $vs_id_prefix; ?>_hierarchyBrowser{n}', {
 						uiStyle: 'horizontal',
-						levelDataUrl: '<?php print caNavUrl($this->request, 'lookup', 'StorageLocation', 'GetHierarchyLevel', array()); ?>',
-						initDataUrl: '<?php print caNavUrl($this->request, 'lookup', 'StorageLocation', 'GetHierarchyAncestorList'); ?>',
+						levelDataUrl: '<?= caNavUrl($this->request, 'lookup', 'StorageLocation', 'GetHierarchyLevel', array()); ?>',
+						initDataUrl: '<?= caNavUrl($this->request, 'lookup', 'StorageLocation', 'GetHierarchyAncestorList'); ?>',
 					
 						selectOnLoad : true,
 						browserWidth: '100%',
@@ -385,35 +390,35 @@ switch($display_mode) {
 					
 						className: 'hierarchyBrowserLevel',
 						classNameContainer: 'hierarchyBrowserContainer',
-						currentSelectionIDID: '<?php print $vs_id_prefix; ?>_ca_storage_locations_id{n}',
+						currentSelectionIDID: '<?= $vs_id_prefix; ?>_ca_storage_locations_id{n}',
 					
-						indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
-						editButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
-						disabledButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
+						indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+						editButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__, 1); ?>",
+						disabledButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_DOT__, 1); ?>",
 					
 						displayCurrentSelectionOnLoad: false,
-						currentSelectionDisplayID: '<?php print $vs_id_prefix; ?>_browseCurrentSelectionText{n}',
+						currentSelectionDisplayID: '<?= $vs_id_prefix; ?>_browseCurrentSelectionText{n}',
 						onSelection: function(item_id, parent_id, name, display, type_id) {
-							caRelationBundle<?php print $vs_id_prefix; ?>_ca_storage_locations.select('{n}', {id: item_id, type_id: type_id}, display);
+							caRelationBundle<?= $vs_id_prefix; ?>_ca_storage_locations.select('{n}', {id: item_id, type_id: type_id}, display);
 						}
 					});
 				
-					jQuery('#<?php print $vs_id_prefix; ?>_hierarchyBrowserSearch{n}').autocomplete({
-							source: '<?php print caNavUrl($this->request, 'lookup', 'StorageLocation', 'Get', array('noInline' => 1)); ?>',
+					jQuery('#<?= $vs_id_prefix; ?>_hierarchyBrowserSearch{n}').autocomplete({
+							source: '<?= caNavUrl($this->request, 'lookup', 'StorageLocation', 'Get', array('noInline' => 1)); ?>',
 							minLength: <?= (int)$t_subject->getAppConfig()->get(["ca_storage_locations_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>, delay: 800, html: true,
 							select: function(event, ui) {
 								if (parseInt(ui.item.id) > 0) {
-									<?php print $vs_id_prefix; ?>oHierBrowser{n}.setUpHierarchy(ui.item.id);	// jump browser to selected item
+									<?= $vs_id_prefix; ?>oHierBrowser{n}.setUpHierarchy(ui.item.id);	// jump browser to selected item
 								}
 								event.preventDefault();
-								jQuery('#<?php print $vs_id_prefix; ?>_hierarchyBrowserSearch{n}').val('');
+								jQuery('#<?= $vs_id_prefix; ?>_hierarchyBrowserSearch{n}').val('');
 							}
 						}
 					);
 <?php
     if (caGetOption('ca_storage_locations_useDatePicker', $settings, false)) {
 ?>
-					jQuery('#<?php print $vs_id_prefix; ?>_ca_storage_locations__effective_date{n}').datepicker({dateFormat: 'yy-mm-dd'});  // attempt to add date picker
+					jQuery('#<?= $vs_id_prefix; ?>_ca_storage_locations__effective_date{n}').datepicker({dateFormat: 'yy-mm-dd'});  // attempt to add date picker
 <?php
     }
 ?>
@@ -432,21 +437,21 @@ if($show_loan_controls) {
 	<textarea class='caHistoryTrackingSetLoanTemplate' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 		
-		<div id="<?php print $vs_id_prefix; ?>_ca_loans_{n}" class="labelInfo caRelatedLoan">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLoanButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_loans_{n}" class="labelInfo caRelatedLoan">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteLoanButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to loan'); ?></h2></td>
+					<td><h2><?= caGetOption('loan_control_label', $settings, _t('Add to loan')); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_loans_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_loans_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_loans_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_loans_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_loans_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_loans_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_loans_id{n}" id="<?php print $vs_id_prefix; ?>_ca_loans_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_loans_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_loans_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_loans_id{n}" id="<?= $vs_id_prefix; ?>_ca_loans_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_loans::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_loans::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -457,21 +462,21 @@ if($show_loan_controls) {
 	<textarea class='caHistoryTrackingSetMovementTemplate' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 	
-		<div id="<?php print $vs_id_prefix; ?>_ca_movements_{n}" class="labelInfo caRelatedMovement">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteMovementButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_movements_{n}" class="labelInfo caRelatedMovement">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteMovementButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to movement'); ?></h2></td>
+					<td><h2><?= caGetOption('movement_control_label', $settings, _t('Add to movement')); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_movements_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_movements_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_movements_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_movements_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_movements_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_movements_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_movements_id{n}" id="<?php print $vs_id_prefix; ?>_ca_movements_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_movements_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_movements_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_movements_id{n}" id="<?= $vs_id_prefix; ?>_ca_movements_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_movements::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_movements::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -482,21 +487,21 @@ if($show_loan_controls) {
 	<textarea class='caHistoryTrackingSetObjectTemplate' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 		
-		<div id="<?php print $vs_id_prefix; ?>_ca_objects_{n}" class="labelInfo caRelatedObject">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteObjectButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_objects_{n}" class="labelInfo caRelatedObject">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteObjectButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to object'); ?></h2></td>
+					<td><h2><?= caGetOption('object_control_label', $settings, _t('Add to object')); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_objects_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_objects_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_objects_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_objects_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_objects_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_objects_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_objects_id{n}" id="<?php print $vs_id_prefix; ?>_ca_objects_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_objects_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_objects_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_objects_id{n}" id="<?= $vs_id_prefix; ?>_ca_objects_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_objects::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_objects::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -505,24 +510,24 @@ if($show_loan_controls) {
 if($show_occurrence_controls) {
 	foreach($occ_types as $vn_type_id => $va_type_info) {
 ?>
-	<textarea class='<?php print $vs_id_prefix; ?>caHistoryTrackingSetOccurrenceTemplate<?php print $vn_type_id; ?>' style='display: none;'>
+	<textarea class='<?= $vs_id_prefix; ?>caHistoryTrackingSetOccurrenceTemplate<?= $vn_type_id; ?>' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 		
-		<div id="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_{n}" class="labelInfo caRelatedOccurrence <?php print $vs_id_prefix; ?>caRelatedOccurrence">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="<?php print $vs_id_prefix; ?>caDeleteOccurrenceButton<?php print $vn_type_id; ?>"><?php print caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_{n}" class="labelInfo caRelatedOccurrence <?= $vs_id_prefix; ?>caRelatedOccurrence">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="<?= $vs_id_prefix; ?>caDeleteOccurrenceButton<?= $vn_type_id; ?>"><?= caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to %1', $va_type_info['name_singular']); ?></h2></td>
+					<td><h2><?= _t(caGetOption('occurrence_control_label', $settings, _t('Add to %1')), $va_type_info['name_singular']); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_id{n}" id="<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_id{n}" id="<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_occurrences::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_occurrences::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -532,24 +537,24 @@ if($show_occurrence_controls) {
 if($show_collection_controls) {
 	foreach($coll_types as $vn_type_id => $va_type_info) {
 ?>
-	<textarea class='caHistoryTrackingSetCollectionTemplate<?php print $vn_type_id; ?>' style='display: none;'>
+	<textarea class='caHistoryTrackingSetCollectionTemplate<?= $vn_type_id; ?>' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 		
-		<div id="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_{n}" class="labelInfo caRelatedCollection">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteCollectionButton<?php print $vn_type_id; ?>"><?php print caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_{n}" class="labelInfo caRelatedCollection">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteCollectionButton<?= $vn_type_id; ?>"><?= caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to %1', $va_type_info['name_singular']); ?></h2></td>
+					<td><h2><?= _t(caGetOption('collection_control_label', $settings, _t('Add to %1')), $va_type_info['name_singular']); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_id{n}" id="<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_id{n}" id="<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_collections::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_collections::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -559,24 +564,24 @@ if($show_collection_controls) {
 if($show_entity_controls) {
 	foreach($entity_types as $vn_type_id => $va_type_info) {
 ?>
-	<textarea class='caHistoryTrackingSetEntityTemplate<?php print $vn_type_id; ?>' style='display: none;'>
+	<textarea class='caHistoryTrackingSetEntityTemplate<?= $vn_type_id; ?>' style='display: none;'>
 		<div class="clear"><!-- empty --></div>
 		
-		<div id="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_{n}" class="labelInfo caRelatedEntity">
-			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteEntityButton<?php print $vn_type_id; ?>"><?php print caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
+		<div id="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_{n}" class="labelInfo caRelatedEntity">
+			<div class="caHistoryTrackingButtonBarDelete"><a href="#" class="caDeleteEntityButton<?= $vn_type_id; ?>"><?= caNavIcon($this->request, __CA_NAV_ICON_DEL_BUNDLE__); ?></a></div>
 			<table class="caListItem">
 				<tr>
-					<td><h2><?php print _t('Add to %1', $va_type_info['name_singular']); ?></h2></td>
+					<td><h2><?= _t(caGetOption('entity_control_label', $settings,_t('Add to %1')), $va_type_info['name_singular']); ?></h2></td>
 					<td>
-						<input type="text" size="60" name="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
+						<input type="text" size="60" name="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_autocomplete{n}" value="{{label}}" id="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_autocomplete{n}" class="lookupBg"/>
 					</td>
 					<td>
-						<select name="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_type_id{n}" id="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
-						<input type="hidden" name="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_id{n}" id="<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_id{n}" value="{id}"/>
+						<select name="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_type_id{n}" id="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_type_id{n}" style="display: none;"></select>
+						<input type="hidden" name="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_id{n}" id="<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_id{n}" value="{id}"/>
 					</td>
 				</tr>
 			</table>
-			<?php print ca_entities::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
+			<?= ca_entities::getHistoryTrackingChronologyInterstitialElementAddHTMLForm($this->request, $vs_id_prefix, $subject_table, $settings, ['type' => $va_type_info['idno'], 'placement_code' => $vs_id_prefix]); ?>
 		</div>
 	</textarea>
 <?php
@@ -585,15 +590,15 @@ if($show_entity_controls) {
 ?>
 </div>
 
-<div id="caRelationQuickAddPanel<?php print $vs_id_prefix; ?>" class="caRelationQuickAddPanel"> 
-	<div id="caRelationQuickAddPanel<?php print $vs_id_prefix; ?>ContentArea">
-	<div class='dialogHeader'><?php print _t('Quick Add'); ?></div>
+<div id="caRelationQuickAddPanel<?= $vs_id_prefix; ?>" class="caRelationQuickAddPanel"> 
+	<div id="caRelationQuickAddPanel<?= $vs_id_prefix; ?>ContentArea">
+	<div class='dialogHeader'><?= _t('Quick Add'); ?></div>
 		
 	</div>
 </div>
-<div id="caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>" class="caRelationInterstitialEditPanel"> 
-	<div id="caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>ContentArea">
-	    <div class='dialogHeader'><?php print _t('Edit'); ?></div>
+<div id="caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>" class="caRelationInterstitialEditPanel"> 
+	<div id="caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>ContentArea">
+	    <div class='dialogHeader'><?= _t('Edit'); ?></div>
 	</div>
 </div>
 
@@ -601,43 +606,43 @@ if($show_entity_controls) {
 	if (!$read_only) {
 ?>
 <script type="text/javascript">
-	var caRelationQuickAddPanel<?php print $vs_id_prefix; ?>, caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>;
+	var caRelationQuickAddPanel<?= $vs_id_prefix; ?>, caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>;
 	jQuery(document).ready(function() {
 	
-		jQuery("#<?php print $vs_id_prefix; ?>").find(".caInterstitialEditButton").on('click', null,  {}, function(e) {
+		jQuery("#<?= $vs_id_prefix; ?>").find(".caInterstitialEditButton").on('click', null,  {}, function(e) {
 			// Trigger interstitial edit panel
 			var table = jQuery(this).data('table');
 			var relation_id = jQuery(this).data('relation_id');
 			var primary = jQuery(this).data('primary');
 			var primary_id = jQuery(this).data('primary_id');
-			var u = '<?php print caNavUrl($this->request, 'editor', 'Interstitial', 'Form', []); ?>/t/' + table + '/relation_id/' + relation_id + '/primary/' + primary + '/primary_id/' + primary_id;
+			var u = '<?= caNavUrl($this->request, 'editor', 'Interstitial', 'Form', []); ?>/t/' + table + '/relation_id/' + relation_id + '/primary/' + primary + '/primary_id/' + primary_id;
 		
-			caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>.showPanel(u);
+			caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>.showPanel(u);
 		
-			jQuery('#' + caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>.getPanelContentID()).data('panel', caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>);
+			jQuery('#' + caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>.getPanelContentID()).data('panel', caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>);
 		
 			e.preventDefault();
 			return false;
 		});
 	
-		jQuery("#<?php print $vs_id_prefix; ?>").find(".caDeleteItemButton").on('click', null,  {}, function(e) {
+		jQuery("#<?= $vs_id_prefix; ?>").find(".caDeleteItemButton").on('click', null,  {}, function(e) {
 			// Handle delete of chronology item
 			var table = jQuery(this).data('table');
 			var relation_id = jQuery(this).data('relation_id');
 		
-			jQuery("#caHistoryTrackingEntry<?php print $vs_id_prefix; ?>" + table + "-" + relation_id).remove();
-			jQuery("#<?php print $vs_id_prefix; ?>").append("<input type='hidden' name='<?php print $vs_id_prefix; ?>_delete_" + table + "[]' value='" +relation_id + "'/>");
+			jQuery("#caHistoryTrackingEntry<?= $vs_id_prefix; ?>" + table + "-" + relation_id).remove();
+			jQuery("#<?= $vs_id_prefix; ?>").append("<input type='hidden' name='<?= $vs_id_prefix; ?>_delete_" + table + "[]' value='" +relation_id + "'/>");
 			e.preventDefault();
 		});
 		
 	<?php if($display_mode === 'tabs') { ?>
-			jQuery("#<?php print $vs_id_prefix; ?>Tabs").tabs({ selected: 0 });	
+			jQuery("#<?= $vs_id_prefix; ?>Tabs").tabs({ selected: 0 });	
 	<?php } ?>	
 	
 			if (caUI.initPanel) {
-				caRelationQuickAddPanel<?php print $vs_id_prefix; ?> = caUI.initPanel({ 
-					panelID: "caRelationQuickAddPanel<?php print $vs_id_prefix; ?>",						/* DOM ID of the <div> enclosing the panel */
-					panelContentID: "caRelationQuickAddPanel<?php print $vs_id_prefix; ?>ContentArea",		/* DOM ID of the content area <div> in the panel */
+				caRelationQuickAddPanel<?= $vs_id_prefix; ?> = caUI.initPanel({ 
+					panelID: "caRelationQuickAddPanel<?= $vs_id_prefix; ?>",						/* DOM ID of the <div> enclosing the panel */
+					panelContentID: "caRelationQuickAddPanel<?= $vs_id_prefix; ?>ContentArea",		/* DOM ID of the content area <div> in the panel */
 					exposeBackgroundColor: "#000000",				
 					exposeBackgroundOpacity: 0.7,					
 					panelTransitionSpeed: 400,						
@@ -650,9 +655,9 @@ if($show_entity_controls) {
 						jQuery("#topNavContainer").show(250);
 					}
 				});
-				caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?> = caUI.initPanel({ 
-					panelID: "caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>",						/* DOM ID of the <div> enclosing the panel */
-					panelContentID: "caRelationInterstitialEditPanel<?php print $vs_id_prefix; ?>ContentArea",		/* DOM ID of the content area <div> in the panel */
+				caRelationInterstitialEditPanel<?= $vs_id_prefix; ?> = caUI.initPanel({ 
+					panelID: "caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>",						/* DOM ID of the <div> enclosing the panel */
+					panelContentID: "caRelationInterstitialEditPanel<?= $vs_id_prefix; ?>ContentArea",		/* DOM ID of the content area <div> in the panel */
 					exposeBackgroundColor: "#000000",				
 					exposeBackgroundOpacity: 0.7,					
 					panelTransitionSpeed: 400,						
@@ -664,7 +669,7 @@ if($show_entity_controls) {
 					onCloseCallback: function() {
 						jQuery("#topNavContainer").show(250);
 						if(caBundleUpdateManager) { 
-							caBundleUpdateManager.reloadBundle('<?php print $bundle_name; ?>'); 
+							caBundleUpdateManager.reloadBundle('<?= $bundle_name; ?>'); 
 							caBundleUpdateManager.reloadInspector(); 
 						}
 					}
@@ -673,38 +678,38 @@ if($show_entity_controls) {
 <?php	
 	if($show_location_controls || $show_return_home_controls) {
 ?>	
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_storage_locations = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_storage_locations_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_storage_locations = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_storage_locations_',
 				templateValues: ['label', 'type_id', 'id'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_storage_locations_',
-				placementID: '<?php print $vn_placement_id; ?>',
-				templateClassName: '<?php print $vs_id_prefix; ?>caHistoryTrackingSetLocationTemplate',
+				itemID: '<?= $vs_id_prefix; ?>_ca_storage_locations_',
+				placementID: '<?= $vn_placement_id; ?>',
+				templateClassName: '<?= $vs_id_prefix; ?>caHistoryTrackingSetLocationTemplate',
 				initialValueTemplateClassName: null,
-				itemListClassName: '<?php print $vs_id_prefix; ?>caLocationList',
-				listItemClassName: '<?php print $vs_id_prefix; ?>caRelatedLocation',
-				addButtonClassName: '<?php print $vs_id_prefix; ?>caChangeLocationButton',
-				deleteButtonClassName: '<?php print $vs_id_prefix; ?>caDeleteLocationButton',
+				itemListClassName: '<?= $vs_id_prefix; ?>caLocationList',
+				listItemClassName: '<?= $vs_id_prefix; ?>caRelatedLocation',
+				addButtonClassName: '<?= $vs_id_prefix; ?>caChangeLocationButton',
+				deleteButtonClassName: '<?= $vs_id_prefix; ?>caDeleteLocationButton',
 				showEmptyFormsOnLoad: 0,
-				relationshipTypes: <?php print json_encode($this->getVar('location_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'StorageLocation', 'Get', []); ?>',
+				relationshipTypes: <?= json_encode($this->getVar('location_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'StorageLocation', 'Get', []); ?>',
 				minChars:<?= (int)$t_subject->getAppConfig()->get(["ca_storage_locations_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
 				readonly: false,
 				isSortable: false,
 				listSortItems: 'div.roundedRel',			
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/storage_locations', 'StorageLocationQuickAdd', 'Form', array('location_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/storage_locations', 'StorageLocationQuickAdd', 'Form', array('location_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				addMode: 'prepend',
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 <?php
@@ -713,19 +718,19 @@ if($show_entity_controls) {
 			if (!_currentHomeLocation) {
 				_currentHomeLocation = <?= json_encode($home_location_idno); ?>;
 			}
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_storage_locations_return_home = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_storage_locations_return_home_',
 				templateValues: ['label', 'type_id', 'id'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_',
-				placementID: '<?php print $vn_placement_id; ?>',
-				templateClassName: '<?php print $vs_id_prefix; ?>caHistoryTrackingReturnToHomeLocationTemplate',
+				itemID: '<?= $vs_id_prefix; ?>_ca_storage_locations_return_home_',
+				placementID: '<?= $vn_placement_id; ?>',
+				templateClassName: '<?= $vs_id_prefix; ?>caHistoryTrackingReturnToHomeLocationTemplate',
 				initialValueTemplateClassName: null,
-				itemListClassName: '<?php print $vs_id_prefix; ?>caLocationList',
-				listItemClassName: '<?php print $vs_id_prefix; ?>caRelatedLocation',
-				addButtonClassName: '<?php print $vs_id_prefix; ?>caReturnToHomeLocationButton',
-				deleteButtonClassName: '<?php print $vs_id_prefix; ?>caDeleteReturnToHomeLocationButton',
+				itemListClassName: '<?= $vs_id_prefix; ?>caLocationList',
+				listItemClassName: '<?= $vs_id_prefix; ?>caRelatedLocation',
+				addButtonClassName: '<?= $vs_id_prefix; ?>caReturnToHomeLocationButton',
+				deleteButtonClassName: '<?= $vs_id_prefix; ?>caDeleteReturnToHomeLocationButton',
 				showEmptyFormsOnLoad: 0,
 				minChars:1,
 				readonly: false,
@@ -734,16 +739,16 @@ if($show_entity_controls) {
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
-					jQuery("#<?php print $vs_id_prefix; ?>_ca_storage_locations_return_homenew_0").val(1);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>_ca_storage_locations_return_homenew_0").val(1);
 					
-					var msg = <?= json_encode(_t('Return to home location ')); ?>;
-					jQuery("#<?php print $vs_id_prefix; ?>_ca_storage_locations_return_home_heading").html(msg + "<em>" + _currentHomeLocation + "</em>");
+					var msg = <?= json_encode(caGetOption('return_to_home_location_control_label', $settings, _t('Return to home location '))); ?>;
+					jQuery("#<?= $vs_id_prefix; ?>_ca_storage_locations_return_home_heading").html(msg + "<em>" + _currentHomeLocation + "</em>");
 				
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
-					jQuery("#<?php print $vs_id_prefix; ?>_ca_storage_locations_return_homenew_0").val(0);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>_ca_storage_locations_return_homenew_0").val(0);
 				}
 			});
 <?php
@@ -751,13 +756,13 @@ if($show_entity_controls) {
     }
 	if($show_loan_controls) {
 ?>			
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_loans = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_loans_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_loans = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_loans_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_loans_',
-				placementID: '<?php print $vn_placement_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_loans_',
+				placementID: '<?= $vn_placement_id; ?>',
 				templateClassName: 'caHistoryTrackingSetLoanTemplate',
 				initialValueTemplateClassName: null,
 				itemListClassName: 'caLoanList',
@@ -767,37 +772,37 @@ if($show_entity_controls) {
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_loans_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('loan_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'Loan', 'Get', []); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>LoanBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('loan_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'Loan', 'Get', []); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>LoanBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/loans', 'LoanQuickAdd', 'Form', array('loan_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/loans', 'LoanQuickAdd', 'Form', array('loan_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 <?php	
     }
 	if($show_movement_controls) {
 ?>			
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_movements = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_movements_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_movements = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_movements_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_movements_',
-				placementID: '<?php print $vn_placement_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_movements_',
+				placementID: '<?= $vn_placement_id; ?>',
 				templateClassName: 'caHistoryTrackingSetMovementTemplate',
 				initialValueTemplateClassName: null,
 				itemListClassName: 'caMovementList',
@@ -807,37 +812,37 @@ if($show_entity_controls) {
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_movements_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('movement_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'Movement', 'Get', []); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>MovementBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('movement_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'Movement', 'Get', []); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>MovementBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/movements', 'MovementQuickAdd', 'Form', array('movement_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/movements', 'MovementQuickAdd', 'Form', array('movement_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 <?php	
     }
 	if($show_object_controls) {
 ?>
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_objects = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_objects_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_objects = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_objects_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_objects_',
-				placementID: '<?php print $vn_placement_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_objects_',
+				placementID: '<?= $vn_placement_id; ?>',
 				templateClassName: 'caHistoryTrackingSetObjectTemplate',
 				initialValueTemplateClassName: null,
 				itemListClassName: 'caObjectList',
@@ -847,24 +852,24 @@ if($show_entity_controls) {
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_objects_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('object_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'object', 'Get', []); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>ObjectBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('object_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'object', 'Get', []); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>ObjectBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/objects', 'ObjectQuickAdd', 'Form', array('object_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/objects', 'ObjectQuickAdd', 'Form', array('object_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 <?php
@@ -872,40 +877,40 @@ if($show_entity_controls) {
 	if($show_occurrence_controls) {
 		foreach($occ_types as $vn_type_id => $va_type_info) {
 ?>
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?> = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?> = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_occurrences_<?php print $vn_type_id; ?>_',
-				placementID: '<?php print $vn_placement_id; ?>',
-				templateClassName: '<?php print $vs_id_prefix; ?>caHistoryTrackingSetOccurrenceTemplate<?php print $vn_type_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>_',
+				placementID: '<?= $vn_placement_id; ?>',
+				templateClassName: '<?= $vs_id_prefix; ?>caHistoryTrackingSetOccurrenceTemplate<?= $vn_type_id; ?>',
 				initialValueTemplateClassName: null,
-				itemListClassName: '<?php print $vs_id_prefix; ?>caOccurrenceList<?php print $vn_type_id; ?>',
-				listItemClassName: '<?php print $vs_id_prefix; ?>caRelatedOccurrence',
-				addButtonClassName: '<?php print $vs_id_prefix; ?>caAddOccurrenceButton<?php print $vn_type_id; ?>',
-				deleteButtonClassName: '<?php print $vs_id_prefix; ?>caDeleteOccurrenceButton<?php print $vn_type_id; ?>',
+				itemListClassName: '<?= $vs_id_prefix; ?>caOccurrenceList<?= $vn_type_id; ?>',
+				listItemClassName: '<?= $vs_id_prefix; ?>caRelatedOccurrence',
+				addButtonClassName: '<?= $vs_id_prefix; ?>caAddOccurrenceButton<?= $vn_type_id; ?>',
+				deleteButtonClassName: '<?= $vs_id_prefix; ?>caDeleteOccurrenceButton<?= $vn_type_id; ?>',
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_occurrences_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('occurrence_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'Occurrence', 'Get', array_merge($occ_lookup_params, ['types' => $vn_type_id])); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>OccurrenceBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('occurrence_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'Occurrence', 'Get', array_merge($occ_lookup_params, ['types' => $vn_type_id])); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>OccurrenceBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_occurrence_<?php print $vn_type_id; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/occurrences', 'OccurrenceQuickAdd', 'Form', array('types' => $vn_type_id,'occurrence_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_occurrence_<?= $vn_type_id; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/occurrences', 'OccurrenceQuickAdd', 'Form', array('types' => $vn_type_id,'occurrence_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 	<?php
@@ -914,40 +919,40 @@ if($show_entity_controls) {
 	if($show_collection_controls) {
 		foreach($coll_types as $vn_type_id => $va_type_info) {
 	?>
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?> = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?> = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_collections_<?php print $vn_type_id; ?>_',
-				placementID: '<?php print $vn_placement_id; ?>',
-				templateClassName: 'caHistoryTrackingSetCollectionTemplate<?php print $vn_type_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_collections_<?= $vn_type_id; ?>_',
+				placementID: '<?= $vn_placement_id; ?>',
+				templateClassName: 'caHistoryTrackingSetCollectionTemplate<?= $vn_type_id; ?>',
 				initialValueTemplateClassName: null,
-				itemListClassName: 'caCollectionList<?php print $vn_type_id; ?>',
+				itemListClassName: 'caCollectionList<?= $vn_type_id; ?>',
 				listItemClassName: 'caRelatedCollection',
-				addButtonClassName: 'caAddCollectionButton<?php print $vn_type_id; ?>',
-				deleteButtonClassName: 'caDeleteCollectionButton<?php print $vn_type_id; ?>',
+				addButtonClassName: 'caAddCollectionButton<?= $vn_type_id; ?>',
+				deleteButtonClassName: 'caDeleteCollectionButton<?= $vn_type_id; ?>',
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_collections_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('collection_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'collection', 'Get', array_merge($coll_lookup_params, ['types' => $vn_type_id])); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>CollectionBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('collection_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'collection', 'Get', array_merge($coll_lookup_params, ['types' => $vn_type_id])); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>CollectionBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_collection_<?php print $vn_type_id; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/collections', 'collectionQuickAdd', 'Form', array('types' => $vn_type_id,'collection_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_collection_<?= $vn_type_id; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/collections', 'collectionQuickAdd', 'Form', array('types' => $vn_type_id,'collection_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 	<?php
@@ -956,50 +961,50 @@ if($show_entity_controls) {
 	if($show_entity_controls) {
 		foreach($entity_types as $vn_type_id => $va_type_info) {
 	?>
-			caRelationBundle<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?> = caUI.initRelationBundle('#<?php print $vs_id_prefix; ?>', {
-				fieldNamePrefix: '<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_',
+			caRelationBundle<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?> = caUI.initRelationBundle('#<?= $vs_id_prefix; ?>', {
+				fieldNamePrefix: '<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_',
 				templateValues: ['label', 'id', 'type_id', 'typename', 'idno_sort'],
 				initialValues: [],
 				initialValueOrder: [],
-				itemID: '<?php print $vs_id_prefix; ?>_ca_entities_<?php print $vn_type_id; ?>_',
-				placementID: '<?php print $vn_placement_id; ?>',
-				templateClassName: 'caHistoryTrackingSetEntityTemplate<?php print $vn_type_id; ?>',
+				itemID: '<?= $vs_id_prefix; ?>_ca_entities_<?= $vn_type_id; ?>_',
+				placementID: '<?= $vn_placement_id; ?>',
+				templateClassName: 'caHistoryTrackingSetEntityTemplate<?= $vn_type_id; ?>',
 				initialValueTemplateClassName: null,
-				itemListClassName: 'caEntityList<?php print $vn_type_id; ?>',
+				itemListClassName: 'caEntityList<?= $vn_type_id; ?>',
 				listItemClassName: 'caRelatedEntity',
-				addButtonClassName: 'caAddEntityButton<?php print $vn_type_id; ?>',
-				deleteButtonClassName: 'caDeleteEntityButton<?php print $vn_type_id; ?>',
+				addButtonClassName: 'caAddEntityButton<?= $vn_type_id; ?>',
+				deleteButtonClassName: 'caDeleteEntityButton<?= $vn_type_id; ?>',
 				hideOnNewIDList: [],
 				showEmptyFormsOnLoad: 0,
 				minChars: <?= (int)$t_subject->getAppConfig()->get(["ca_entities_autocomplete_minimum_search_length", "autocomplete_minimum_search_length"]); ?>,
-				relationshipTypes: <?php print json_encode($this->getVar('entity_relationship_types_by_sub_type')); ?>,
-				autocompleteUrl: '<?php print caNavUrl($this->request, 'lookup', 'entity', 'Get', array_merge($entity_lookup_params, ['types' => $vn_type_id])); ?>',
-				types: <?php print json_encode($settings['restrict_to_types']); ?>,
-				readonly: <?php print $read_only ? "true" : "false"; ?>,
-				isSortable: <?php print ($read_only || $vs_sort) ? "false" : "true"; ?>,
-				listSortOrderID: '<?php print $vs_id_prefix; ?>EntityBundleList',
+				relationshipTypes: <?= json_encode($this->getVar('entity_relationship_types_by_sub_type')); ?>,
+				autocompleteUrl: '<?= caNavUrl($this->request, 'lookup', 'entity', 'Get', array_merge($entity_lookup_params, ['types' => $vn_type_id])); ?>',
+				types: <?= json_encode($settings['restrict_to_types']); ?>,
+				readonly: <?= $read_only ? "true" : "false"; ?>,
+				isSortable: <?= ($read_only || $vs_sort) ? "false" : "true"; ?>,
+				listSortOrderID: '<?= $vs_id_prefix; ?>EntityBundleList',
 				listSortItems: 'div.roundedRel',
-				autocompleteInputID: '<?php print $vs_id_prefix; ?>_entity_<?php print $vn_type_id; ?>_autocomplete',
-				quickaddPanel: caRelationQuickAddPanel<?php print $vs_id_prefix; ?>,
-				quickaddUrl: '<?php print caNavUrl($this->request, 'editor/entities', 'entityQuickAdd', 'Form', array('types' => $vn_type_id,'entity_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
+				autocompleteInputID: '<?= $vs_id_prefix; ?>_entity_<?= $vn_type_id; ?>_autocomplete',
+				quickaddPanel: caRelationQuickAddPanel<?= $vs_id_prefix; ?>,
+				quickaddUrl: '<?= caNavUrl($this->request, 'editor/entities', 'entityQuickAdd', 'Form', array('types' => $vn_type_id,'entity_id' => 0, 'dont_include_subtypes_in_type_restriction' => (int)$settings['dont_include_subtypes_in_type_restriction'])); ?>',
 				minRepeats: 0,
 				maxRepeats: 2,
 				useAnimation: 1,
 				onAddItem: function(id, options, isNew) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideUp(250);
 				},
 				onDeleteItem: function(id) {
-					jQuery("#<?php print $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
+					jQuery("#<?= $vs_id_prefix; ?>").find(".caHistoryTrackingButtonBar").slideDown(250);
 				}
 			});
 	<?php
-		}
+		}s
 	}
 	?>
-		jQuery('#<?php print $vs_id_prefix; ?>SetChildView').on('click', function(e) {
+		jQuery('#<?= $vs_id_prefix; ?>SetChildView').on('click', function(e) {
 			if(caBundleUpdateManager) { 
-				caBundleUpdateManager.reloadBundle('ca_objects_history', {'showChildHistory': <?php print Session::getVar('ca_objects_history_showChildHistory') ? 0 : 1; ?>}); 
-				caBundleUpdateManager.reloadBundle('history_tracking_chronology', {'showChildHistory': <?php print Session::getVar('ca_objects_history_showChildHistory') ? 0 : 1; ?>}); 
+				caBundleUpdateManager.reloadBundle('ca_objects_history', {'showChildHistory': <?= Session::getVar('ca_objects_history_showChildHistory') ? 0 : 1; ?>}); 
+				caBundleUpdateManager.reloadBundle('history_tracking_chronology', {'showChildHistory': <?= Session::getVar('ca_objects_history_showChildHistory') ? 0 : 1; ?>}); 
 			}
 
 		});

--- a/themes/default/views/find/Browse/ajax_browse_facet_html.php
+++ b/themes/default/views/find/Browse/ajax_browse_facet_html.php
@@ -56,15 +56,15 @@
 ?>
 <script type="text/javascript">
 	function caUpdateFacetDisplay(grouping) {
-		caUIBrowsePanel.showBrowsePanel('<?php print $vs_facet_name; ?>', <?php print ((intval($vm_modify_id) > 0) ? 'true' : 'false'); ?>, <?php print ((intval($vm_modify_id) > 0) ?  $vm_modify_id : 'null'); ?>, grouping);
+		caUIBrowsePanel.showBrowsePanel('<?= $vs_facet_name; ?>', <?= ((intval($vm_modify_id) > 0) ? 'true' : 'false'); ?>, <?= ((intval($vm_modify_id) > 0) ?  $vm_modify_id : 'null'); ?>, grouping);
 	}
 </script>
 
-<div class="browseSelectPanelContentArea <?php print ($vb_multiple_selection_facet) ? "browseSelectMultiplePanelContentArea" : "" ?>" id="browseSelectPanelContentArea">
+<div class="browseSelectPanelContentArea <?= ($vb_multiple_selection_facet) ? "browseSelectMultiplePanelContentArea" : "" ?>" id="browseSelectPanelContentArea">
 <?php
 	if ($vb_multiple_selection_facet) {
 ?>
-		<div class='applyFacetContainer'><a href="#" id="facet_apply" data-facet="<?php print $vs_facet_name; ?>" class="facetApply">Apply</a></div>
+		<div class='applyFacetContainer'><a href="#" id="facet_apply" data-facet="<?= $vs_facet_name; ?>" class="facetApply">Apply</a></div>
 <?php
 	}
 
@@ -73,14 +73,14 @@
 		# ------------------------------------------------------------
 		case 'hierarchical';
 ?>
-	<h2 class='browse'><?php print caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
+	<h2 class='browse'><?= caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
 	<div class='clearDivide'></div>
-	<div id="hierarchyBrowserContainer"><div id="<?php print $vs_facet_name; ?>_facet_container">
+	<div id="hierarchyBrowserContainer"><div id="<?= $vs_facet_name; ?>_facet_container">
 		<div id="hierarchyBrowser" class='hierarchyBrowser'>
 			<!-- Content for hierarchy browser is dynamically inserted here by ca.hierbrowser -->
 		</div>
 		<div class="hierarchyBrowserSearchBar">
-			<label for="hierarchyBrowserSearch"><?php print _t("Search"); ?>:</label>
+			<label for="hierarchyBrowserSearch"><?= _t("Search"); ?>:</label>
 			<input id="hierarchyBrowserSearch" type="text" size="40" />
 			<span class="ui-helper-hidden-accessible" role="status" aria-live="polite"></span>
 		</div>
@@ -88,7 +88,7 @@
 		if ($t_item && $t_subject) {
 ?>
 			<div class="hierarchyBrowserHelpText">
-				<?php print _t("Click on a %1 to find %2 related to it. Click on the arrow next to a %3 to see more specific %4 within that %5, or use the search field.", $t_item->getProperty('NAME_SINGULAR'), $t_subject->getProperty('NAME_PLURAL'), $t_item->getProperty('NAME_SINGULAR'), $t_item->getProperty('NAME_PLURAL'), $t_item->getProperty('NAME_SINGULAR') ); ?>
+				<?= _t("Click on a %1 to find %2 related to it. Click on the arrow next to a %3 to see more specific %4 within that %5, or use the search field.", $t_item->getProperty('NAME_SINGULAR'), $t_subject->getProperty('NAME_PLURAL'), $t_item->getProperty('NAME_SINGULAR'), $t_item->getProperty('NAME_PLURAL'), $t_item->getProperty('NAME_SINGULAR') ); ?>
 			</div>
 <?php
 		}
@@ -101,22 +101,22 @@
 		jQuery(document).ready(function() {
 
 			oHierBrowser = caUI.initHierBrowser('hierarchyBrowser', {
-				levelDataUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacetHierarchyLevel', array('facet' => $vs_facet_name)); ?>',
-				initDataUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacetHierarchyAncestorList', array('facet' => $vs_facet_name)); ?>',
+				levelDataUrl: '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacetHierarchyLevel', array('facet' => $vs_facet_name)); ?>',
+				initDataUrl: '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacetHierarchyAncestorList', array('facet' => $vs_facet_name)); ?>',
 
-				editUrl: '<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'addCriteria', array('facet' => $vs_facet_name, 'id' => '')); ?>',
-				editButtonIcon: "<?php print caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__ ,1); ?>",
+				editUrl: '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'addCriteria', array('facet' => $vs_facet_name, 'id' => '')); ?>',
+				editButtonIcon: "<?= caNavIcon(__CA_NAV_ICON_RIGHT_ARROW__ ,1); ?>",
 
-				initItemID: '<?php print $this->getVar('browse_last_id'); ?>',
-				indicator: "<?php print caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
+				initItemID: '<?= $this->getVar('browse_last_id'); ?>',
+				indicator: "<?= caNavIcon(__CA_NAV_ICON_SPINNER__, 1); ?>",
 
 				currentSelectionDisplayID: 'browseCurrentSelection',
 				
-				selectMultiple: <?php print ($vb_multiple_selection_facet) ? 1 : 0; ?>
+				selectMultiple: <?= ($vb_multiple_selection_facet) ? 1 : 0; ?>
 			});
 
 			jQuery('#hierarchyBrowserSearch').autocomplete({
-				source: '<?php print $va_service_urls['search']; ?>',
+				source: '<?= $va_service_urls['search']; ?>',
 				minLength: 3,
 				delay: 800,
 				html: true,
@@ -135,11 +135,11 @@
 		# ------------------------------------------------------------
 		case 'none':
 ?>
-	<h2 class='browse'><?php print caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
+	<h2 class='browse'><?= caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
 	<div class='clearDivide'></div>
 
 	<div class="browseSelectPanelList">
-		<table class='browseSelectPanelListTable' id='<?php print $vs_facet_name; ?>_facet_container'>
+		<table class='browseSelectPanelListTable' id='<?= $vs_facet_name; ?>_facet_container'>
 <?php
 			$va_row = array();
 			foreach($va_facet as $vn_i => $va_item) {
@@ -174,7 +174,7 @@
 ?>
 
 	<div class="browseSelectPanelHeader">
-	<h2 class='browse'><?php print caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
+	<h2 class='browse'><?= caUcFirstUTF8Safe($va_facet_info['label_plural']); ?></h2>
 
 <?php 
 	$vs_g = null;
@@ -207,7 +207,7 @@
 		?>
 		</div>		
 	</div>
-	<div class="browseSelectPanelList" id="browseSelectPanelList"><div id='<?php print $vs_facet_name; ?>_facet_container'>
+	<div class="browseSelectPanelList" id="browseSelectPanelList"><div id='<?= $vs_facet_name; ?>_facet_container'>
 <?php
 			
 			if (($vs_g) && (isset($va_facet[$vs_g]))) {
@@ -257,7 +257,7 @@
 
 <script type="text/javascript">
 	function loadFacetGroup(g) {
-		jQuery('#browseSelectPanelContentArea').parent().load("<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacet', array('facet' => $vs_facet_name, 'grouping' => $this->getVar('grouping'), 'show_group' => '')); ?>" + escape(g));
+		jQuery('#browseSelectPanelContentArea').parent().load("<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'getFacet', array('facet' => $vs_facet_name, 'grouping' => $this->getVar('grouping'), 'show_group' => '')); ?>" + escape(g));
 	}
 	
 	
@@ -289,15 +289,17 @@ if($vb_multiple_selection_facet){
 		});
 		
 		jQuery(".facetApply").on('click', function(e) { 
-			var facet = '<?php print $vs_facet_name; ?>';
+			var facet = '<?= $vs_facet_name; ?>';
 			
 			var ids = [];
 			jQuery.each(jQuery("#" + facet + "_facet_container").find("[facet_item_selected=1]"), function(k,v) {
-				ids.push(jQuery(v).data('facet_item_id'));
+				var id = jQuery(v).data('facet_item_id');
+				if(!id) { id = jQuery(v).data('item_id'); }
+				if (id > 0) { ids.push(id); }
 			});
 
 			if(ids.length){
-				window.location = '<?php print caNavUrl($this->request, 'find', $this->request->getController(),((strlen($vm_modify_id)) ? 'modifyCriteria' : 'addCriteria'), array('mod_id' => $vm_modify_id)); ?>/facet/' + facet + '/id/' + ids.join('|');
+				window.location = '<?= caNavUrl($this->request, 'find', $this->request->getController(),((strlen($vm_modify_id)) ? 'modifyCriteria' : 'addCriteria'), array('mod_id' => $vm_modify_id)); ?>/facet/' + facet + '/id/' + ids.join('|');
 			}
 			e.preventDefault();
 		});

--- a/themes/default/views/manage/widget_watched_items_info_html.php
+++ b/themes/default/views/manage/widget_watched_items_info_html.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2016 Whirl-i-Gig
+ * Copyright 2010-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -30,24 +30,21 @@
 $t_watch_list = $this->getVar('t_watch_list');
 
 ?>
-<h3 class='watchedItems'><?php print _t('Your watched items'); ?></h3>
-<div id="watchedItemsSetControls">
-	<div class="col">
-		<?php
-		print "<span class='header'>"._t("Create set").":</span><br/>";
-		?>
-		<?php print caFormTag($this->request, 'CreateSet', 'caCreateSetFromWatchedItems'); ?>
-			<?php
-			print caHTMLTextInput('set_name', array(
-				'id' => 'caCreateSetFromWatchedItemsInput',
-				'class' => 'searchSetsTextInput',
-				'value' => _t('watchlist').'_'.$this->request->getUser()->get('user_name').'_'.date('Y-m-d')
-			), array('width' => '150px'));
-			print _t("containing watched");
-			print $t_watch_list->getWatchedTablesAsHTMLSelect($this->request->getUserID(), 'set_table');
-			print caBusyIndicatorIcon($this->request, array('id' => 'caCreateSetFromResultsIndicator'))."\n";
+<h3 class='watchedItems'>
+	<?= _t('Your watched items'); ?>
+	<div>
+		<?= "<span class='header'>"._t("Create set").":</span><br/>"; ?>
+		<?= caFormTag($this->request, 'CreateSet', 'caCreateSetFromWatchedItems'); ?>
+			<?= caHTMLTextInput('set_name', [
+					'id' => 'caCreateSetFromWatchedItemsInput',
+					'class' => 'searchSetsTextInput',
+					'value' => _t('watchlist').'_'.$this->request->getUser()->get('user_name').'_'.date('Y-m-d')
+				], ['width' => '150px']).
+				_t("containing watched").
+				$t_watch_list->getWatchedTablesAsHTMLSelect($this->request->getUserID(), 'set_table').
+				caBusyIndicatorIcon($this->request, ['id' => 'caCreateSetFromResultsIndicator'])."\n";
 			?>
-			<a href='#' onclick="jQuery('#caCreateSetFromWatchedItems').submit(); return false;" class="button"><?php print _t('Create'); ?> &rsaquo;</a>
+			<a href='#' onclick="jQuery('#caCreateSetFromWatchedItems').submit(); return false;" class="button"><?= _t('Create'); ?> &rsaquo;</a>
 		</form>
 	</div>
-</div>
+</h3>


### PR DESCRIPTION
PR improves movement-based location tracking:
    
    1. Add options for customization of "add" button text
    2. Add option to trigger new movement every time "add movement" is clicked, rather than requiring a search lookup
    3. Have history list show last-added item as current when multiple objects have the same date
    4. Storage location embedded movement form now enforced required fields and will prevent save on error
    5. Fix issue with prepopulate that would prevent transaction rollback in editing forms (would prevent #4 from functioning)
    6. Index support for non-preferred labels
