### PR TITLE
Trigger metadata alert filters for multi value containers

### DIFF
--- a/app/lib/MetadataAlerts/TriggerTypes/Modification.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Modification.php
@@ -61,9 +61,7 @@ class Modification extends Base {
 		
 		if(!$va_values['element_id'] && !$vs_non_element_filter) {
 			// Trigger on any change
-			$changed =  $t_instance->hasChangedSinceLoad();
-			dump(['hasChangedSinceLoad' => $changed]);
-			return $changed;
+			return $t_instance->hasChangedSinceLoad();
 		}
 		
 		if ($vs_non_element_filter) {

--- a/app/lib/MetadataAlerts/TriggerTypes/Modification.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Modification.php
@@ -61,7 +61,9 @@ class Modification extends Base {
 		
 		if(!$va_values['element_id'] && !$vs_non_element_filter) {
 			// Trigger on any change
-			return $t_instance->hasChangedSinceLoad();
+			$changed =  $t_instance->hasChangedSinceLoad();
+			dump(['hasChangedSinceLoad' => $changed]);
+			return $changed;
 		}
 		
 		if ($vs_non_element_filter) {
@@ -88,7 +90,10 @@ class Modification extends Base {
 				$vs_get_spec = "$vs_parent_code.$vs_get_spec";
 			}
 			if (is_array($va_filter_vals = caGetOption($vs_code, $va_filters, null)) && sizeof($va_filter_vals)) {
-				if(!in_array($t_instance->get($t_instance->tableName().".{$vs_get_spec}"), $va_filter_vals)) { return false; }
+				$va_values = $t_instance->get($t_instance->tableName().".{$vs_get_spec}", ['returnAsArray' => true]);
+				if (! ( array_intersect( $va_values, $va_filter_vals ) ) ) {
+					return false;
+				}
 			}
 			return $t_instance->attributeDidChange($vs_code);
 		}


### PR DESCRIPTION
* Previously _if_:
  * you have an element inside a container and
   * the container is multi valued
* _then_ filtered alerts do not get triggered.
* This change compares the individual values for an attribute rather
than concatenated values.