### PR TITLE
Fix SqlSearch2 issue where field-level searches on fields using modified indexing

### DIFF
--- a/app/lib/Plugins/SearchEngine/BaseSearchPlugin.php
+++ b/app/lib/Plugins/SearchEngine/BaseSearchPlugin.php
@@ -55,6 +55,13 @@ abstract class BaseSearchPlugin extends WLPlug implements IWLPlugSearchEngine {
 	protected $search_config;
 	
 	/**
+	 * Search configuration (search_indexing.conf)
+	 *
+	 * @var Configuration
+	 */
+	protected $search_indexing_config;
+	
+	/**
 	 *
 	 */
 	protected $encoding;
@@ -95,6 +102,7 @@ abstract class BaseSearchPlugin extends WLPlug implements IWLPlugSearchEngine {
 		
 		$this->config = Configuration::load();
 		$this->search_config = Configuration::load(__CA_CONF_DIR__.'/search.conf');
+		$this->search_indexing_config = Configuration::load(__CA_CONF_DIR__.'/search_indexing.conf');
 		$this->encoding = 'UTF-8';
 		
 		$this->db = $db ? $db : new Db();

--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -372,7 +372,7 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 	 	
 	 	$ap = $field ? $this->_getElementIDForAccessPoint($subject_tablenum, $field) : null;
 	 	
-	 	if (is_array($ap)) {
+	 	if (is_array($ap) && !$this->useSearchIndexForAP($ap)) {
 	 		// Handle datatype-specific queries
 	 		$ret = $this->_processMetadataDataType($subject_tablenum, $ap, $query);
 	 		if(is_array($ret)) { return $ret; }
@@ -1483,6 +1483,9 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 			$vn_rel_type = (int)$va_rel_type_ids[0];
 		}
 		
+		if(is_array($indexing_info = $this->search_indexing_config->get(Datamodel::getTableName($subject_tablenum)))) {
+			$indexing_info = $indexing_info[$vs_table]['fields'][$vs_field] ?? null;
+		}
 		if (strtolower($vs_field) == 'count') {
 			if (!is_array($va_rel_type_ids) || !sizeof($va_rel_type_ids)) { $va_rel_type_ids = [0]; }	// for counts must pass "0" as relationship type to pull count for all reltypes in aggregate
 			return array(
@@ -1494,7 +1497,8 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 				'datatype' => 'COUNT',
 				'element_info' => null,
 				'relationship_type_ids' => $va_rel_type_ids,
-				'type' => 'COUNT'
+				'type' => 'COUNT',
+				'indexing_options' => $indexing_info
 			);
 		} elseif (strtolower($vs_field) == 'current_value') {
 		    if(!$vs_subfield) { $vs_subfield = '__default__'; }
@@ -1515,7 +1519,8 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 				'element_info' => null,
 				'relationship_type_ids' => $va_rel_type_ids,
 				'policy' => $vs_subfield,
-				'type' => 'CV'
+				'type' => 'CV',
+				'indexing_options' => $indexing_info
 			);
 		
 		} elseif (is_numeric($vs_field)) {
@@ -1544,7 +1549,8 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 						'datatype' => 'COUNT',
 						'element_info' => $t_element->getFieldValuesArray(),
 						'relationship_type_ids' => $va_rel_type_ids,
-						'type' => 'COUNT'
+						'type' => 'COUNT',
+						'indexing_options' => $indexing_info
 					);
 				} else {
 					return array(
@@ -1556,13 +1562,14 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 						'datatype' => $t_element->get('datatype'),
 						'element_info' => $t_element->getFieldValuesArray(),
 						'relationship_type_ids' => $va_rel_type_ids,
-						'type' => 'METADATA'
+						'type' => 'METADATA',
+						'indexing_options' => $indexing_info
 					);
 				}
 			}
 		} else {
 
-			return array('access_point' => $va_tmp[0], 'relationship_type' => $va_tmp[1], 'table_num' => $vs_table_num, 'field_num' => 'I'.$vs_fld_num, 'field_num_raw' => $vs_fld_num, 'datatype' => null, 'relationship_type_ids' => $va_rel_type_ids, 'type' => 'INTRINSIC');
+			return array('access_point' => $va_tmp[0], 'relationship_type' => $va_tmp[1], 'table_num' => $vs_table_num, 'field_num' => 'I'.$vs_fld_num, 'field_num_raw' => $vs_fld_num, 'datatype' => null, 'relationship_type_ids' => $va_rel_type_ids, 'type' => 'INTRINSIC', 'indexing_options' => $indexing_info);
 		}
 
 		return null;
@@ -1942,6 +1949,18 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 			$text = preg_replace("!^(#[gtleq]+[#=]{1})!i", '', $text);
 		}
 		return [$text, $modifier];
+	}
+	# -------------------------------------------------------
+	/**
+	 *
+	 */
+	private function useSearchIndexForAP(array $ap) : bool {
+		if(is_array($ap['indexing_options'])) {
+			foreach(['INDEX_AS_IDNO', 'INDEX_ANCESTORS', 'CHILDREN_INHERIT', 'ANCESTORS_INHERIT', 'INDEX_AS_MIMETYPE'] as $k) {
+				if(in_array($k, $ap['indexing_options'], true) || isset($ap['indexing_options'][$k])) { return true; }
+			}
+		}
+		return false;
 	}
 	# -------------------------------------------------------
 }


### PR DESCRIPTION
PR addresses SqlSearch2 issue where field-level searches on fields using modified indexing ('INDEX_AS_IDNO', 'INDEX_ANCESTORS', 'CHILDREN_INHERIT', 'ANCESTORS_INHERIT', 'INDEX_AS_MIMETYPE') would not manifest indexing effects due to SqlSearch2 performing queries directly on the underlying data.

SqlSearch2 will now use the index when these modifiers are present in search_indexing.conf