### PR TITLE
Bump library version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "laminas/laminas-stdlib": "*",
     "laminas/laminas-escaper": "*",
     "league/climate": ">=1.0.0",
-    "league/flysystem": "v1.0.45",
+    "league/flysystem": ">=1.1.4",
     "league/flysystem-aws-s3-v3": ">=1.0.0",
     "league/flysystem-cached-adapter": ">=1.0.0",
     "league/flysystem-webdav": ">=1.0.0",


### PR DESCRIPTION
PR bumps version of flysystem library include due to reported security vulnerability.