### PR TITLE
Impovements to movement-based location tracking

### DIFF
--- a/app/lib/BaseObject.php
+++ b/app/lib/BaseObject.php
@@ -124,11 +124,38 @@
 			return true;
 		}
 		# ------------------------------------------------------------------
+		/**
+		 * Check if object has experienced an error with a given numeric code.
+		 *
+		 * @param int $error_num
+		 * @param string $source Optional source to limit errors to. [Default is null; check all errors]
+		 *
+		 * return bool
+		 */
 		public function hasErrorNum(int $error_num, ?string $source=null) : bool {
 			$errors = $this->errors($source);
 			
 			foreach($errors as $e) {
 				if($e->getErrorNumber() == $error_num) { return true; }
+			}
+			return false;
+		}
+		# ------------------------------------------------------------------
+		/**
+		 * Check if object has experienced an error within a range of codes.
+		 *
+		 * @param int $start Start of error code range.
+		 * @param int $end End of error code range.
+		 * @param string $source Optional source to limit errors to. [Default is null; check all errors]
+		 *
+		 * return bool
+		 */
+		public function hasErrorNumInRange(int $start, int $end, ?string $source=null) : bool {
+			$errors = $this->errors($source);
+			
+			foreach($errors as $e) {
+				$error_num = $e->getErrorNumber();
+				if(($error_num >= $start) && ($error_num <= $end)) { return true; }
 			}
 			return false;
 		}

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -260,3 +260,8 @@
 
 # --- Location tracking errors
 3600 = Cannot create movement
+3605 = Could not create storage location - movement relationship for history tracking
+3610 = Could not create storage location - movement original parent relationship for history tracking
+3615 = Could not create storage location - movement new parent relationship for history tracking
+3620 = Could not create storage location - movement new sub-location relationship for history tracking
+3625 = Could not create movement to related item relationship for history tracking

--- a/app/models/ca_storage_locations.php
+++ b/app/models/ca_storage_locations.php
@@ -523,26 +523,23 @@ class ca_storage_locations extends RepresentableBaseModel implements IBundleProv
 						// Link movement to storage location
 						if (!$t_movement->addRelationship('ca_storage_locations', $this->getPrimaryKey(), $policy_config['useRelatedRelationshipType'])) {
 							if($this->inTransaction()) { $this->removeTransaction(false); }
-							throw new ApplicationException(
-								_t('Could not create storage location - movement relationship for history tracking: %1', join($t_movement->getErrors()))
-							);
+							$this->postError(3605, _t('Could not create storage location - movement relationship for history tracking: %1', join($t_movement->getErrors())), 'ca_storage_locations::saveBundlesForScreen()');
+							return false;
 						}
 						
 						// Link movement to old parent location and new parent location
 						if(isset($policy_config['originalLocationTrackingRelationshipType'])) {
 							if (!$t_movement->addRelationship('ca_storage_locations', $old_parent_id, $policy_config['originalLocationTrackingRelationshipType'])) {
 								if($this->inTransaction()) { $this->removeTransaction(false); }
-								throw new ApplicationException(
-									_t('Could not create storage location - movement original parent relationship for history tracking: %1', join($t_movement->getErrors()))
-								);
+								$this->postError(3610, _t('Could not create storage location - movement original parent relationship for history tracking: %1', join($t_movement->getErrors())), 'ca_storage_locations::saveBundlesForScreen()');
+								return false;
 							}
 						}
 						if(isset($policy_config['newLocationTrackingRelationshipType'])) {
 							if (!$t_movement->addRelationship('ca_storage_locations', $new_parent_id, $policy_config['newLocationTrackingRelationshipType'])) {
 								if($this->inTransaction()) { $this->removeTransaction(false); }
-								throw new ApplicationException(
-									_t('Could not create storage location - movement new parent relationship for history tracking: %1', join($t_movement->getErrors()))
-								);
+								$this->postError(3615, _t('Could not create storage location - movement new parent relationship for history tracking: %1', join($t_movement->getErrors())), 'ca_storage_locations::saveBundlesForScreen()');
+								return false;
 							}
 						}
 						
@@ -553,9 +550,8 @@ class ca_storage_locations extends RepresentableBaseModel implements IBundleProv
 							foreach($sub_location_ids as $sub_location_id) {
 								if (!$t_movement->addRelationship('ca_storage_locations', $sub_location_id, $policy_config['subLocationTrackingRelationshipType'])) {
 									if($this->inTransaction()) { $this->removeTransaction(false); }
-									throw new ApplicationException(
-										_t('Could not create storage location - movement new sub-location relationship for history tracking: %1', join($t_movement->getErrors()))
-									);
+									$this->postError(3620, _t('Could not create storage location - movement new sub-location relationship for history tracking: %1', join($t_movement->getErrors())), 'ca_storage_locations::saveBundlesForScreen()');
+									return false;
 								}
 							}
 						}
@@ -568,9 +564,8 @@ class ca_storage_locations extends RepresentableBaseModel implements IBundleProv
 						foreach($content_ids as $content_id) {
 							if(!$t_movement->addRelationship($policy['table'], $content_id, $policy_config['trackingRelationshipType'])) {
 								if($this->inTransaction()) { $this->removeTransaction(false); }
-								throw new ApplicationException(
-									_t('Could not create movement - %1 relationship for history tracking: %2', $policy['table'], join($t_movement->getErrors()))
-								);
+								$this->postError(3625, _t('Could not create movement - %1 relationship for history tracking: %2', $policy['table'], join($t_movement->getErrors())), 'ca_storage_locations::saveBundlesForScreen()');
+								return false;
 							}
 						}
 					}

--- a/assets/ca/ca.genericbundle.js
+++ b/assets/ca/ca.genericbundle.js
@@ -6,7 +6,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2020 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -228,6 +228,15 @@ var caUI = caUI || {};
 				}
 			}
 
+			// Set default value for new items
+			var is_new = id ? false : true;
+			if (!id) {
+				jQuery.each(this.defaultValues, function(k, v) {
+					if (v && !templateValues[k]) { templateValues[k] = v; }
+				});
+				id = 'new_' + this.getCount();	// set id to ensure sub-fields get painted with unsaved warning handler
+			}
+		
 			// print out any errors
 			var errStrs = [];
 			if (this.errors && this.errors[id]) {
@@ -239,15 +248,6 @@ var caUI = caUI || {};
 
 			templateValues.error = errStrs.join('<br/>');
 			templateValues.fieldNamePrefix = this.fieldNamePrefix; // always pass field name prefix to template
-
-			// Set default value for new items
-			var is_new = id ? false : true;
-			if (!id) {
-				jQuery.each(this.defaultValues, function(k, v) {
-					if (v && !templateValues[k]) { templateValues[k] = v; }
-				});
-				id = 'new_' + this.getCount();	// set id to ensure sub-fields get painted with unsaved warning handler
-			}
 
 			// replace values in template
 			var jElement = jQuery(this.container + ' textarea.' + (isNew ? this.templateClassName : this.initialValueTemplateClassName)).template(templateValues);

--- a/assets/ca/ca.relationbundle.js
+++ b/assets/ca/ca.relationbundle.js
@@ -6,7 +6,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -255,7 +255,7 @@ var caUI = caUI || {};
 		
 		var that = caUI.initBundle(container, options);
 		
-		that.triggerQuickAdd = function(q, id) {
+		that.triggerQuickAdd = function(q, id, params=null) {
 			var autocompleter_id = options.fieldNamePrefix + 'autocomplete' + id;
 			var panelUrl = options.quickaddUrl;
 			if (options && options.types) {
@@ -266,6 +266,13 @@ var caUI = caUI || {};
 					panelUrl += '/types/' + options.types;
 				}
 			}
+			
+			if (params && (typeof params === 'object')) {
+				for(var k in params) {
+					panelUrl += '/' + k + '/' + params[k];
+				}
+			}
+			
 			options.quickaddPanel.showPanel(panelUrl, null, null, {q: q, field_name_prefix: options.fieldNamePrefix});
 			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteRawID', id);
 			jQuery('#' + options.quickaddPanel.getPanelContentID()).data('autocompleteInputID', autocompleter_id);

--- a/themes/default/views/bundles/ca_attributes.php
+++ b/themes/default/views/bundles/ca_attributes.php
@@ -162,6 +162,13 @@
 				$va_template_tags[] = "{$vn_element_id}_label";
 			}
 		}
+		
+		// Set element errors an unsaved/new elements
+		if(is_array($va_action_errors = $this->request->getActionErrors($vs_error_source_code))) {
+			foreach($va_action_errors as $o_error) {
+				$va_errors['new_0'][] = array('errorDescription' => $o_error->getErrorDescription(), 'errorCode' => $o_error->getErrorNumber());
+			}
+		}
 	}
 	
 	// bundle settings
@@ -194,20 +201,20 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 	
 	
 ?>
-<div id="<?php print $vs_id_prefix; ?>" <?php print $vb_batch ? "class='editorBatchBundleContent'" : ''; ?>>
+<div id="<?= $vs_id_prefix; ?>" <?= $vb_batch ? "class='editorBatchBundleContent'" : ''; ?>>
 <?php
 	//
 	// The bundle template - used to generate each editing bundle in the form
 	//
 ?>
 	<textarea class='caItemTemplate' style='display: none;'>
-		<div id="<?php print $vs_id_prefix; ?>Item_{n}" class="labelInfo repeatingItem" style="clear: both;">	
+		<div id="<?= $vs_id_prefix; ?>Item_{n}" class="labelInfo repeatingItem" style="clear: both;">	
 			<span class="formLabelError">{error}</span>
 <?php
 	if (($vs_render_mode !== 'checklist') && !$vb_read_only) {		// static (non-repeating) checkbox list for list attributes
 ?>
 			<div style="float: right;">
-				<a href="#" class="caDeleteItemButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a>
+				<a href="#" class="caDeleteItemButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a>
 			</div>				
 <?php
 	}
@@ -220,7 +227,7 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 		$va_template_list = caGetAvailablePrintTemplates('bundles', array('table' => $t_instance->tableName(), 'restrictToTypes' => $t_instance->getTypeID(), 'elementCode' => $t_element->get('element_code'), 'forHTMLSelect' => true));
 		if (sizeof($va_template_list) > 0) {
 ?>
-		<div class='editorBundleValuePrintControl iconButton' id='<?php print $vs_id_prefix; ?>_print_control_{n}'>
+		<div class='editorBundleValuePrintControl iconButton' id='<?= $vs_id_prefix; ?>_print_control_{n}'>
 <?php
 			print (sizeof($va_template_list) > 1) ? caHTMLSelect('template', $va_template_list, array('class' => 'dontTriggerUnsavedChangeWarning', 'id' => "{$vs_id_prefix}PrintTemplate{n}")) : caHTMLHiddenInput('template', array('value' => array_pop($va_template_list), 'id' => "{$vs_id_prefix}PrintTemplate{n}"));
 			print "<a href='#' onclick='{$vs_id_prefix}Print({n}); return false;'>".caNavIcon(__CA_NAV_ICON_PDF__, 1)."</a>";
@@ -259,13 +266,13 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 		//
 ?>
 	<textarea class='caExistingItemTemplate' style='display: none;'>
-		<div id="<?php print $vs_id_prefix; ?>Item_{n}" class="labelInfo roundedRel caRelatedItem">
+		<div id="<?= $vs_id_prefix; ?>Item_{n}" class="labelInfo roundedRel caRelatedItem">
 		
-			<span id='<?php print $vs_id_prefix; ?>_BundleTemplateDisplay{n}'>{<?php print "{$root_element_id}_label"; ?>}</span>
-			<?php print caHTMLHiddenInput($vs_id_prefix.'_'.$root_element_id.'_{n}', ['value' => '{'.$root_element_id.'}']); ?>	
+			<span id='<?= $vs_id_prefix; ?>_BundleTemplateDisplay{n}'>{<?= "{$root_element_id}_label"; ?>}</span>
+			<?= caHTMLHiddenInput($vs_id_prefix.'_'.$root_element_id.'_{n}', ['value' => '{'.$root_element_id.'}']); ?>	
 <?php
 			if (!$vb_read_only && !$vb_dont_show_del) {
-?><a href="#" class="caDeleteItemButton"><?php print caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a><?php
+?><a href="#" class="caDeleteItemButton"><?= caNavIcon(__CA_NAV_ICON_DEL_BUNDLE__, 1); ?></a><?php
 	}
 ?>
 		</div>
@@ -289,16 +296,16 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 <?php
 					foreach($va_readonly_previews as $vn_attr_id => $vs_readonly_preview) {
 ?>
-						<div class="caReadonlyContainer" id="caReadonlyContainer<?php print $vs_id_prefix.'_'.$vn_attr_id; ?>">
-							<a class="caReadonlyContainerEditLink" id="caContainerEditLink<?php print $vs_id_prefix.'_'.$vn_attr_id; ?>" href="#"><?php print _t('Edit'); ?></a>
-							<div class="caReadonlyContainerDisplay"><?php print $vs_readonly_preview; ?></div>
+						<div class="caReadonlyContainer" id="caReadonlyContainer<?= $vs_id_prefix.'_'.$vn_attr_id; ?>">
+							<a class="caReadonlyContainerEditLink" id="caContainerEditLink<?= $vs_id_prefix.'_'.$vn_attr_id; ?>" href="#"><?= _t('Edit'); ?></a>
+							<div class="caReadonlyContainerDisplay"><?= $vs_readonly_preview; ?></div>
 						</div>
 						<script type="text/javascript">
 							jQuery(document).ready(function() {
-								jQuery("#caContainerEditLink<?php print $vs_id_prefix . '_' . $vn_attr_id; ?>").click(function () {
-									jQuery('#<?php print $vs_id_prefix; ?>Item_<?php print $vn_attr_id; ?>').show();
-									jQuery('#caReadonlyContainer<?php print $vs_id_prefix.'_'.$vn_attr_id; ?>').hide();
-									jQuery('input[name="<?php print $vs_id_prefix.'_dont_save_'.$vn_attr_id; ?>"]').val('0');
+								jQuery("#caContainerEditLink<?= $vs_id_prefix . '_' . $vn_attr_id; ?>").click(function () {
+									jQuery('#<?= $vs_id_prefix; ?>Item_<?= $vn_attr_id; ?>').show();
+									jQuery('#caReadonlyContainer<?= $vs_id_prefix.'_'.$vn_attr_id; ?>').hide();
+									jQuery('input[name="<?= $vs_id_prefix.'_dont_save_'.$vn_attr_id; ?>"]').val('0');
 								});
 							});
 						</script>
@@ -316,7 +323,7 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 <?php
 	if (($vs_render_mode !== 'checklist') && !$vb_read_only) {
 ?>
-		<div class='button labelInfo caAddItemButton'><a href='#'><?php print caNavIcon(__CA_NAV_ICON_ADD__, "15px"); ?> <?php print $vs_add_label; ?></a></div>
+		<div class='button labelInfo caAddItemButton'><a href='#'><?= caNavIcon(__CA_NAV_ICON_ADD__, "15px"); ?> <?= $vs_add_label; ?></a></div>
 <?php
 	}
 ?>
@@ -330,21 +337,21 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 	}
 	if ($vs_render_mode === 'checklist') {
 ?>
-		caUI.initChecklistBundle('#<?php print $vs_id_prefix; ?>', {
-			fieldNamePrefix: '<?php print $vs_id_prefix; ?>_',
-			templateValues: [<?php print join(',', caQuoteList($va_template_tags)); ?>],
-			initialValues: <?php print json_encode($va_initial_values); ?>,
-			initialValueOrder: <?php print json_encode(array_keys($va_initial_values)); ?>,
-			errors: <?php print json_encode($va_errors); ?>,
-			itemID: '<?php print $vs_id_prefix; ?>Item_',
+		caUI.initChecklistBundle('#<?= $vs_id_prefix; ?>', {
+			fieldNamePrefix: '<?= $vs_id_prefix; ?>_',
+			templateValues: [<?= join(',', caQuoteList($va_template_tags)); ?>],
+			initialValues: <?= json_encode($va_initial_values); ?>,
+			initialValueOrder: <?= json_encode(array_keys($va_initial_values)); ?>,
+			errors: <?= json_encode($va_errors); ?>,
+			itemID: '<?= $vs_id_prefix; ?>Item_',
 			templateClassName: 'caItemTemplate',
 			itemListClassName: 'caItemList',
-			minRepeats: <?php print ($vn_n = $this->getVar('min_num_repeats')) ? $vn_n : 0 ; ?>,
-			maxRepeats: <?php print ($vn_n = $this->getVar('max_num_repeats')) ? $vn_n : 65535; ?>,
-			defaultValues: <?php print json_encode($va_element_value_defaults); ?>,
-			bundlePreview: <?php print caEscapeForBundlePreview($vs_bundle_preview); ?>,
-			readonly: <?php print $vb_read_only ? "1" : "0"; ?>,
-			defaultLocaleID: <?php print ca_locales::getDefaultCataloguingLocaleID(); ?>
+			minRepeats: <?= ($vn_n = $this->getVar('min_num_repeats')) ? $vn_n : 0 ; ?>,
+			maxRepeats: <?= ($vn_n = $this->getVar('max_num_repeats')) ? $vn_n : 65535; ?>,
+			defaultValues: <?= json_encode($va_element_value_defaults); ?>,
+			bundlePreview: <?= caEscapeForBundlePreview($vs_bundle_preview); ?>,
+			readonly: <?= $vb_read_only ? "1" : "0"; ?>,
+			defaultLocaleID: <?= ca_locales::getDefaultCataloguingLocaleID(); ?>
 		});
 <?php	
 	} else {
@@ -357,46 +364,46 @@ if (caGetOption('canMakePDF', $va_element_info[$root_element_id]['settings'], fa
 ?>
 			var bundleFormElement = jQuery("#" + element.container.replace('#', '') + "Item_" + attribute_id);
 			bundleFormElement.hide();
-			bundleFormElement.after(jQuery('#caReadonlyContainer<?php print $vs_id_prefix?>_' + attribute_id));
+			bundleFormElement.after(jQuery('#caReadonlyContainer<?= $vs_id_prefix?>_' + attribute_id));
 <?php
 		}
 ?>
 		};
-		caUI.initBundle('#<?php print $vs_id_prefix; ?>', {
-			fieldNamePrefix: '<?php print $vs_id_prefix; ?>_',
-			templateValues: [<?php print join(',', caQuoteList($va_template_tags)); ?>],
-			initialValues: <?php print json_encode($va_initial_values); ?>,
-			initialValueOrder: <?php print json_encode(array_keys($va_initial_values)); ?>,
-			forceNewValues: <?php print json_encode($va_failed_inserts); ?>,
-			errors: <?php print json_encode($va_errors); ?>,
-			itemID: '<?php print $vs_id_prefix; ?>Item_',
+		caUI.initBundle('#<?= $vs_id_prefix; ?>', {
+			fieldNamePrefix: '<?= $vs_id_prefix; ?>_',
+			templateValues: [<?= join(',', caQuoteList($va_template_tags)); ?>],
+			initialValues: <?= json_encode($va_initial_values); ?>,
+			initialValueOrder: <?= json_encode(array_keys($va_initial_values)); ?>,
+			forceNewValues: <?= json_encode($va_failed_inserts); ?>,
+			errors: <?= json_encode($va_errors); ?>,
+			itemID: '<?= $vs_id_prefix; ?>Item_',
 			templateClassName: 'caItemTemplate',
-			initialValueTemplateClassName: '<?php print $minimize_existing_values ?  'caExistingItemTemplate' : 'caItemTemplate'; ?>',
+			initialValueTemplateClassName: '<?= $minimize_existing_values ?  'caExistingItemTemplate' : 'caItemTemplate'; ?>',
 			itemListClassName: 'caItemList',
 			addButtonClassName: 'caAddItemButton',
 			deleteButtonClassName: 'caDeleteItemButton',
-			minRepeats: <?php print ($vn_n = $this->getVar('min_num_repeats')) ? $vn_n : 0 ; ?>,
-			maxRepeats: <?php print ($vn_n = $this->getVar('max_num_repeats')) ? $vn_n : 65535; ?>,
-			showEmptyFormsOnLoad: <?php print intval($this->getVar('min_num_to_display')); ?>,
-			hideOnNewIDList: ['<?php print $vs_id_prefix; ?>_download_control_', '<?php print $vs_id_prefix; ?>_print_control_',],
-			showOnNewIDList: ['<?php print $vs_id_prefix; ?>_upload_control_'],
-			defaultValues: <?php print json_encode($va_element_value_defaults); ?>,
-			bundlePreview: <?php print caEscapeForBundlePreview($vs_bundle_preview); ?>,
-			readonly: <?php print $vb_read_only ? "1" : "0"; ?>,
-			defaultLocaleID: <?php print ca_locales::getDefaultCataloguingLocaleID(); ?>,
+			minRepeats: <?= ($vn_n = $this->getVar('min_num_repeats')) ? $vn_n : 0 ; ?>,
+			maxRepeats: <?= ($vn_n = $this->getVar('max_num_repeats')) ? $vn_n : 65535; ?>,
+			showEmptyFormsOnLoad: <?= intval($this->getVar('min_num_to_display')); ?>,
+			hideOnNewIDList: ['<?= $vs_id_prefix; ?>_download_control_', '<?= $vs_id_prefix; ?>_print_control_',],
+			showOnNewIDList: ['<?= $vs_id_prefix; ?>_upload_control_'],
+			defaultValues: <?= json_encode($va_element_value_defaults); ?>,
+			bundlePreview: <?= caEscapeForBundlePreview($vs_bundle_preview); ?>,
+			readonly: <?= $vb_read_only ? "1" : "0"; ?>,
+			defaultLocaleID: <?= ca_locales::getDefaultCataloguingLocaleID(); ?>,
 			onInitializeItem: caHideBundlesForReadOnlyContainers, /* todo: look for better callback (or make one up?) */
 			
 			listItemClassName: 'repeatingItem',
-			oddColor: '<?php print caGetOption('colorOddItem', $va_settings, 'FFFFFF'); ?>',
-			evenColor: '<?php print caGetOption('colorEvenItem', $va_settings, 'FFFFFF'); ?>'
+			oddColor: '<?= caGetOption('colorOddItem', $va_settings, 'FFFFFF'); ?>',
+			evenColor: '<?= caGetOption('colorEvenItem', $va_settings, 'FFFFFF'); ?>'
 		});
 <?php
 	}
 ?>
 	
-	function <?php print $vs_id_prefix; ?>Print(attribute_id) {
+	function <?= $vs_id_prefix; ?>Print(attribute_id) {
 		if (!attribute_id) { attribute_id = ''; }
-		var template = jQuery('#<?php print $vs_id_prefix; ?>PrintTemplate' + attribute_id).val();
-		window.location = '<?php print caNavUrl($this->request, '*', '*', 'PrintBundle', array('element_code' => $t_element->get('element_code'), $t_instance->primaryKey() => $t_instance->getPrimaryKey())); ?>/template/' + template + '/attribute_id/' + attribute_id;
+		var template = jQuery('#<?= $vs_id_prefix; ?>PrintTemplate' + attribute_id).val();
+		window.location = '<?= caNavUrl($this->request, '*', '*', 'PrintBundle', array('element_code' => $t_element->get('element_code'), $t_instance->primaryKey() => $t_instance->getPrimaryKey())); ?>/template/' + template + '/attribute_id/' + attribute_id;
 	}
 </script>

--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -101,7 +101,7 @@
 <?php
 				} else {
 ?>
-					<div style='float: left;' class='button caAddMovementButton'><a href="#" id="<?= $vs_id_prefix; ?>AddMovement" onclick='caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd("", "new_0"); return false;'><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('movement_control_label', $settings, _t('Add to movement')); ?></a></div>					
+					<div style='float: left;' class='button caAddMovementButton'><a href="#" id="<?= $vs_id_prefix; ?>AddMovement" onclick='caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd("", "new_0", { usePolicy: <?= json_encode($policy); ?> }); return false;'><?= caNavIcon(__CA_NAV_ICON_ADD__, '15px'); ?> <?= caGetOption('movement_control_label', $settings, _t('Add to movement')); ?></a></div>					
 <?php
 				}
 			}

--- a/themes/default/views/editor/movements/quickadd_html.php
+++ b/themes/default/views/editor/movements/quickadd_html.php
@@ -75,7 +75,8 @@
 					'request' => $this->request, 
 					'restrictToTypes' => array($t_subject->get('type_id')),
 					'formName' => $vs_form_name.$vs_field_name_prefix.$vs_n,
-					'forceLabelForNew' => $this->getVar('forceLabel')							// force query text to be default in label fields
+					'forceLabelForNew' => $this->getVar('forceLabel'),							// force query text to be default in label fields
+					'policy' => $this->request->getParameter('usePolicy', pString)
 			));
 			
 			print join("\n", $va_form_elements);


### PR DESCRIPTION
PR includes various fixes and improvements to movement-based location tracking, including:

1. Automatic restriction of movement-record based storage location relationship bundle to policy-configured type (previously it would show all types available in the editor, which would often result in movements without appropriately linked locations).
2. Reworked error checking for storage location move-specific movement form.