### PR TITLE
Oops

### DIFF
--- a/app/lib/ApplicationChangeLog.php
+++ b/app/lib/ApplicationChangeLog.php
@@ -1026,12 +1026,6 @@ require_once(__CA_LIB_DIR__."/Db.php");
 			$params[] = $d['start']; $params[] = $d['end'];
 		}
 		
-		$sql_changetype = null;
-		if(!is_null($changetype)) {
-			$sql_changetype = "AND (wcl.changetype = ?)";
-			$params[] = $changetype;
-		}
-		
 		$sql_user_id = null;
 		if($user_id) {
 			if (!is_array($user_id)) { $user_id = [$user_id]; }
@@ -1039,6 +1033,12 @@ require_once(__CA_LIB_DIR__."/Db.php");
 		    	$sql_user_id = "AND (wcl.user_id IN (?))";
 				$params[] = $user_id;
 			}
+		}
+
+		$sql_changetype = null;
+		if(in_array($changetype, ['I', 'U', 'D'], true)) {
+			$sql_changetype = "AND (wcl.changetype = ?)";
+			$params[] = $changetype;
 		}
 		
 		if (!$sql_table) { $sql_table = "1"; }


### PR DESCRIPTION
PR adds display option for text elements to control how line breaks are rendered. Two modes are now supported: as-is (default) and conversion to HTML breaks.