### PR TITLE
Miscellaneous fixes

### DIFF
--- a/app/helpers/errorHelpers.php
+++ b/app/helpers/errorHelpers.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015-2018 Whirl-i-Gig
+ * Copyright 2015-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -137,7 +137,7 @@ function caExtractRequestParams() {
 	$o_purifier = new HTMLPurifier();
 	$pa_params = [];
 	foreach($_REQUEST as $vs_k => $vm_val) {
-		if(is_array($vs_k)) { $vs_k = join(',', caFlattenArray($vs_k));}
+		if(is_array($vm_val)) { $vm_val = join(',', caFlattenArray($vm_val));}
 		if($vs_k == 'password') { continue; } // don't dump plain text passwords on screen
 		$pa_params[$o_purifier->purify($vs_k)] = $o_purifier->purify($vm_val);
 	}

--- a/app/lib/Configuration.php
+++ b/app/lib/Configuration.php
@@ -1116,7 +1116,7 @@ class Configuration {
 	}
 	/* ---------------------------------------- */
 	/**
-	 * Removes all cached configuration
+	 * Remove all cached configuration
 	 */
 	public static function clearCache() {
 		ExternalCache::flush('ConfigurationCache');

--- a/app/lib/ConfigurationExporter.php
+++ b/app/lib/ConfigurationExporter.php
@@ -449,15 +449,21 @@ final class ConfigurationExporter {
 				foreach($t_element->getSettings() as $vs_setting => $va_values) {
 					if(is_null($va_values)) { continue; }
 					if(!is_array($va_values)) { $va_values = array($va_values); }
+					
+					switch($vs_setting) {
+						case 'restrictToTypes':
+						case 'restrict_to_types':
+							// Convert authority type restriction
+							if ($t = AuthorityAttributeValue::elementTypeToInstance($t_element->get('datatype'))) {
+								$va_values = caMakeTypeList($t->tableName(), $va_values);
+							}
+							break;
+					}
 					foreach($va_values as $vs_value) {
 						if ($t_element->isValidSetting($vs_setting)) {
 							// we export all settings (not just non-default) when we're running diff exports ..
 							// otherwise we only care about non default ones
 							if($this->opn_modified_after || ($vs_value != $va_available_settings[$vs_setting]["default"])) {
-								if ($vs_setting === 'restrictToTypes'){
-									$t_item = new ca_list_items($vs_value);
-									$vs_value = $t_item->get('idno');
-								}
 								$vo_setting = $this->opo_dom->createElement("setting", caEscapeForXML($vs_value));
 								$vo_setting->setAttribute("name", $vs_setting);
 								$vo_settings->appendChild($vo_setting);

--- a/app/lib/ModelSettings.php
+++ b/app/lib/ModelSettings.php
@@ -552,7 +552,7 @@ trait ModelSettings {
 							$va_type_opts[$va_type_info['idno']] = $vn_type_id;
 						}
 					} else { // "normal" (list-based) type restriction
-						$vs_select_element = $t_show_types_for_table->getTypeListAsHTMLFormElement($vs_input_name.(($vn_height > 1) ? '[]' : ''), ['multiple' => ($vn_height > 1), 'width' => $vn_width, 'height' => $vn_height, 'id' => $vs_input_id], ['values' => $vs_value]);
+						$vs_select_element = $t_show_types_for_table->getTypeListAsHTMLFormElement($vs_input_name.(($vn_height > 1) ? '[]' : ''), ['multiple' => ($vn_height > 1), 'width' => $vn_width, 'height' => $vn_height, 'id' => $vs_input_id], ['values' => $vs_value, 'nullOption' => '', 'useDefaultWhenNull' => false]);
 					}
 					
 					if($vs_select_element == '') {

--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2020 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -38,13 +38,11 @@
 # --- Import classes
 # ----------------------------------------------------------------------
 include_once(__CA_LIB_DIR__."/BaseObject.php");
-include_once(__CA_LIB_DIR__."/Datamodel.php");
 include_once(__CA_LIB_DIR__."/Media/MediaInfoCoder.php");
 include_once(__CA_LIB_DIR__."/File/FileInfoCoder.php");
 include_once(__CA_LIB_DIR__."/Parsers/TimeExpressionParser.php");
 include_once(__CA_LIB_DIR__."/Parsers/TimecodeParser.php");
 include_once(__CA_LIB_DIR__."/ApplicationChangeLog.php");
-include_once(__CA_MODELS_DIR__."/ca_locales.php");
 
 
 # ----------------------------------------------------------------------
@@ -108,7 +106,7 @@ class SearchResult extends BaseObject {
 	 *		hierarchy_siblings_prefetch_cache_index
 	 *		hierarchy_children_prefetch_cache_index
 	 */
-	static $s_cache_size_limit = 256;
+	static $s_cache_size_limit = 2048;
 
 	# ------------------------------------------------------------------
 	private $opb_disable_get_with_template_prefetch = false;

--- a/app/models/ca_site_pages.php
+++ b/app/models/ca_site_pages.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2016-2017 Whirl-i-Gig
+ * Copyright 2016-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -104,7 +104,7 @@ BaseModel::$s_ca_models_definitions['ca_site_pages'] = array(
 				'DISPLAY_WIDTH' => 100, 'DISPLAY_HEIGHT' => 5,
 				'IS_NULL' => false, 
 				'DEFAULT' => '',
-				'LABEL' => _t('Page metdata: keywords'), 'DESCRIPTION' => _t('Optional keywords for this page.')
+				'LABEL' => _t('Page metadata: keywords'), 'DESCRIPTION' => _t('Optional keywords for this page.')
 		),
 		'deleted' => array(
 				'FIELD_TYPE' => FT_BIT, 'DISPLAY_TYPE' => DT_OMIT, 
@@ -335,6 +335,7 @@ class ca_site_pages extends BundlableLabelableBaseModelWithAttributes {
 	 * @return string Returns null if page cannot be rendered
 	 */
 	public static function renderPageForPath($po_controller, $ps_path, $options=null) {
+		$ps_path = preg_replace("!/_default$!", "", $ps_path);	// strip default path component if present
 		if (
 			(
 				is_numeric($ps_path) 


### PR DESCRIPTION
PR provides miscellaneous fixes, including:

    1. Fix typos in comments
    2. Don't set list default in item type settings UI element
    3. Honor _default paths in site pages
    4. Increase searchResult cache size
    5. Ensure restrictToTypes settings in exported profiles use codes, not numeric ids
    6. Properly check array params on exception screen