### PR TITLE
Resolves #1039 - Don't try to cast list-based numeric intrinsics

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -738,7 +738,7 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 			
 			switch($fi['FIELD_TYPE']) {
 				case FT_NUMBER:
-					$ap['element_info']['datatype'] = __CA_ATTRIBUTE_VALUE_NUMERIC__;
+					$ap['element_info']['datatype'] = isset($fi['LIST_CODE']) ? null : __CA_ATTRIBUTE_VALUE_NUMERIC__;
 					break;
 				case FT_HISTORIC_DATERANGE:
 				case FT_DATERANGE:


### PR DESCRIPTION
PR resolves debugging warning when attempting to use idno equivalent to search on numeric intrinsics such as type_id.