### PR TITLE
Live update of multipart idnos broken for newly created records when policy includes a dropdown

### DIFF
--- a/assets/ca/ca.idnochecker.js
+++ b/assets/ca/ca.idnochecker.js
@@ -94,7 +94,7 @@ var caUI = caUI || {};
                         if(that.includesSequence) {
                             for(var k in data.sequences) {
                                 for(var j in that.idnoFormElementIDs) {
-                                    if(that.idnoFormElementIDs[j].match(k)) {
+                                    if(that.idnoFormElementIDs[j] === ('#idno_' + k)) {
                                         jQuery(that.idnoFormElementIDs[j]).html(that.sequenceMessage.replace('%1', data.sequences[k]));
                                     }
                                 }


### PR DESCRIPTION
PR addresses issue where multipart idnos with a drop-down component are rendered incorrectly for newly created records, with the drop-down having no selectable options.