### PR TITLE
Improvements to OAI provder service

### DIFF
--- a/app/conf/oai_provider.conf
+++ b/app/conf/oai_provider.conf
@@ -23,6 +23,10 @@ providers = {
 		# Query
 		query = *,
 		
+		# Optional type restrictions for result set. Use either restrictToTypes or excludeTypes, but not both.
+		restrictToTypes = [],
+		excludeTypes = [],
+		
 		formats = {
 			oai_dc = {
 				mapping = code_of_your_oai_dc_mapping_here,

--- a/app/helpers/accessHelpers.php
+++ b/app/helpers/accessHelpers.php
@@ -65,6 +65,7 @@
 			} else {
 				$va_access = $va_public_access_settings;
 			}
+			if(!is_array($va_access)) { $va_access = []; }
 			
 			if ($po_request->isLoggedIn()) {
 				$va_user_access = $po_request->user->getAccessStatuses(1);

--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -7233,6 +7233,26 @@ if (!$va_facet_info['show_all_when_first_facet'] || ($this->numCriteria() > 0)) 
 		}
 		# ------------------------------------------------------
 		/**
+		 * When type exclusions are specified, the browse will only browse upon items that are not of the specified types.
+		 * If you specify a type that has hierarchical children then the children will automatically be included
+		 * in the exclusion. You may pass numeric type_id and alphanumeric type codes interchangeably.
+		 *
+		 * @param array $pa_type_codes_or_ids List of type_id or code values to exclude from browse.  Using a hierarchical parent type will automatically include its children in the exclusion.
+		 * @param array $pa_options Options include
+		 *		dontExpandHierarchically =
+		 * @return boolean True on success, false on failure
+		 */
+		public function setTypeExclusions($pa_type_codes_or_ids, $pa_options=null) {
+			$t_instance = $this->getSubjectInstance();
+			$type_list = array_keys($t_instance->getTypeList());
+			$types_to_exclude = caMakeTypeIDList($this->ops_browse_table_name, $pa_type_codes_or_ids);
+			
+			$type_list = array_filter($type_list, function($v) use ($types_to_exclude) { return !in_array($v, $types_to_exclude); });
+		
+			return $this->setTypeRestrictions($type_list, $pa_options);
+		}
+		# ------------------------------------------------------
+		/**
 		 *
 		 *
 		 * @param array $pa_type_codes_or_ids List of type codes or ids

--- a/app/lib/Service/OAIPMHService.php
+++ b/app/lib/Service/OAIPMHService.php
@@ -572,12 +572,23 @@ class OAIPMHService extends BaseService {
 			if($vs_query === '*') {
 				$o_search = caGetSearchInstance($this->table);
 				
+				if(is_array($type_res = caGetOption('restrictToTypes', $this->opa_provider_info, null)) && sizeof($type_res)) {
+					$o_search->setTypeRestrictions($type_res);
+				} elseif(is_array($type_exclusion = caGetOption('excludeTypes', $this->opa_provider_info, null)) && sizeof($type_exclusion)) {
+					$o_search->setTypeExclusions($type_exclusion);
+				}
 				$qr_res = $o_search->search($vs_range ? 'modified:"'.$vs_range.'"' : '*', array('showDeleted' => $vb_show_deleted, 'no_cache' => $vb_dont_cache, 'checkAccess' => $vb_dont_enforce_access_settings ? null : $va_access_values, 'dontFilterByACL' => $this->opa_provider_info['dontFilterByACL']));
 			} else {
 				$o_browse = caGetBrowseInstance($this->table);
 		
 				if ($vs_query) {
 					$o_browse->addCriteria("_search", $vs_query);
+				}
+				
+				if(is_array($type_res = caGetOption('restrictToTypes', $this->opa_provider_info, null)) && sizeof($type_res)) {
+					$o_browse->setTypeRestrictions($type_res);
+				} elseif(is_array($type_exclusion = caGetOption('excludeTypes', $this->opa_provider_info, null)) && sizeof($type_exclusion)) {
+					$o_browse->setTypeExclusions($type_exclusion);
 				}
 			
 				if ($this->opa_provider_info['setFacet'] && $set) {
@@ -590,6 +601,11 @@ class OAIPMHService extends BaseService {
 				$qr_res = $o_browse->getResults();
 			}
 		} else {
+			if(is_array($type_res = caGetOption('restrictToTypes', $this->opa_provider_info, null)) && sizeof($type_res)) {
+				$o_search->setTypeRestrictions($type_res);
+			} elseif(is_array($type_exclusion = caGetOption('excludeTypes', $this->opa_provider_info, null)) && sizeof($type_exclusion)) {
+				$o_search->setTypeExclusions($type_exclusion);
+			}
 			$qr_res = $o_search->search(strlen($this->opa_provider_info['query']) ? $this->opa_provider_info['query'] : "*", array('no_cache' => $vb_dont_cache, 'limitToModifiedOn' => $vs_range, 'showDeleted' => $vb_show_deleted, 'checkAccess' => $vb_dont_enforce_access_settings ? null : $va_access_values, 'dontFilterByACL' => $this->opa_provider_info['dontFilterByACL']));
 		}
 

--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -2259,6 +2259,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 	 * @return BundlableLabelableBaseModelWithAttributes|bool|null
 	 */
 	static public function loadInstanceByID($pn_record_id,$pn_table_num, $pa_options=null) {
+		unset($pa_options['start']);
+		unset($pa_options['limit']);
 		if(sizeof(ca_data_exporters::$s_instance_cache)>10) {
 			array_shift(ca_data_exporters::$s_instance_cache);
 		}


### PR DESCRIPTION
PR adds restrictToTypes and excludeTypes option to OAI provider, allowing restriction of results to specific record types, as requested in GitHub issue #1024. Also resolves issue where provider could experience fatal error due to incorrect seeking through returned result set.

