### PR TITLE
Save compressed files

### DIFF
--- a/app/lib/Plugins/Media/PDFWand.php
+++ b/app/lib/Plugins/Media/PDFWand.php
@@ -597,7 +597,9 @@ class WLPlugMediaPDFWand Extends BaseMediaPlugin implements IWLPlugMedia {
 					}
 				}
 				$va_files[] = "{$ps_filepath}.{$vs_ext}";
-			} elseif (!copy($this->filepath, $ps_filepath.".pdf")) {
+			} elseif(copy($this->filepath, $ps_filepath.".pdf")) {
+				$va_files[] = $ps_filepath.".pdf";
+			} else {
 				$this->postError(1610, _t("Couldn't write file to '%1'", $ps_filepath), "WLPlugPDFWand->write()");
 				return false;
 			}


### PR DESCRIPTION
PR resolves issue where presence of compressed derivative PDF file could cause save of PDFs into media metadata elements to fail.