### PR TITLE
Fix ranges with no spaces around dash separator

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -854,7 +854,7 @@ class TimeExpressionParser {
 			if (intval($va_matches[2]) > 12) {
 				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})(\/|$)/", "$1-".substr($va_matches[1], 0, 2)."$2$3", $ps_expression);
 			} else {
-				$ps_expression = preg_replace("/([\d]{4})-([\d]{2})(\/|$)/", "$1#$2$3", $ps_expression);
+				$ps_expression = preg_replace("/(?<![\/#\-])([\d]{4})-([\d]{2})(\/|$)/", "$1#$2$3", $ps_expression);
 			}
 		}
 		

--- a/tests/lib/Parsers/TimeExpressionParserTest.php
+++ b/tests/lib/Parsers/TimeExpressionParserTest.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -1898,5 +1898,31 @@ class TimeExpressionParserTest extends TestCase {
 		$this->assertEquals($va_historic['end'], '1970.031023595900');
 		
 		$this->assertEquals($o_tep->getText(), 'before March 10 1970');
+	}
+	
+	function testCompressedRange() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		
+		$this->assertEquals($o_tep->parse("4/21/2010-5/3/2012"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_historic['start'], '2010.042100000000');
+		$this->assertEquals($va_historic['end'], '2012.050323595900');
+		
+		$this->assertEquals($o_tep->parse("04/21/2010-05/3/2012"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+	
+		$this->assertEquals($va_historic['start'], '2010.042100000000');
+		$this->assertEquals($va_historic['end'], '2012.050323595900');
+	}
+	
+	function testSingleDigitDayDate() {
+		$o_tep = new TimeExpressionParser();
+		$o_tep->setLanguage("en_US");
+		
+		$this->assertEquals($o_tep->parse("4/21/2010"), true);
+		$va_historic = $o_tep->getHistoricTimestamps();
+		$this->assertEquals($va_historic['start'], '2010.042100000000');
+		$this->assertEquals($va_historic['end'], '2010.042123595900');
 	}
 }

--- a/tests/models/historyTrackingCurrentValueTest.php
+++ b/tests/models/historyTrackingCurrentValueTest.php
@@ -1,0 +1,151 @@
+<?php
+/** ---------------------------------------------------------------------
+ * tests/models/historyTrackingCurrentValueTest.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage tests
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+use PHPUnit\Framework\TestCase;
+
+require_once(__CA_MODELS_DIR__.'/ca_objects.php');
+require_once(__CA_LIB_DIR__.'/Service/ItemService.php');
+require_once(__CA_BASE_DIR__.'/tests/testsWithData/BaseTestWithData.php');
+
+class historyTrackingCurrentValueTest extends BaseTestWithData {
+	protected $image_id;
+	protected $shelf1_id;
+	protected $shelf2_id;
+	protected $shelf3_id;
+
+	protected function setUp() : void {
+		parent::setUp();
+		
+		$this->image_id = $this->addTestRecord('ca_objects', [
+			'intrinsic_fields' => [
+				'type_id' => 'image',
+			],
+			'preferred_labels' => [
+				[
+					"locale" => "en_US",
+					"name" => "My test image",
+				]
+			]
+		]);
+		$this->assertGreaterThan(0, $this->image_id);
+
+		$this->shelf1_id = $this->addTestRecord('ca_storage_locations', [
+			'intrinsic_fields' => [
+				'type_id' => 'shelf',
+				'idno' => '100',
+			],
+			'preferred_labels' => [
+				[
+					"locale" => "en_US",
+					"name" => "Shelf 1",
+				]
+			]
+		]);
+		$this->assertGreaterThan(0, $this->shelf1_id);
+		
+
+		$this->shelf2_id = $this->addTestRecord('ca_storage_locations', [
+			'intrinsic_fields' => [
+				'type_id' => 'shelf',
+				'idno' => '200',
+			],
+			'preferred_labels' => [
+				[
+					"locale" => "en_US",
+					"name" => "Shelf 2",
+				]
+			]
+		]);
+		$this->assertGreaterThan(0, $this->shelf2_id);
+		
+
+		$this->shelf3_id = $this->addTestRecord('ca_storage_locations', [
+			'intrinsic_fields' => [
+				'type_id' => 'shelf',
+				'idno' => '200',
+			],
+			'preferred_labels' => [
+				[
+					"locale" => "en_US",
+					"name" => "Shelf 3",
+				]
+			]
+		]);
+		$this->assertGreaterThan(0, $this->shelf3_id);
+	}
+
+	/**
+	 * 
+	 */
+	public function testCurrentValueUusingHistory() {
+		$object = ca_objects::findAsInstance(['object_id' => $this->image_id]);		
+		$rel1 = $object->addRelationship('ca_storage_locations', $this->shelf1_id, 'related', '5/2020');
+		
+		$history = $object->getHistory();
+		$this->assertIsArray($history);
+		$this->assertCount(1, $history);
+		$by_time = array_shift($history);
+		$this->assertIsArray($by_time);
+		$this->assertCount(1, $by_time);
+		$this->assertArrayHasKey('display', $by_time[0]);
+		$this->assertEquals('Shelf 1', $by_time[0]['display']);
+		
+		$rel2 = $object->addRelationship('ca_storage_locations', $this->shelf2_id, 'related', '10/2002');
+		$history = $object->getHistory();
+		
+		$this->assertIsArray($history);
+		$this->assertCount(2, $history);
+		$by_time = array_shift($history);
+		$this->assertIsArray($by_time);
+		$this->assertCount(1, $by_time);
+		$this->assertArrayHasKey('display', $by_time[0]);
+		$this->assertEquals('Shelf 1', $by_time[0]['display']);
+		
+		$rel3 = $object->addRelationship('ca_storage_locations', $this->shelf3_id, 'related', '7/7/2021');
+		$history = $object->getHistory();
+		
+		$this->assertIsArray($history);
+		$this->assertCount(3, $history);
+		$by_time = array_shift($history);
+		$this->assertIsArray($by_time);
+		$this->assertCount(1, $by_time);
+		$this->assertArrayHasKey('display', $by_time[0]);
+		$this->assertEquals('Shelf 3', $by_time[0]['display']);
+		
+		$rel1->delete();
+		$rel2->delete();
+		$rel3->delete();
+	}
+	
+	protected function tearDown() : void {
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
PR resolves issue with date parser where dates ranges using the dash separator with no spaces between dates and separator would fail.