### PR TITLE
Fix various query builder UI errors

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -1899,8 +1899,8 @@
 						if (((int)$sub_element['datatype'] === __CA_ATTRIBUTE_VALUE_CONTAINER__) && ($sub_element['parent_id'] > 0)) { continue; }	// skip sub-containers
 						$sub_element_code = $sub_element['element_code'];
 						
-						if ($sub_element['parent_id'] != $sub_element['hier_element_id']) {	// is root
-							if(!is_array($b)) { $bundles[$b] = []; }
+						if ($sub_element['element_id'] == $sub_element['hier_element_id']) {	// is root
+							if(!is_array($b) && !is_array($bundles[$b])) { $bundles[$b] = []; }
 							$bundles[$b] = array_merge($bundles[$b], [
 								'id' => "{$bundle_info['bundle']}",
 								'bundle' => "{$bundle_info['bundle']}",

--- a/app/lib/Parsers/TimeExpressionParser/en_AU.lang
+++ b/app/lib/Parsers/TimeExpressionParser/en_AU.lang
@@ -54,11 +54,29 @@ dateMYA = [mya]
 # What to use to indicate radiocarbon dates ("before present")
 dateBP = [bp]
 
-dateADIndicator = ad
-dateBCIndicator = bc
+dateADIndicator = CE
+dateBCIndicator = BCE
 ADBCTable = {
-	a.d. = ad,
-	b.c. = bc
+	ad = CE,
+	a.d. = CE,
+	AD = CE,
+	bc = BCE,
+	b.c. = BCE,
+	BC = BCE,
+	c.e. = CE,
+	b.c.e. = BCE,
+	ce = CE,
+	bce = BCE,
+	a.d = CE,
+	a.d. = CE,
+	ad. = CE,
+	c.e = CE,
+	c.e. = CE,
+	ce. = CE,
+	b.c. = BCE,
+	bc. = BCE,
+	b.c = BCE,
+	bce. = BCE
 }
 
 nowDate = [now]
@@ -79,13 +97,21 @@ bornQualifier = [b., b, born]
 # Text to indicate century (as in "20th century")
 centuryIndicator = [century, cent]
 
-# Text to indicate decdae (as in "1920s")
+# Text to indicate decade (as in "1920s")
 decadeIndicator = [s]
 
 # list of numeric suffixes, starting with the one for zero
 # (eg. 0th, 1st, 2nd, 3rd would be a list like so: [th, st, nd, rd])
 ordinalSuffixes = [th, st, nd, rd]
 ordinalSuffixDefault = th
+ordinalSuffixExceptions = {
+	11 = th,
+	12 = th,
+	13 = th
+}
+
+# Words for ordinals from 0 to 20
+ordinalWords = [zeroth, first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth, eleventh, twelfth, thirteenth, fourteenth, fifteenth, sixteenth, seventeenth, eighteenth, nineteenth, twentieth]
 
 # in delimited dates (ex. 12/10/2009) is the first number a month or a day?
 # set to "0" for European style dates (day comes first); "1" for American-style dates (month comes first)

--- a/app/lib/Parsers/TimeExpressionParser/en_CA.lang
+++ b/app/lib/Parsers/TimeExpressionParser/en_CA.lang
@@ -54,11 +54,29 @@ dateMYA = [mya]
 # What to use to indicate radiocarbon dates ("before present")
 dateBP = [bp]
 
-dateADIndicator = ad
-dateBCIndicator = bc
+dateADIndicator = CE
+dateBCIndicator = BCE
 ADBCTable = {
-	a.d. = ad,
-	b.c. = bc
+	ad = CE,
+	a.d. = CE,
+	AD = CE,
+	bc = BCE,
+	b.c. = BCE,
+	BC = BCE,
+	c.e. = CE,
+	b.c.e. = BCE,
+	ce = CE,
+	bce = BCE,
+	a.d = CE,
+	a.d. = CE,
+	ad. = CE,
+	c.e = CE,
+	c.e. = CE,
+	ce. = CE,
+	b.c. = BCE,
+	bc. = BCE,
+	b.c = BCE,
+	bce. = BCE
 }
 
 nowDate = [now]
@@ -79,13 +97,21 @@ bornQualifier = [b., b, born]
 # Text to indicate century (as in "20th century")
 centuryIndicator = [century, cent]
 
-# Text to indicate decdae (as in "1920s")
+# Text to indicate decade (as in "1920s")
 decadeIndicator = [s]
 
 # list of numeric suffixes, starting with the one for zero
 # (eg. 0th, 1st, 2nd, 3rd would be a list like so: [th, st, nd, rd])
 ordinalSuffixes = [th, st, nd, rd]
 ordinalSuffixDefault = th
+ordinalSuffixExceptions = {
+	11 = th,
+	12 = th,
+	13 = th
+}
+
+# Words for ordinals from 0 to 20
+ordinalWords = [zeroth, first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth, eleventh, twelfth, thirteenth, fourteenth, fifteenth, sixteenth, seventeenth, eighteenth, nineteenth, twentieth]
 
 # in delimited dates (ex. 12/10/2009) is the first number a month or a day?
 # set to "0" for European style dates (day comes first); "1" for American-style dates (month comes first)

--- a/app/lib/Parsers/TimeExpressionParser/en_GB.lang
+++ b/app/lib/Parsers/TimeExpressionParser/en_GB.lang
@@ -51,11 +51,32 @@ dateUncertaintyDayIndicator = [d]
 # What to use to indicate a geological date ("millions of years ago")
 dateMYA = [mya]
 
-dateADIndicator = ad
-dateBCIndicator = bc
+# What to use to indicate radiocarbon dates ("before present")
+dateBP = [bp]
+
+dateADIndicator = CE
+dateBCIndicator = BCE
 ADBCTable = {
-	a.d. = ad,
-	b.c. = bc
+	ad = CE,
+	a.d. = CE,
+	AD = CE,
+	bc = BCE,
+	b.c. = BCE,
+	BC = BCE,
+	c.e. = CE,
+	b.c.e. = BCE,
+	ce = CE,
+	bce = BCE,
+	a.d = CE,
+	a.d. = CE,
+	ad. = CE,
+	c.e = CE,
+	c.e. = CE,
+	ce. = CE,
+	b.c. = BCE,
+	bc. = BCE,
+	b.c = BCE,
+	bce. = BCE
 }
 
 nowDate = [now]
@@ -76,13 +97,21 @@ bornQualifier = [b., b, born]
 # Text to indicate century (as in "20th century")
 centuryIndicator = [century, cent]
 
-# Text to indicate decdae (as in "1920s")
+# Text to indicate decade (as in "1920s")
 decadeIndicator = [s]
 
 # list of numeric suffixes, starting with the one for zero
 # (eg. 0th, 1st, 2nd, 3rd would be a list like so: [th, st, nd, rd])
 ordinalSuffixes = [th, st, nd, rd]
 ordinalSuffixDefault = th
+ordinalSuffixExceptions = {
+	11 = th,
+	12 = th,
+	13 = th
+}
+
+# Words for ordinals from 0 to 20
+ordinalWords = [zeroth, first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth, eleventh, twelfth, thirteenth, fourteenth, fifteenth, sixteenth, seventeenth, eighteenth, nineteenth, twentieth]
 
 # in delimited dates (ex. 12/10/2009) is the first number a month or a day?
 # set to "0" for European style dates (day comes first); "1" for American-style dates (month comes first)

--- a/app/lib/Search/Common/Parsers/LuceneSyntaxLexer.php
+++ b/app/lib/Search/Common/Parsers/LuceneSyntaxLexer.php
@@ -1,5 +1,34 @@
 <?php
-
+/** ---------------------------------------------------------------------
+ * app/lib/Search/Common/Parsers/LuceneSyntaxLexer.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2009-2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Search
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
 
 class LuceneSyntaxLexer extends Zend_Search_Lucene_FSM
 {

--- a/app/lib/Search/Common/Parsers/LuceneSyntaxParserContext.php
+++ b/app/lib/Search/Common/Parsers/LuceneSyntaxParserContext.php
@@ -1,5 +1,34 @@
 <?php
-
+/** ---------------------------------------------------------------------
+ * app/lib/Search/Common/Parsers/LuceneSyntaxParserContext.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2009-2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Search
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
 
 class LuceneSyntaxParserContext {
     /**

--- a/app/lib/Search/Common/Parsers/QueryEntry/PhraseQueryEntry.php
+++ b/app/lib/Search/Common/Parsers/QueryEntry/PhraseQueryEntry.php
@@ -1,5 +1,34 @@
 <?php
-
+/** ---------------------------------------------------------------------
+ * app/lib/Search/Common/Parsers/QueryEntry/PhraseQueryEntry.php
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2009-2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Search
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
 
 class PhraseQueryEntry extends Zend_Search_Lucene_Search_QueryEntry {
 	/**
@@ -66,9 +95,10 @@ class PhraseQueryEntry extends Zend_Search_Lucene_Search_QueryEntry {
 	 * @throws Zend_Search_Lucene_Search_QueryParserException
 	 */
 	public function getQuery($encoding) {
-		if (strpos($this->_phrase, '?') !== false || strpos($this->_phrase, '*') !== false) {
-		    throw new Zend_Search_Lucene_Search_QueryParserException('Wildcards are only allowed in a single terms.');
-		}
+		// SqlSearch2 supports this now
+		//if (strpos($this->_phrase, '?') !== false || strpos($this->_phrase, '*') !== false) {
+		//    throw new Zend_Search_Lucene_Search_QueryParserException('Wildcards are only allowed in a single terms.');
+		//}
 
 		$tokens = explode(" ",$this->_phrase);
 

--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -392,7 +392,11 @@ var caUI = caUI || {};
 	        rule.value = queryValue.replace(/^#eq#/, '');
 		} else {
 			rule.value = queryValue;
-			if (wildcardPrefix && wildcardSuffix) {
+			
+			if(queryValue.match(/^\*/) && queryValue.match(/\*$/)) {
+				rule.value = queryValue.replace(/^\*/, "").replace(/\*$/, "");
+				rule.operator = negation ? 'not_contains' : 'contains';
+			} else if (wildcardPrefix && wildcardSuffix) {
 				rule.operator = negation ? 'not_contains' : 'contains';
 			} else if (wildcardPrefix) {
 				rule.operator = negation ? 'not_ends_with' : 'ends_with';


### PR DESCRIPTION
PR addresses issues with query builder user interface:
    
1.  "contains" queries on phrases fail
2.   BCE date queries fail when using en_AU, en_GB and en_CA locales
3.   Some container elements may be omitted from query builder field list