### PR TITLE
Add support for locale-specific replacements in translation.conf "strings" feature

### DIFF
--- a/app/conf/translations.conf
+++ b/app/conf/translations.conf
@@ -1,9 +1,11 @@
 #
 # Keys listed here exactly matching translated text will be
-# converted to values listed here, overriding those in the locale translation. 
-# Note that matching is case-sensitive. Also note that
-# translations are aggressively cached. You may need to clear the application cache after
-# modifying strings for them to take effect.
+# converted to values listed here, overriding those in the locale translation. If the value
+# is a string, it will be used for all locales. You may also specify strings for specific locales
+# by setting the value to an associative array with locale codes and locale-specific values.
+#
+# Note that matching is case-sensitive. Also note that translations are aggressively cached. 
+# You may need to clear the application cache after modifying strings for them to take effect.
 #
 strings = {
     #   existing text = new text

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -74,9 +74,15 @@ $g_translation_cache = [];
 
 function _t($ps_key) {
 	if(!$ps_key) { return ''; }
-	global $_, $g_translation_strings, $g_translation_replacements, $g_translation_cache;
+	global $_, $_locale, $g_translation_strings, $g_translation_replacements, $g_translation_cache;
 	
-	if (isset($g_translation_strings[$ps_key])) { return $g_translation_strings[$ps_key]; }
+	if (
+		isset($g_translation_strings[$ps_key]) && 
+		(
+			is_string($g_translation_strings[$ps_key]) || 
+			(is_array($g_translation_strings[$ps_key]) && isset($g_translation_strings[$ps_key][(string)$_locale]))
+		)
+	) { return is_array($g_translation_strings[$ps_key]) ? $g_translation_strings[$ps_key][(string)$_locale] : $g_translation_strings[$ps_key]; }
 	
 	if(!isset($g_translation_cache[$ps_key])) {
 		if (is_array($_)) {
@@ -4554,5 +4560,18 @@ function caFileIsIncludable($ps_file) {
 			$ret[mb_convert_case($k, (($case === CASE_LOWER) ? MB_CASE_LOWER : MB_CASE_UPPER), "UTF-8")] = (is_array($v) ? caChangeArrayKeyCase($v, $case) : $v );
 		}
 		return $ret;
+	}
+	# ----------------------------------------
+	/**
+	 * Transform comma separated values in the form "Print, Photo" to a serialized version ("Photo Print")
+	 *
+	 * @param string $value Value to transform
+	 *
+	 * @return string Transformed value
+	 */
+	function caSerializeCommaSeparatedName(string $value) {
+		$tmp = array_map("trim", explode(',', $value));
+		$v = array_shift($tmp);
+		return join(" ", $tmp)." {$v}";
 	}
     # ----------------------------------------


### PR DESCRIPTION
PR extends translation.conf "strings" replacement feature to support locale-specific replacements. Previously, string replacements would apply to all locales.