### PR TITLE
Declare ACL constants in post-setup.php 

### DIFF
--- a/app/helpers/post-setup.php
+++ b/app/helpers/post-setup.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2018-2020 Whirl-i-Gig
+ * Copyright 2018-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -285,6 +285,20 @@ if (!defined('__CA_REDIS_PORT__')) {
 if (!defined('__CA_REDIS_DB__')) { 
 	define('__CA_REDIS_DB__', 0);
 }
+
+
+#
+# Access control constants - declared here to ensure
+# They are accessible when parsing configuration files that reference them
+#
+define('__CA_BUNDLE_ACCESS_NONE__', 0);
+define('__CA_BUNDLE_ACCESS_READONLY__', 1);
+define('__CA_BUNDLE_ACCESS_EDIT__', 2);
+
+define('__CA_ACL_NO_ACCESS__', 0);
+define('__CA_ACL_READONLY_ACCESS__', 1);
+define('__CA_ACL_EDIT_ACCESS__', 2);
+define('__CA_ACL_EDIT_DELETE_ACCESS__', 3);
 
 
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -45,9 +45,9 @@ require_once(__CA_LIB_DIR__."/IDNumbering.php");
 require_once(__CA_APP_DIR__."/helpers/accessHelpers.php");
 require_once(__CA_APP_DIR__."/helpers/searchHelpers.php");
 
-define('__CA_BUNDLE_ACCESS_NONE__', 0);
-define('__CA_BUNDLE_ACCESS_READONLY__', 1);
-define('__CA_BUNDLE_ACCESS_EDIT__', 2);
+if(!defined('__CA_BUNDLE_ACCESS_NONE__')) { define('__CA_BUNDLE_ACCESS_NONE__', 0); }
+if(!defined('__CA_BUNDLE_ACCESS_READONLY__')) { define('__CA_BUNDLE_ACCESS_READONLY__', 1); }
+if(!defined('__CA_BUNDLE_ACCESS_READONLY__')) { define('__CA_BUNDLE_ACCESS_READONLY__', 2); }
 
 /**
  * Returned by BundlableLabelableBaseModelWithAttributes::saveBundlesForScreenWillChangeParent() when parent will not be changed

--- a/app/models/ca_acl.php
+++ b/app/models/ca_acl.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2012 Whirl-i-Gig
+ * Copyright 2008-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -35,10 +35,10 @@
    */
  
  
-define('__CA_ACL_NO_ACCESS__', 0);
-define('__CA_ACL_READONLY_ACCESS__', 1);
-define('__CA_ACL_EDIT_ACCESS__', 2);
-define('__CA_ACL_EDIT_DELETE_ACCESS__', 3);
+if(!defined('__CA_ACL_NO_ACCESS__')) { define('__CA_ACL_NO_ACCESS__', 0); }
+if(!defined('__CA_ACL_READONLY_ACCESS__')) { define('__CA_ACL_READONLY_ACCESS__', 1); }
+if(!defined('__CA_ACL_EDIT_ACCESS__')) { define('__CA_ACL_EDIT_ACCESS__', 2); }
+if(!defined('__CA_ACL_EDIT_DELETE_ACCESS__')) { define('__CA_ACL_EDIT_DELETE_ACCESS__', 3); }
  
  BaseModel::$s_ca_models_definitions['ca_acl'] = array(
  	'NAME_SINGULAR' 	=> _t('access control list'),
@@ -439,4 +439,3 @@ class ca_acl extends BaseModel {
 	}
 	# ------------------------------------------------------
 }
-?>


### PR DESCRIPTION
PR declares ACL constants in post-setup.php to ensure they are set prior to parsing of config files. In Pawtucket where ACL may be set by default value, when these constants are not set most data will fail to display. In Providence ACL should be set with user's specific privs, so initialization is not so critical, but we make the change here just in case and for consistency with the Pawtucket code base.