### PR TITLE
Address issue where display template parser will fail to emit content

### DIFF
--- a/app/lib/Parsers/DisplayTemplateParser.php
+++ b/app/lib/Parsers/DisplayTemplateParser.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2015-2020 Whirl-i-Gig
+ * Copyright 2015-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -242,19 +242,25 @@ class DisplayTemplateParser {
 				if(isset($pa_options['sort'])&& is_array($pa_options['sort'])) {
 					$va_vals = caSortArrayByKeyInValue($va_vals, array('__sort__'), $pa_options['sortDirection'], array('dontRemoveKeyPrefixes' => true));
 				}
-				foreach($va_vals as $vn_index => $va_val_list) {
-			        try {
-				        if ($ps_skip_when && ExpressionParser::evaluate($ps_skip_when, $va_val_list)) { continue; }
-					} catch (Exception $e) {
-					    // noop
-					}
+				
+				if(is_array($va_vals) && sizeof($va_vals)) {
+					foreach($va_vals as $vn_index => $va_val_list) {
+						try {
+							if ($ps_skip_when && ExpressionParser::evaluate($ps_skip_when, $va_val_list)) { continue; }
+						} catch (Exception $e) {
+							// noop
+						}
 					
-					$v = is_array($va_val_list) ? DisplayTemplateParser::_processChildren($qr_res, $va_template['tree']->children, $va_val_list, array_merge($pa_options, ['index' => $vn_index, 'returnAsArray' => $pa_options['aggregateUnique']])) : '';
-					if ($pb_index_with_ids) {
-				        $va_proc_templates[$qr_res->get($vs_pk)] = $v;
-				    } else {
-				        $va_proc_templates[] = $v;
-				    }
+						$v = is_array($va_val_list) ? DisplayTemplateParser::_processChildren($qr_res, $va_template['tree']->children, $va_val_list, array_merge($pa_options, ['index' => $vn_index, 'returnAsArray' => $pa_options['aggregateUnique']])) : '';
+						if ($pb_index_with_ids) {
+							$va_proc_templates[$qr_res->get($vs_pk)] = $v;
+						} else {
+							$va_proc_templates[] = $v;
+						}
+					}
+				} elseif(sizeof($va_template['units']) > 0) {
+					$v = DisplayTemplateParser::_processChildren($qr_res, $va_template['tree']->children, [], array_merge($pa_options, ['returnAsArray' => $pa_options['aggregateUnique']]));
+					$va_proc_templates[$qr_res->get($vs_pk)] = $v;
 				}
 			} else {
 			    $va_val_list = DisplayTemplateParser::_getValues($qr_res, array_merge($va_template['tags'], array_flip(caGetTemplateTags($ps_skip_when))), $pa_options);


### PR DESCRIPTION
PR addresss issue where display template parser will fail to emit content if template has only nested units with no top-level content.