### PR TITLE
#1062 Make it possible to have bidirectional self rels in related lists

### DIFF
--- a/app/controllers/find/RelatedListController.php
+++ b/app/controllers/find/RelatedListController.php
@@ -147,7 +147,12 @@ class RelatedListController extends BaseSearchController {
 
 		$va_relation_id_typenames = array();
 		while($o_interstitial_res->nextHit()) {
-			$va_relation_id_typenames[$o_interstitial_res->getPrimaryKey()] = $o_interstitial_res->getWithTemplate('^relationship_typename');
+			$va_get_params = [];
+			if ( method_exists($t_related_rel, 'isSelfRelationship') && $t_related_rel->isSelfRelationship()) {
+				$vn_left_id = $o_interstitial_res->get($t_related_rel->getLeftTableFieldName());
+				$va_get_params['orientation'] = ( $t_subject->getPrimaryKey() === $vn_left_id ? 'LTOR' : 'RTOL' );
+			}
+			$va_relation_id_typenames[$o_interstitial_res->getPrimaryKey()] = $o_interstitial_res->getWithTemplate('^relationship_typename', $va_get_params);
 		}
 
 		$this->getView()->setVar('relationIdTypeNames', $va_relation_id_typenames);


### PR DESCRIPTION
* Previously relationships to other records in the same table would
always display using the 'forward' sense.
* Adapts logic used elsewhere in CA.

Fixes #1062 