### PR TITLE
Fix typo in translation file

### DIFF
--- a/app/lib/Parsers/TimeExpressionParser/fr_CA.lang
+++ b/app/lib/Parsers/TimeExpressionParser/fr_CA.lang
@@ -15,7 +15,7 @@ monthTable = {
 	mar = mars, mars = mars,
 	avr = avril, avr. = avril,
 	mai = mai,
-	jun = juin, juin = juin
+	jun = juin, juin = juin,
 	jul = juillet, juill. = juillet,
 	aoû = août, 
 	sep = septembre, sept. = septembre,


### PR DESCRIPTION
PR fixes typo in Canadian French date/time parser locale file that would cause June date expressions to fail.