### PR TITLE
Add functionality to prevent duplicate representations from being uploaded

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2039,6 +2039,11 @@ dont_use_exiftool_to_strip_exif_orientation_tags = 0
 #
 allow_representations_without_media = 0
 
+
+# Allow creation of object representation records containing media already in an existing representation
+#
+allow_representations_duplicate_media = 0
+
 # If you wish to allow the linking to existing object representations in the manner other relationships
 # set the relevant directives below to 1. Using representations as records that can be targets of
 # relationships can be confusing and, well, odd for many common setups. Still, when you need this behavior

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -5328,3 +5328,28 @@ require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 		throw new ApplicationException(_t('Invalid sidecar type'));
 	}
 	# ------------------------------------------------------------------
+	/**
+	 *
+	 */
+	function caGetReferenceToExistingRepresentationMedia($t_rep) {
+		global $g_request;
+		$rel = $rec_label = null;
+		foreach(['ca_objects', 'ca_entities', 'ca_occurrences', 'ca_collections'] as $parent_table) {
+			if($rel_list = $t_rep->getRelatedItems($parent_table, ['returnAs' => 'array'])) {
+				$rel = array_shift($rel_list);
+				$rec_label = $rel['label'].($rel['idno']? " (".$rel['idno'].")" : '');
+				break;
+			}
+		}
+	
+		$rec_label = $rec_label ? 
+			_t('Media aleady exists in %1', ($g_request ? 
+				caEditorLink($g_request, $rec_label, '', $parent_table, $rel[Datamodel::primaryKey($parent_table)])
+				: $rec_label))
+			:
+			($g_request ? _t('Media aleady %1', caEditorLink($g_request, _t('exists'), '', 'ca_object_representations', $t_rep->getPrimaryKey())) : _t('Media already exists'))
+		;
+		
+		return $rec_label;
+	}
+	# ------------------------------------------------------------------

--- a/app/lib/Error/errors.en_us
+++ b/app/lib/Error/errors.en_us
@@ -213,6 +213,7 @@
 2700 = Could not update primary flag for representation
 2710 = No media specified for new representation
 2720 = File is not part of representation
+2730 = Media already exists
 
 # --- User commenting/tagging errors
 2800 = Comment does not exist

--- a/app/lib/Exceptions/MediaExistsException.php
+++ b/app/lib/Exceptions/MediaExistsException.php
@@ -1,0 +1,54 @@
+<?php
+/** ---------------------------------------------------------------------
+ * app/lib/Exceptions/MediaExistsException.php :
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * This source code is free and modifiable under the terms of
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * @package CollectiveAccess
+ * @subpackage Core
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License version 3
+ *
+ * ----------------------------------------------------------------------
+ */
+
+/**
+ *
+ */
+
+
+class MediaExistsException extends ApplicationException {
+	/**
+	 * Instance of representation with existing media
+	 */
+	private $representation;
+	
+	public function __construct(string $message, ca_object_representations $representation) {
+		parent::__construct($message);
+		$this->representation = $representation;
+	}
+	/**
+	 *
+	 */
+	public function getRepresentation() {
+		return $this->representation;
+	}
+}

--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -599,8 +599,12 @@
 					$t_rep->setIdnoWithTemplate('%', ['serialOnly' => true]);
 				}
 				
-				$t_rep->insert();
-		
+				try {
+					$t_rep->insert();
+				} catch (MediaExistsException $e) {
+					$this->postError(2730, caGetReferenceToExistingRepresentationMedia($e->getRepresentation()), 'ca_object_representations->insert()');
+					return false;
+				}
 				if ($t_rep->numErrors()) {
 					$this->errors = array_merge($this->errors, $t_rep->errors());
 					return false;
@@ -756,7 +760,12 @@
 					}
 				}
 			
-				$t_rep->update();
+				try {
+					$t_rep->update();
+				} catch (MediaExistsException $e) {
+					$this->postError(2730, caGetReferenceToExistingRepresentationMedia($e->getRepresentation()), 'ca_object_representations->insert()');
+					return false;
+				}
 			
 				if ($t_rep->numErrors()) {
 					$this->errors = array_merge($this->errors, $t_rep->errors());


### PR DESCRIPTION
PR adds functionality to prevent duplicate representations from being uploaded. When a dupe upload is attempted it will be rejected with an error message pointing the user to the existing media. 

Also added app.conf directive to control whether duplicate uploads are allowed and sets default behavior to not allow duplicates. This is a change from previous behavior, where dupes were allowed.