### PR TITLE
Don't try to read GLTF files > 1mb

### DIFF
--- a/app/lib/Plugins/Media/Mesh.php
+++ b/app/lib/Plugins/Media/Mesh.php
@@ -218,6 +218,8 @@ class WLPlugMediaMesh extends BaseMediaPlugin implements IWLPlugMedia {
 			
 			// GLTF?
 			if(
+				(filesize($filepath) <= 1048576)
+				&&
 				($json = json_decode(file_get_contents($filepath), true))
 				&& 
 				(sizeof(array_intersect(


### PR DESCRIPTION
PR limits GLTF file parsing to files <= 1mb to avoid performance issues and memory exhaustion.