### PR TITLE
Circa dates lose "circa" specification due to Insufficient decimal precision

### DIFF
--- a/app/helpers/post-setup.php
+++ b/app/helpers/post-setup.php
@@ -376,3 +376,21 @@ if (!defined('__CA_ALLOW_AUTOMATIC_UPDATE_OF_DATABASE__')) {
 if (!defined("__CA_APP_TYPE__")) {
 	define("__CA_APP_TYPE__", "PROVIDENCE");
 }
+
+
+# __CA_MEMORY_LIMIT__
+#
+# Override server request memory limit with setup.php defined value
+if (defined("__CA_MEMORY_LIMIT__")) {
+	ini_set('memory_limit', __CA_MEMORY_LIMIT__)
+}
+
+# __CA_FLOAT_PRECISION__
+#
+# Override server default floating point precision with setup.php 
+# set value or CA default (19)
+if (!defined("__CA_FLOAT_PRECISION__")) {
+	# Default set precision wide enough to handle 4 digit year dates w/circa flag
+	define("__CA_FLOAT_PRECISION__", 19);
+}
+ini_set('precision', __CA_FLOAT_PRECISION__);

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -989,7 +989,10 @@ class BaseModel extends BaseObject {
 				}
 				
 				if(($ps_field_type == FT_NUMBER) && isset($vs_prop) && is_numeric($vs_prop)) {
+					$p = ini_get('precision');
+					ini_set('precision', strlen($vs_prop) + 2);
 					$vs_prop = ((float)$vs_prop != (int)$vs_prop) ? (float)$vs_prop : (int)$vs_prop;
+					ini_set('precision', $p);
 				}
 				
 				//

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -725,7 +725,7 @@ if (!$for_current_value_reindex) {
 
 					// specialized identifier (idno) processing; uses IDNumbering plugin to generate searchable permutations of identifier
 					if (((isset($va_data['INDEX_AS_IDNO']) && $va_data['INDEX_AS_IDNO']) || in_array('INDEX_AS_IDNO', $va_data, true)) && method_exists($t_subject, "getIDNoPlugInInstance") && ($o_idno = $t_subject->getIDNoPlugInInstance())) {
-						if (strlen($va_data['IDNO_DELIMITERS']) || (is_array($va_data['IDNO_DELIMITERS']) && count($va_data['IDNO_DELIMITERS']))) {
+						if ((is_array($va_data['IDNO_DELIMITERS']) && count($va_data['IDNO_DELIMITERS'])) || strlen($va_data['IDNO_DELIMITERS'])) {
 							if (!is_array($va_data['IDNO_DELIMITERS'])) { $va_data['IDNO_DELIMITERS'] = [$va_data['IDNO_DELIMITERS']]; }
 							$va_values = array_map(function($v) { return trim($v); }, preg_split('!('.join('|', $va_data['IDNO_DELIMITERS']).')!', $pa_field_data[$vs_field]));
 						} else {


### PR DESCRIPTION
PR adjusts PHP decimal precision to avoid truncation of historic date/time format (which is a large floating point number). When truncation occurs it typically manifests as loss of "circa" specification in inexact dates.