### PR TITLE
Add new exporter options

### DIFF
--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1841,6 +1841,12 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 		$vs_element = $t_exporter_item->get('element');
 		$vb_repeat = $settings['repeat_element_for_multiple_values'];
 
+		if($vs_skip_if_empty = $settings['skipIfEmpty']) {
+			if(!(strlen($t_instance->get($vs_source))>0)) {
+				return array();
+			}
+		}
+		
 		// if omitIfEmpty is set and get() returns nothing, we ignore this exporter item and all children
 		if($vs_omit_if_empty = $settings['omitIfEmpty']) {
 			if(!(strlen($t_instance->get($vs_omit_if_empty))>0)) {
@@ -2153,6 +2159,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 		$vs_original_values = $settings['original_values'];
 		$vs_replacement_values = $settings['replacement_values'];
 		
+		$apply_regular_expressions = $settings['applyRegularExpressions'];
+		
 		$va_replacements = ca_data_exporter_items::getReplacementArray($vs_original_values,$vs_replacement_values);
 
 		foreach($va_item_info as $vn_key => &$va_item) {
@@ -2190,7 +2198,12 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 				}
 			}
 
-			// do replacements
+			// do regex replacements
+			if(is_array($apply_regular_expressions) && sizeof($apply_regular_expressions)) {
+				$va_item['text'] = ca_data_exporter_items::_processAppliedRegexes($va_item['text'], $apply_regular_expressions);
+			}
+			
+			// do text replacements
 			$va_item['text'] = ca_data_exporter_items::replaceText($va_item['text'],$va_replacements);
 			
 			// do templates
@@ -2350,7 +2363,7 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
                                 'style' => \PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN)));
 
         $o_sheet->getParent()->getDefaultStyle()->applyFromArray($cellstyle);
-        $o_sheet->setTitle(_t("Exporter %1", $exporter_code));
+        $o_sheet->setTitle(substr($exporter_code, 0, 31));
         
         $o_sheet->getRowDimension($vn_line)->setRowHeight(30);
         

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -8,7 +8,7 @@
 #
 #				Providence: Cataloguing system for CollectiveAccess
 #               Open-source collections management software
-#               Version 1.7.7
+#               Version 1.8
 #				
 # -------------------------------------------------------------------------------------------
 # 


### PR DESCRIPTION
PR adds new exporter options for rewriting of output using regular expressions and simplified skipping of blank values export values. The new "skipIfEmpty" option skips an export mapping if the source value is blank. Previously skipping required use of "omitIfEmpty", which requires specification of the value to test for blank-ness. "skipIfEmpty" assumes the current source, and is more convenient for this very common case.

Also fix minor issue where long exporter codes could cause failure when attempting to output an existing exporter to an XLSX file.