### PR TITLE
Only save record on prepopulate if there have been any changes.

### DIFF
--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -525,15 +525,16 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		}
 
 
-		if(isset($_REQUEST['form_timestamp']) && ($_REQUEST['form_timestamp'] > 0)) { $_REQUEST['form_timestamp'] = time(); }
-		$t_instance->update(['force' => true, 'hooks' => false]);
-
-		if($t_instance->numErrors() > 0) {
-			foreach($t_instance->getErrors() as $vs_error) {
-				Debug::msg("[prepopulateFields()] there was an error while updating the record: ".$vs_error);
+		if ($t_instance->getChangedFieldValuesArray()) {
+			if(isset($_REQUEST['form_timestamp']) && ($_REQUEST['form_timestamp'] > 0)) { $_REQUEST['form_timestamp'] = time(); }
+			$t_instance->update(['force' => true, 'hooks' => false]);
+			if($t_instance->numErrors() > 0) {
+				foreach($t_instance->getErrors() as $vs_error) {
+					Debug::msg("[prepopulateFields()] there was an error while updating the record: ".$vs_error);
+				}
+				if ($vb_we_set_transaction) { $t_instance->removeTransaction(false); }
+				return false;
 			}
-			if ($vb_we_set_transaction) { $t_instance->removeTransaction(false); }
-			return false;
 		}
 
 		if ($vb_we_set_transaction) { $t_instance->removeTransaction(true); }

--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -525,7 +525,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 		}
 
 
-		if ($t_instance->getChangedFieldValuesArray()) {
+		if (count($t_instance->getChangedFieldValuesArray()) > 0) {
 			if(isset($_REQUEST['form_timestamp']) && ($_REQUEST['form_timestamp'] > 0)) { $_REQUEST['form_timestamp'] = time(); }
 			$t_instance->update(['force' => true, 'hooks' => false]);
 			if($t_instance->numErrors() > 0) {


### PR DESCRIPTION
We're currently using prepopulate with an `edit` configuration which is resulting in change log entries for records every time you view them rather than when you actually edit them. 

I think this change will only save the record if there have been any actual changes as a result of the prepopulate.