### PR TITLE
Sort by filename before processing. May resolve #1069.

### DIFF
--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -617,7 +617,7 @@
 
  			if (!$vn_locale_id) { $vn_locale_id = $g_ui_locale_id; }
 
- 			$va_files_to_process = caGetDirectoryContentsAsList($pa_options['importFromDirectory'], $vb_include_subdirectories);
+ 			$va_files_to_process = caGetDirectoryContentsAsList($pa_options['importFromDirectory'], $vb_include_subdirectories, false, true);
  			$o_log->logInfo(_t('Found %1 files in directory \'%2\'', sizeof($va_files_to_process), $pa_options['importFromDirectory']));
 
  			if ($vs_set_mode == 'add') {


### PR DESCRIPTION
PR sorts files in media importer prior to import, to ensure predictable order. Previously, unsorted output of scandir() was used.  Potential fix for https://github.com/collectiveaccess/providence/issues/1069