### PR TITLE
Sort by filename before processing. May resolve #1069.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,7 +11,7 @@ Allow from all
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico|gltf|mtl|bin)$">
         Allow from all
 </FilesMatch>
 

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -621,7 +621,7 @@ class BatchProcessor {
 
 		if (!$vn_locale_id) { $vn_locale_id = $g_ui_locale_id; }
 
-		$va_files_to_process = caGetDirectoryContentsAsList($pa_options['importFromDirectory'], $vb_include_subdirectories);
+		$va_files_to_process = caGetDirectoryContentsAsList($pa_options['importFromDirectory'], $vb_include_subdirectories, false, true);
 		$o_log->logInfo(_t('Found %1 files in directory \'%2\'', sizeof($va_files_to_process), $pa_options['importFromDirectory']));
 
 		if ($vs_set_mode == 'add') {
@@ -1372,7 +1372,7 @@ class BatchProcessor {
 		$vn_log_level = BatchProcessor::_logLevelStringToNumber($vs_log_level);
 
 		if (!isURL($ps_source) && is_dir($ps_source)) {
-			$va_sources = caGetDirectoryContentsAsList($ps_source, true, false, false, false);
+			$va_sources = caGetDirectoryContentsAsList($ps_source, true, false, false, true);
 		} else {
 			$va_sources = array($ps_source);
 		}


### PR DESCRIPTION
PR sorts files in media importer prior to import, to ensure predictable order. Previously, unsorted output of scandir() was used. Potential fix for #1069