### PR TITLE
Only set context for idno if it isn't already set.

### DIFF
--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -274,7 +274,7 @@ class BaseEditorController extends ActionController {
 				}
 			}
 
-			if ($vn_context_id && !$t_subject->get($vs_idno_context_field, $vn_context_id)) { $t_subject->set($vs_idno_context_field, $vn_context_id); }
+			if ($vn_context_id && !$t_subject->get($vs_idno_context_field)) { $t_subject->set($vs_idno_context_field, $vn_context_id); }
 		}
 
 		if (!($vs_type_name = $t_subject->getTypeName())) {

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -274,7 +274,7 @@ class BaseEditorController extends ActionController {
 				}
 			}
 
-			if ($vn_context_id) { $t_subject->set($vs_idno_context_field, $vn_context_id); }
+			if ($vn_context_id && !$t_subject->get($vs_idno_context_field, $vn_context_id)) { $t_subject->set($vs_idno_context_field, $vn_context_id); }
 		}
 
 		if (!($vs_type_name = $t_subject->getTypeName())) {


### PR DESCRIPTION
* Fixes warning about not being able to set the type_id if that has
already been set for a record.