### PR TITLE
Add setup error messages 

### DIFF
--- a/app/helpers/errorHelpers.php
+++ b/app/helpers/errorHelpers.php
@@ -145,4 +145,15 @@ function caExtractRequestParams() {
 	return $pa_params;
 }
 # --------------------------------------------------------------------------------------------
+ /**
+  * Return URL path to themes directory, guessing based upon PHP script name is constants aren't set
+  *
+  * @return string
+  */
+function caGetThemeUrlPath() : string {
+	$tmp = explode("/", str_replace("\\", "/", $_SERVER['SCRIPT_NAME']));
+	array_pop($tmp);
+	return defined('__CA_THEME_URL__') ? __CA_THEME_URL__ : join("/", $tmp).'/themes/default';
+}
+# ---------------------------------------------------------------------------------------------
 		

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@
 	require("./app/helpers/errorHelpers.php");
 	
 	if (!file_exists('./setup.php')) {
-		caDisplayException(new ApplicationException("No setup.php found"));
+		require_once("./themes/default/views/system/no_setup_html.php");
 		exit; 
 	}
 	require('./setup.php');
@@ -39,8 +39,9 @@
 
 	try {
 		// connect to database
-		$o_db = new Db(null, null, false);
-		if (!$o_db->connected()) {
+		try {
+			$o_db = new Db(null, null, false);
+		} catch(DatabaseException $e) {
 			$opa_error_messages = array("Could not connect to database. Check your database configuration in <em>setup.php</em>.");
 			require_once(__CA_BASE_DIR__."/themes/default/views/system/configuration_error_html.php");
 			exit();

--- a/themes/default/views/system/configuration_error_html.php
+++ b/themes/default/views/system/configuration_error_html.php
@@ -47,7 +47,7 @@ if (!is_array($opa_error_messages)) {
 		<div id="logo"><?= caGetLoginLogo(); ?></div><!-- end logo -->
 		<div id="content">
 			<?= "<div class='error'>There are issues with your configuration</div>
-				<div class='errorDescription'>xxGeneral installation instructions can be found
+				<div class='errorDescription'>General installation instructions can be found
 				<a href='https://manual.collectiveaccess.org/setup/Installation.html' target='_blank'>here</a>.
 				or more specific information on detected issues review the messages below:</div>"; ?>
 <?php

--- a/themes/default/views/system/error_html.php
+++ b/themes/default/views/system/error_html.php
@@ -1,11 +1,7 @@
-<?php
-print _t("Errors occurred when trying to access")." <code>".$this->getVar('referrer')."</code>:<br/>";
-?>
+<?= _t("Errors occurred when trying to access")." <code>".$this->getVar('referrer')."</code>:<br/>"; ?>
 
-<ul>
-<?php
+<ul><?php
 	foreach($this->getVar("error_messages") as $vs_message) {
 		print "<li>$vs_message </li>\n";
 	}
-?>
-</ul>
+?></ul>

--- a/themes/default/views/system/fatal_error_html.php
+++ b/themes/default/views/system/fatal_error_html.php
@@ -26,14 +26,11 @@
  * ----------------------------------------------------------------------
  */
  
-	$va_tmp = explode("/", str_replace("\\", "/", $_SERVER['SCRIPT_NAME']));
-	array_pop($va_tmp);
-	$vs_path = join("/", $va_tmp);
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>CollectiveAccess error</title>
-	<link href="<?php print $vs_path; ?>/themes/default/css/error.css" rel="stylesheet" type="text/css" />
+	<link href="<?= caGetThemeUrlPath(); ?>/css/error.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
 	<div id='errorDetails'>

--- a/themes/default/views/system/no_setup_html.php
+++ b/themes/default/views/system/no_setup_html.php
@@ -34,7 +34,7 @@
 </head>
 <body>
 	<div id='errorDetails'>
-		<div id="logo"><img src='/themes/default/graphics/logos/logo.svg' alt='CollectiveAccess logo' width='327px' height='45px' /></div><!-- end logo -->
+		<div id="logo"><img src='<?= caGetThemeUrlPath(); ?>/graphics/logos/logo.svg' alt='CollectiveAccess logo' width='327px' height='45px' /></div><!-- end logo -->
 		<div id="content">
 			<div class='error'>No <code>setup.php</code> file found!</div>
 			<div id="errorLocation" class="errorPanel">

--- a/themes/default/views/system/no_setup_html.php
+++ b/themes/default/views/system/no_setup_html.php
@@ -1,0 +1,51 @@
+<?php
+/* ----------------------------------------------------------------------
+ * views/system/no_setup_html.php : 
+ * ----------------------------------------------------------------------
+ * CollectiveAccess
+ * Open-source collections management software
+ * ----------------------------------------------------------------------
+ *
+ * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
+ * Copyright 2021 Whirl-i-Gig
+ *
+ * For more information visit http://www.CollectiveAccess.org
+ *
+ * This program is free software; you may redistribute it and/or modify it under
+ * the terms of the provided license as published by Whirl-i-Gig
+ *
+ * CollectiveAccess is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTIES whatsoever, including any implied warranty of 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * This source code is free and modifiable under the terms of 
+ * GNU General Public License. (http://www.gnu.org/copyleft/gpl.html). See
+ * the "license.txt" file for details, or visit the CollectiveAccess web site at
+ * http://www.CollectiveAccess.org
+ *
+ * ----------------------------------------------------------------------
+ */
+ 
+?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title>CollectiveAccess error</title>
+	<link href="<?= caGetThemeUrlPath(); ?>/css/error.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+	<div id='errorDetails'>
+		<div id="logo"><img src='/themes/default/graphics/logos/logo.svg' alt='CollectiveAccess logo' width='327px' height='45px' /></div><!-- end logo -->
+		<div id="content">
+			<div class='error'>No <code>setup.php</code> file found!</div>
+			<div id="errorLocation" class="errorPanel">
+				<div class="errorDescription">
+						In the main directory of your Providence install there is a file called <code>setup.php-dist</code>. 
+						Make a copy of this file and rename it to <code>setup.php</code>. For your CollectiveAccess system to work you MUST add 
+						values for your database server hostname, user name, password, database, and administrative e-email. More more information see the 
+						<a href="https://manual.collectiveaccess.org/setup/Installation.html">installation instructions</a> and the manual page for <a href="https://manual.collectiveaccess.org/setup/setup.php.html">setup.php</a>.
+				</div>
+			</div>
+		</div><!-- end content -->
+	</div><!-- end box -->
+</body>
+</html>


### PR DESCRIPTION
PR adds alert when no setup.php file is present (vs. previous behavior of splurting a PHP error on screen), and adds a situation-specific error (rather than raw MySQL error text) when database login fails.