### PR TITLE
Resolve #1069 by setting is_primary passively

### DIFF
--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -923,12 +923,12 @@
 		/** 
 		 * Link existing media represention to currently loaded item
 		 *
-		 * @param $pn_representation_id - 
-		 * @param $pb_is_primary - if set to true, representation is designated "primary." Primary representation are used in cases where only one representation is required (such as search results). If a primary representation is already attached to this item, then it will be changed to non-primary as only one representation can be primary at any given time. If no primary representations exist, then the new representation will always be marked primary no matter what the setting of this parameter (there must always be a primary representation, if representations are defined).
-		 * @param $pa_options - an array of options passed through to BaseModel::set() when creating the new representation. Currently supported options:
-		 *		rank - a numeric rank used to order the representations when listed
+		 * @param $pn_representation_id 
+		 * @param $pb_is_primary = if set to true, representation is designated "primary." Primary representation are used in cases where only one representation is required (such as search results). If a primary representation is already attached to this item, then it will be changed to non-primary as only one representation can be primary at any given time. If no primary representations exist, then the new representation will always be marked primary no matter what the setting of this parameter (there must always be a primary representation, if representations are defined). To automatically set primary (eg. first imported is primary, subsequent are not) set this to null.
+		 * @param $pa_options = an array of options passed through to BaseModel::set() when creating the new representation. Currently supported options:
+		 *		rank = a numeric rank used to order the representations when listed
 		 *
-		 * @return mixed Returns primary key (link_id) of the relatipnship row linking the  representation to the item; boolean false is returned on error
+		 * @return mixed Returns primary key (link_id) of the relationship row linking the representation to the item; boolean false is returned on error
 		 */
 		public function linkRepresentation($pn_representation_id, $pb_is_primary, $pa_options=null) {
 			if (!($vn_id = $this->getPrimaryKey())) { return null; }
@@ -944,7 +944,10 @@
 			$t_oxor->setMode(ACCESS_WRITE);
 			$t_oxor->set($vs_pk, $vn_id);
 			$t_oxor->set('representation_id', $pn_representation_id);
-			$t_oxor->set('is_primary', $pb_is_primary ? 1 : 0);
+			
+			if(!is_null($pb_is_primary)) {
+				$t_oxor->set('is_primary', $pb_is_primary ? 1 : 0);
+			}
 			$t_oxor->set('rank', isset($pa_options['rank']) ? (int)$pa_options['rank'] : $pn_representation_id);
 			if ($t_oxor->hasField('type_id') && ($pm_type_id = caGetOption('type_id', $pa_options, null))) {
 			    $pn_type_id = null;

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -3744,7 +3744,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 										break;
 									case 'ca_object_representations':
 										if ($vn_rel_id = DataMigrationUtils::getObjectRepresentationID($vs_name, $va_element_data['_type'], $vn_locale_id, $va_data_for_rel_table, array('logReference' => $vs_idno, 'forceUpdate' => true, 'dontCreate' => $vb_dont_create, 'matchOn' => $va_match_on, 'log' => $o_log, 'transaction' => $o_trans, 'importEvent' => $o_event, 'importEventSource' => $vn_row, 'nonPreferredLabels' => $va_nonpreferred_labels, 'matchMediaFilesWithoutExtension' => true))) {
-											$t_subject->linkRepresentation($vn_rel_id, true, ['type_id' => trim($va_element_data['_relationship_type'])]);
+											$t_subject->linkRepresentation($vn_rel_id, null, ['type_id' => trim($va_element_data['_relationship_type'])]);
 										
 											if ($vs_error = DataMigrationUtils::postError($t_subject, _t("[%1] Could not add related object representation with:", $vs_idno), __CA_DATA_IMPORT_ERROR__, array('dontOutputLevel' => true, 'dontPrint' => true))) {
 												$this->logImportError($vs_error, array_merge($va_log_import_error_opts, ['bundle' => $vs_table_name, 'notes' => null]));


### PR DESCRIPTION
PR resolves is_primary order issue reported in #1069 by changing is_primary value on import to "passive" mode. (Eg. first imported is primary).