### PR TITLE
Filter quicksearch terms and form input

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2677,10 +2677,10 @@ service_view_path = <ca_app_dir>/service/views
 #
 # Set to filter all entered data through HTMLPurifier
 # removing any potentially dangerous markup. This is generally 
-# a good thing, but significantly impacts performance and is
-# left disabled by default.
+# a good thing, but significantly impacts performance. You may
+# wish to disable it if all user input is trusted.
 # -----------------------------------
-purify_all_text_input = 0
+purify_all_text_input = 1
 
 
 # -----------------------------------

--- a/app/controllers/find/QuickSearchController.php
+++ b/app/controllers/find/QuickSearchController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -57,8 +57,8 @@
  		 *
  		 */ 
  		public function Index($pa_options=null) {
- 			$ps_search 		= $this->request->getParameter('search', pString);
- 			$ps_sort 		= $this->request->getParameter('sort', pString);
+ 			$ps_search 		= $this->request->getParameter('search', pString,  null, ['forcePurify' => true]);
+ 			$ps_sort 		= $this->request->getParameter('sort', pString, null, ['forcePurify' => true]);
  			
  			if (!$ps_search) { $ps_search = Session::getVar('quick_search_last_search'); }
  			if (!in_array($ps_sort, array('name', 'idno', 'relevance'))) {


### PR DESCRIPTION
PR forces filtering of quicksearch input for XSS and changes overall form filtering default to active. Filtering had been disabled by default (opt-in) for performance reasons and due to user complaints:

-  For virtually all installations, user input is trusted and unfiltered input is preferred – some users do mean to enter literal markup. 
- Filtering impact on performance is negligible in normal use but can become an issue in large data imports.

With this change in default configuration, filtering is now opt-out.