### PR TITLE
Add filtering to remove external references in HTML 

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2682,6 +2682,10 @@ service_view_path = <ca_app_dir>/service/views
 # -----------------------------------
 purify_all_text_input = 1
 
+# Allow external URL references (eg. images) in HTML text input? 
+# Leaving this enabled may be a security risk
+purify_allow_external_references = 0
+
 
 # -----------------------------------
 # Paths to other config files

--- a/app/controllers/find/QuickSearchController.php
+++ b/app/controllers/find/QuickSearchController.php
@@ -57,7 +57,7 @@
  		 *
  		 */ 
  		public function Index($pa_options=null) {
- 			$ps_search 		= $this->request->getParameter('search', pString,  null, ['forcePurify' => true]);
+ 			$ps_search 		= strip_tags($this->request->getParameter('search', pString,  null, ['forcePurify' => true]));
  			$ps_sort 		= $this->request->getParameter('sort', pString, null, ['forcePurify' => true]);
  			
  			if (!$ps_search) { $ps_search = Session::getVar('quick_search_last_search'); }

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -556,7 +556,11 @@ class BaseModel extends BaseObject {
 	 * @return HTMLPurifier Returns instance
 	 */
 	static public function getPurifier() {
-		if (!BaseModel::$html_purifier) { BaseModel::$html_purifier = new HTMLPurifier(); }
+		if (!BaseModel::$html_purifier) { 
+			$config = HTMLPurifier_Config::createDefault();
+			$config->set('URI.DisableExternalResources', !Configuration::load()->get('purify_allow_external_references'));
+			BaseModel::$html_purifier = new HTMLPurifier($config); 
+		}
 		return BaseModel::$html_purifier;
 	}
 	# --------------------------------------------------------------------------------


### PR DESCRIPTION
PR adds filtering to remove external references in HTML input (Eg. <img> tags) . This prevents a situation where arbitrary urls are fetched on the server side when generating PDFs. (Thanks to @haxatron for pointing this out). Also filter HTML tags from quicksearch, to prevent reflection of html content in results message (and because we don't want to be including html tags in quicksearch, which is not supported). (Thanks to @0xamal for pointing this out).