### PR TITLE
Filter params in stacktrace

### DIFF
--- a/app/helpers/errorHelpers.php
+++ b/app/helpers/errorHelpers.php
@@ -99,7 +99,7 @@ function caExtractStackTraceArguments($pa_errcontext) {
 	
 	$pconfig = HTMLPurifier_Config::createDefault();
 	$pconfig->set('URI.DisableExternalResources', true);		
-	$o_purifier = new HTMLPurifier($pa_argsconfig);
+	$o_purifier = new HTMLPurifier($pconfig);
 	$pa_args = [];
 	
 	foreach($pa_errcontext as $vn_i => $va_trace) {

--- a/app/helpers/errorHelpers.php
+++ b/app/helpers/errorHelpers.php
@@ -97,7 +97,9 @@ function caDisplayFatalError($pn_errno, $ps_errstr, $ps_errfile, $pn_errline, $p
 function caExtractStackTraceArguments($pa_errcontext) {
 	if(!is_array($pa_errcontext)) { return []; }
 	
-	$o_purifier = new HTMLPurifier();
+	$pconfig = HTMLPurifier_Config::createDefault();
+	$pconfig->set('URI.DisableExternalResources', true);		
+	$o_purifier = new HTMLPurifier($pa_argsconfig);
 	$pa_args = [];
 	
 	foreach($pa_errcontext as $vn_i => $va_trace) {
@@ -134,7 +136,9 @@ function caExtractRequestParams() {
 
 	if(!is_array($_REQUEST)) { return []; }
 
-	$o_purifier = new HTMLPurifier();
+	$pconfig = HTMLPurifier_Config::createDefault();
+	$pconfig->set('URI.DisableExternalResources', true);		
+	$o_purifier = new HTMLPurifier($pconfig);
 	$pa_params = [];
 	foreach($_REQUEST as $vs_k => $vm_val) {
 		if(is_array($vm_val)) { $vm_val = join(',', caFlattenArray($vm_val));}


### PR DESCRIPTION
PR adds filtering of external references to stacktrace display, to avoid broken markup and potential XSS.