### PR TITLE
Use context document root where available

### DIFF
--- a/app/helpers/post-setup.php
+++ b/app/helpers/post-setup.php
@@ -53,7 +53,7 @@ if (!defined("__CA_BASE_DIR__")) {
 # 		Example: If CollectiveAccess will be accessed via http://www.mysite.org/apps/ca then __CA_URL_ROOT__ would be set to /apps/ca
 #
 if (!defined("__CA_URL_ROOT__")) {
-	define("__CA_URL_ROOT__", str_replace(isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '', '', __CA_BASE_DIR__));
+	define("__CA_URL_ROOT__", str_replace($_SERVER['CONTEXT_DOCUMENT_ROOT'] ?? $_SERVER['DOCUMENT_ROOT'] ?? '', '', __CA_BASE_DIR__));
 }
 
 

--- a/app/lib/ConfigurationCheck.php
+++ b/app/lib/ConfigurationCheck.php
@@ -383,7 +383,7 @@ final class ConfigurationCheck {
 	private static function _urlRootGuesses() {
 		return [
 			str_replace("/index.php", "", str_replace("\\", "/", $_SERVER["SCRIPT_NAME"])),
-			str_replace(isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '', '', __CA_BASE_DIR__)
+			str_replace($_SERVER['CONTEXT_DOCUMENT_ROOT'] ?? $_SERVER['DOCUMENT_ROOT'] ?? '', '', __CA_BASE_DIR__)
 		];
 	}
 	# -------------------------------------------------------


### PR DESCRIPTION
PR modified bootstrap process to use context document root where available in order to support path detection when Apache aliases are configured.