### PR TITLE
Check for case where somehow there's more than one preferred label

### DIFF
--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -426,7 +426,9 @@ class SearchIndexer extends SearchBase {
 			$va_hier_values = array();
 			while($qr_hier_res->nextHit()) {
 				if ($vs_v = $qr_hier_res->get($vs_subject_tablename.".".$ps_field)) {
-					$va_hier_values[$is_label ? $qr_hier_res->get($vs_subject_tablename.'.preferred_labels.label_id') : $qr_hier_res->getPrimaryKey()] = $vs_v;
+					// return as array in case somehow there are dupe preferred labels (ie. the database is corrupt 
+					$label_id = is_array($label_ids = $qr_hier_res->get($vs_subject_tablename.'.preferred_labels.label_id', ['returnAsArray' => true])) ? array_shift($label_ids) : null;
+					$va_hier_values[$is_label ? $label_id : $qr_hier_res->getPrimaryKey()] = $vs_v;
 				}
 			}
 

--- a/app/lib/Search/SearchIndexer.php
+++ b/app/lib/Search/SearchIndexer.php
@@ -427,8 +427,8 @@ class SearchIndexer extends SearchBase {
 			while($qr_hier_res->nextHit()) {
 				if ($vs_v = $qr_hier_res->get($vs_subject_tablename.".".$ps_field)) {
 					// return as array in case somehow there are dupe preferred labels (ie. the database is corrupt 
-					$label_id = is_array($label_ids = $qr_hier_res->get($vs_subject_tablename.'.preferred_labels.label_id', ['returnAsArray' => true])) ? array_shift($label_ids) : null;
-					$va_hier_values[$is_label ? $label_id : $qr_hier_res->getPrimaryKey()] = $vs_v;
+					$label_id = is_array($label_ids = $qr_hier_res->get($vs_subject_tablename.'.preferred_labels.label_id', ['returnAsArray' => true])) ? (int)array_shift($label_ids) : null;
+					$va_hier_values[($is_label && ($label_id > 0)) ? $label_id : $qr_hier_res->getPrimaryKey()] = $vs_v;
 				}
 			}
 


### PR DESCRIPTION
PR checks for case where somehow there's more than one preferred label on a row. When hierarchical indexing is enabled this state (which shouldn't happen, although if you're messing with the database directly it could) will cause indexing to barf when  multiple ids are returned in a single indexing row. This patch just ignores anything after  the first returned label. This seems reasonable in this situation, which shouldn't actually happen and generally does not happen. (There is only a single report of this happening in the "real world").