### PR TITLE
Add option to multipart idno config for uniqueness constraint across multiple tables

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -894,15 +894,16 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 				if(is_array($additional_tables)) {
 					foreach($additional_tables as $additional_table) {
 						if(!($t = Datamodel::getInstance($additional_table, true))) { continue; }
-					
-						$vs_deleted_sql = '';
-						if ($this->hasField('deleted')) {
-							$vs_deleted_sql = " AND ({$additional_table}.deleted = 0)";
+						if(!($idno_field = $t->getProperty('ID_NUMBERING_ID_FIELD'))) { continue; }
+						
+						$deleted_sql = '';
+						if ($t->hasField('deleted')) {
+							$deleted_sql = " AND ({$additional_table}.deleted = 0)";
 						}
 						$qr_idno = $o_db->query("
 							SELECT ".$t->primaryKey()." 
 							FROM {$additional_table}
-							WHERE {$vs_idno_field} = ? {$vs_deleted_sql}
+							WHERE {$idno_field} = ? {$deleted_sql}
 						", [$ps_idno]);
 			
 						while($qr_idno->nextRow()) {


### PR DESCRIPTION
PR adds new  `compare_against_values_in` option to multipart idno config  allowing enforcement of uniqueness of identifiers across multiple tables.