### PR TITLE
Skip primary table when evaluating cross-table idno uniqueness

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -893,6 +893,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 				// other tables to check?
 				if(is_array($additional_tables)) {
 					foreach($additional_tables as $additional_table) {
+						if($additional_table === $this->tableName()) { continue; }
 						if(!($t = Datamodel::getInstance($additional_table, true))) { continue; }
 						if(!($idno_field = $t->getProperty('ID_NUMBERING_ID_FIELD'))) { continue; }
 						


### PR DESCRIPTION
PR forces primary table to be skipped if it is incorrectly included in the list of additional tables to compare against. This prevents odd behaviors than can prevent creation of new records.