### PR TITLE
Add importer applyTransformations option

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -1627,4 +1627,26 @@ function caProcessRefineryRelatedMultiple($po_refinery_instance, &$pa_item, $pa_
 		}
 		return $value;
 	}
+	# ------------------------------------------------------
+	/**
+	 * Transform $value using specified transformation. Used by data importer applyTransformations option.
+	 *
+	 * Supported transformations:
+	 *		filesize = Transform integer filesize in bytes to display text with scaled suffix (KiB, MiB, GiB, etc.)
+	 *		           Options: decimal = number of decimal places to display. [Default is 2]
+	 * 
+	 * @param mixed $value Value to transform.
+	 * @param string $transform Code for transform to apply.
+	 * @param array $options Options for selected transform. [Default is null]
+	 *
+	 * @return mixed Transformed value
+	 */
+	function caApplyDataTransforms($value, string $transform, ?array $options){
+		switch(strtolower($transform)) {
+			case 'filesize':
+				$value = caHumanFilesize((int)$value, caGetOption('decimals', $options, 2));
+				break;
+		}
+		return $value;
+	}
 	# ---------------------------------------------------------------------

--- a/app/models/ca_data_importer_items.php
+++ b/app/models/ca_data_importer_items.php
@@ -510,6 +510,15 @@ class ca_data_importer_items extends BaseModel {
 			'label' => _t('Apply one or more regular expression-based substitutions to a source value prior to import.'),
 			'description' => _t('A list of Perl-compatible regular expressions. Each expression has two parts, a matching expression and a substitution expression, and is expressed as a JSON object with <em>match</em> and <em>replaceWith</em> keys. Ex. [{"match": "([\\d]+)\\.([\\d]+)", "replaceWith": "\\1:\\2"}, {"match": "[^\\d:]+", "replaceWith": ""}] ')
 		);
+		$settings['applyTransformations'] = array(
+			'formatType' => FT_TEXT,
+			'displayType' => DT_FIELD,
+			'width' => 40, 'height' => 4,
+			'takesLocale' => false,
+			'default' => '',
+			'label' => _t('Apply one or more tranformations a source value prior to import.'),
+			'description' => _t('A list of data transformations, each with a list of transformation-specific options.')
+		);
 		$settings['maxLength'] = array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -1776,6 +1776,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				}
 				
 				$vs_idno = self::_applyCaseTransforms($vs_idno, $va_mapping_items[$vn_idno_mapping_item_id]);
+				$vs_idno = self::_applyDataTransforms($vs_idno, $va_mapping_items[$vn_idno_mapping_item_id]);
 				
 										
 				if (isset($va_mapping_items[$vn_idno_mapping_item_id]['settings']['applyRegularExpressions']) && is_array($va_mapping_items[$vn_idno_mapping_item_id]['settings']['applyRegularExpressions'])) {
@@ -1857,6 +1858,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					}
 				
 					$vs_label_val = self::_applyCaseTransforms($vs_label_val, $va_mapping_items[$vn_preferred_label_mapping_id]);
+					$vs_label_val = self::_applyDataTransforms($vs_label_val, $va_mapping_items[$vn_preferred_label_mapping_id]);
 				
 					$va_pref_label_values[$vs_preferred_label_mapping_fld] = $vs_label_val;
 				}
@@ -2474,6 +2476,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							}
 							
 							$vm_val = self::_applyCaseTransforms($vm_val, $va_item);
+							$vm_val = self::_applyDataTransforms($vm_val, $va_item);
 
 							$va_vals[ $vn_i ] = $vm_val;
 							if ( $o_reader->valuesCanRepeat() ) {
@@ -4201,6 +4204,25 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 			}
 			if (isset($mapping['settings']['upperCaseFirst']) && (bool)$mapping['settings']['upperCaseFirst']) {
 				$value = caUcFirstUTF8Safe($value);
+			}
+		}
+		return $value;
+	}
+	# ------------------------------------------------------
+	/**
+	 * 
+	 */
+	private static function _applyDataTransforms($value, array $mapping) {
+		if (strlen($value)) {
+			$transforms = $mapping['settings']['applyTransformations'];
+			if(is_array($transforms) && sizeof($transforms)) {
+				foreach($transforms as $t) {
+					if(!is_array($t)) { continue; }
+					if(!($transform = caGetOption('transform', $t, null))) { continue; }
+					$opts = $t;
+					unset($t['transform']);
+					$value = caApplyDataTransforms($value,  $transform, $t);
+				}
 			}
 		}
 		return $value;


### PR DESCRIPTION
PR adds importer `applyTransformations` option for transforming data on import from one form to another. Implements single transform, for now ,to format integer file sizes (in bytes) as "human readable" file sizes.