### PR TITLE
Add configurable media version skipping options

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2076,8 +2076,8 @@ allow_user_embedded_metadata_extraction_mapping_null_option = 0
 # 
 # Defaults are used automatically when configured to not present a list of mappings to the user.
 embedded_metadata_extraction_mapping_defaults = {
-	video/* = a_mapping_code,
-	image/* = another_mapping_code
+#	video/* = a_mapping_code,
+#	image/* = another_mapping_code
 }
 
 # Log level used when performing embedded metadata import. 
@@ -2265,6 +2265,32 @@ ajax_media_upload_tmp_directory_timeout = 86400
 # Reprocess media
 # -----------------------------------
 reprocess_media_log_directory = <ca_base_dir>/app/log
+
+
+# -----------------------------------
+# Conditional media versions
+# -----------------------------------
+# Normally all configured versions are generated when media is uploaded. In some cases it 
+# may be desirable to not create a version if a file exceeds a certain size. For example, it
+# may not be practical to store large original, high-quality media files, but the derivatives of that file
+# are still required. In this case you can specify in the media_processing.conf configuration file 
+# that selected versions be skipped after a threshold is reached, and optionally that another, existing, version
+# is used in its place whenever it is referenced. The SKIP_WHEN_FILE_LARGER_THAN and REPLACE_WITH_VERSION
+# options may be set for this purpose.
+#
+# For situations where skipping versions must be dependent upon metadata in the representation record, rather than
+# just file type and size, rules can be specified using the skip_object_representation_versions_for_mimetype_when directive
+# below. Rules are set by mime type and version. The example will skip the "original" version for video files if they 
+# are larger than 500k and have their "ca_object_representations.access_pres" metadata value set to "Preservation". 
+# When skipped the "medium" version will be used as a placeholder wherever "original" is referenced.
+#
+#skip_object_representation_versions_for_mimetype_when = {
+#	video/* = {
+#		original = {
+#			threshold = 50000, replaceWithVersion = medium, when = "^access_pres = 'Preservation'"
+#		}
+#	}
+#}
 
 # -----------------------------------
 # Object representation download options

--- a/app/conf/media_processing.conf
+++ b/app/conf/media_processing.conf
@@ -811,7 +811,7 @@ ca_object_representations = {
 				original 	= {
 					RULE = rule_video, VOLUME = quicktime,
 					#SKIP_WHEN_FILE_LARGER_THAN = 500000,
-					#REPLACE_WITH = page
+					#REPLACE_WITH_VERSION = page
 				}
 			},
 			MEDIA_VIEW_DEFAULT_VERSION = h264_hi,

--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -2080,11 +2080,24 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		return (caGetOption('contentOnly', $pa_options, false) ? $vs_element : $vs_output).$prompt;
 	}
 	# ------------------------------------------------------
-	public function getBundleList($pa_options=null) {
-		if (isset($pa_options['includeBundleInfo']) && $pa_options['includeBundleInfo']) { 
-			return $this->BUNDLES;
+	/**
+	 *
+	 */
+	public function getBundleList($options=null) {
+		$bundles = $this->BUNDLES;
+		if (caGetOption('rewriteKeys', $options, false)) {
+		    $keys = array_keys($bundles);
+			foreach($keys as $k) {
+				if(substr($k, 0, 13) === 'ca_attribute_') {
+					$bundles[substr($k, 13)] = $bundles[$k];
+					unset($bundles[$k]);
+				}		
+			}
 		}
-		return array_keys($this->BUNDLES);
+		if (caGetOption('includeBundleInfo', $options, false)) { 
+			return $bundles;
+		}
+		return array_keys($bundles);
 	}
 	# ------------------------------------------------------
 	public function isValidBundle($ps_bundle_name) {
@@ -3889,6 +3902,7 @@ if (!$vb_batch) {
 						$this->set($this->HIERARCHY_ID_FLD, $this->getPrimaryKey());
 						if (!($this->addRelationship('ca_collections', $vn_parent_id, $vs_coll_rel_type))) {
 							$this->postError(2510, _t('Could not move object under collection: %1', join("; ", $this->getErrors())), "BundlableLabelableBaseModelWithAttributes->saveBundlesForScreen()");
+							$po_request->addActionErrors($this->errors());
 						}
 					}
 				}

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -1330,6 +1330,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	 *		importAllDatasets = for data formats (such as Excel/XLSX) that support multiple data sets in a single file (worksheets in Excel), indicated that all data sets should be imported; otherwise only the default data set is imported [Default=false]
 	 *		addToSet = identifier for set to add all imported items to. [Default is null]
 	 *		detailedLogName = [Default is null]
+	 *		reader = Reader instance preloaded with data for import. If set reader content will be used rather than reading the file pointed to by $ps_source. [Default is null]
 	 */
 	public function importDataFromSource($ps_source, $ps_mapping, $pa_options=null) {
 		$this->num_import_errors = 0;
@@ -1454,18 +1455,21 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 	
 		// Open file 
 		$ps_format = (isset($pa_options['format']) && $pa_options['format']) ? $pa_options['format'] : null;	
-		if (!($o_reader = $t_mapping->getDataReader($ps_source, $ps_format))) {
-			$this->logImportError(_t("Could not open source %1 (format=%2)", $ps_source, $ps_format), $va_log_import_error_opts);
-			if ($o_trans) { $o_trans->rollback(); }
-			return false;
-		}
+		if(!($o_reader = caGetOption('reader', $pa_options, null))) { 
+			$o_reader = $t_mapping->getDataReader($ps_source, $ps_format); 
+			if (!$o_reader) {
+				$this->logImportError(_t("Could not open source %1 (format=%2)", $ps_source, $ps_format), $va_log_import_error_opts);
+				if ($o_trans) { $o_trans->rollback(); }
+				return false;
+			}
 		
-		$va_reader_opts = array('basePath' => $t_mapping->getSetting('basePath'), 'originalFilename' => caGetOption('originalFilename', $pa_options, null));
+			$va_reader_opts = array('basePath' => $t_mapping->getSetting('basePath'), 'originalFilename' => caGetOption('originalFilename', $pa_options, null));
 		
-		if (!$o_reader->read($ps_source, $va_reader_opts)) {
-			$this->logImportError(_t("Could not read source %1 (format=%2)", $ps_source, $ps_format), $va_log_import_error_opts);
-			if ($o_trans) { $o_trans->rollback(); }
-			return false;
+			if (!$o_reader->read($ps_source, $va_reader_opts)) {
+				$this->logImportError(_t("Could not read source %1 (format=%2)", $ps_source, $ps_format), $va_log_import_error_opts);
+				if ($o_trans) { $o_trans->rollback(); }
+				return false;
+			}
 		}
 		
 		$o_log->logDebug(_t('Finished reading input source at %1 seconds', $t->getTime(4)));
@@ -2480,6 +2484,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 
 							$va_vals[ $vn_i ] = $vm_val;
 							if ( $o_reader->valuesCanRepeat() ) {
+								if(!is_array($va_row_with_replacements[ $va_item['source']])) { 
+									$va_row_with_replacements[ $va_item['source']] = $va_row[ $va_item['source']] =  $va_row[mb_strtolower( $va_item['source'])] = []; 
+								}
 								$va_row_with_replacements[ $va_item['source'] ][ $vn_i ]
 									= $va_row[ $va_item['source'] ][ $vn_i ]
 									= $va_row[ mb_strtolower( $va_item['source'] ) ][ $vn_i ] = $vm_val;
@@ -2741,12 +2748,12 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 								$va_group_buf[$vn_c]['_replace'] = $va_item['settings']['_replace'];
 							}
 
-							if ( $va_item['settings']['skipIfDataPresent'] ) {
+							if ($va_item['settings']['skipIfDataPresent']) {
 								$va_group_buf[ $vn_c ]['_skipIfDataPresent'] = true;
 							}
 							
 
-							if ( $displaynameFormat_setting = $va_item['settings']['displaynameFormat'] ) {
+							if ($displaynameFormat_setting = $va_item['settings']['displaynameFormat']) {
 								$va_group_buf[ $vn_c ]['_displaynameFormat'] = $displaynameFormat_setting;
 							}
 

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -483,6 +483,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	 *
 	 */
 	public function insert($options=null) {
+		if(!is_array($options)) { $options = []; }
 		// reject if media is empty
 		if ($this->mediaIsEmpty() && !(bool)$this->getAppConfig()->get('allow_representations_without_media')) {
 			$this->postError(2710, _t('No media was specified'), 'ca_object_representations->insert()');
@@ -493,11 +494,13 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 		if (!($media_path = $this->getMediaPath('media', 'original'))) {
 			$media_path = array_shift($this->get('media', ['returnWithStructure' => true]));
 		}
-		if(!$this->getAppConfig()->get('allow_representations_duplicate_media') && ($t_existing_rep = ca_object_representations::mediaExists($media_path))) {
+		if($media_path && !$this->getAppConfig()->get('allow_representations_duplicate_media') && ($t_existing_rep = ca_object_representations::mediaExists($media_path))) {
 			throw new MediaExistsException(_t('Media already exists'), $t_existing_rep);
 		}
 		
 		// do insert
+		$reader = $media_path ? $this->_readEmbeddedMetadata($media_path) : null;
+		
 		if ($vn_rc = parent::insert($options)) {
 			if (is_array($va_media_info = $this->getMediaInfo('media', 'original'))) {
 				$this->set('md5', $va_media_info['MD5']);
@@ -523,7 +526,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 			caExtractEmbeddedMetadata($this, $va_metadata, $this->get('locale_id'));	// TODO: deprecate in favor of import mapping based system below?
 			
 			// Extract metadata mapping with configured mappings
-			$this->_importEmbeddedMetadata($options);
+			$this->_importEmbeddedMetadata(array_merge($options, ['reader' => $reader]));
 			
 			$vn_rc = parent::update($options);
 
@@ -536,6 +539,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	 *
 	 */
 	public function update($options=null) {
+		if(!is_array($options)) { $options = []; }
 		if($vb_media_has_changed = $this->changed('media')) {
 			// does media already exist?
 			if (!($media_path = $this->getMediaPath('media', 'original'))) {
@@ -545,6 +549,10 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 				throw new MediaExistsException(_t('Media already exists'), $t_existing_rep);
 			}
 		}
+		
+		// Do update
+		$reader = $media_path ? $this->_readEmbeddedMetadata($media_path) : null;
+		
 		if ($vn_rc = parent::update($options)) {
 			if(is_array($va_media_info = $this->getMediaInfo('media', 'original'))) {
 				$this->set('md5', $va_media_info['MD5']);
@@ -571,7 +579,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 				caExtractEmbeddedMetadata($this, $va_metadata, $this->get('locale_id'));	// TODO: deprecate in favor of import mapping based system below?
 								
 				// Extract metadata mapping with configured mappings
-				$this->_importEmbeddedMetadata($options);
+				$this->_importEmbeddedMetadata(array_merge($options, ['reader' => $reader]));
 			}
 			
 			$vn_rc = parent::update($options);
@@ -585,20 +593,33 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 	/**
 	 *
 	 */
-	private function _importEmbeddedMetadata($options=null) {
-		$object_representation_mapping_id = caGetOption('mapping_id', $options, null);
-		$log = caGetImportLogger(['logLevel' => $this->_CONFIG->get('embedded_metadata_extraction_mapping_log_level')]);
-		if(!$object_representation_mapping_id && is_array($media_metadata_extraction_defaults = $this->_CONFIG->getAssoc('embedded_metadata_extraction_mapping_defaults'))) {
-			$media_mimetype = $this->get('mimetype');
-			
-			foreach($media_metadata_extraction_defaults as $m => $importer_code) {
-				if(caCompareMimetypes($media_mimetype, $m)) {
-					if (!($object_representation_mapping_id = ca_data_importers::find(['importer_code' => $importer_code], ['returnAs' => 'firstId']))) {
-						if ($log) { $log->logInfo(_t('Could not find embedded metadata importer with code %1', $importer_code)); }
-					}
-					break;
-				}
+	private function _readEmbeddedMetadata(string $media_path, ?array $options=null) {
+		$t_mapping = new ca_data_importers();
+		$m = new Media();
+		$mimetype = $m->divineFileFormat($media_path);
+		
+		$type = 'EXIF';
+		if ($object_representation_mapping_id = $this->_getEmbeddedMetadataMappingID(['mimetype' => $mimetype])) {
+			$t_mapping = ca_data_importers::find(['importer_id' => $object_representation_mapping_id], ['returnAs' => 'firstModelInstance']);
+			$formats = $t_mapping->getSetting('inputFormats');
+			if(is_array($formats) && sizeof($formats)) {
+				$type = array_shift($formats);
 			}
+		}
+		if (!($reader = $t_mapping->getDataReader(null, $type))) { return null; }
+		$reader->read($media_path);
+		
+		return $reader;
+	}
+	# ------------------------------------------------------
+	/**
+	 *
+	 */
+	private function _importEmbeddedMetadata($options=null) {
+		$path = caGetOption('path', $options, $this->getMediaPath('media', 'original'));
+		$log = caGetImportLogger(['logLevel' => $this->_CONFIG->get('embedded_metadata_extraction_mapping_log_level')]);
+		if(!($object_representation_mapping_id = caGetOption('mapping_id', $options, null))) {
+			$object_representation_mapping_id = $this->_getEmbeddedMetadataMappingID(['log' => $log]);
 		}
 		
 		if ($object_representation_mapping_id && ($t_mapping = ca_data_importers::find(['importer_id' => $object_representation_mapping_id], ['returnAs' => 'firstModelInstance']))) {
@@ -607,15 +628,38 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 			if ($log) { $log->logDebug(_t('Using embedded media mapping %1 (format %2)', $t_mapping->get('importer_code'), $format)); }
 			
 			$va_media_info = $this->getMediaInfo('media');
-			$t_importer = new ca_data_importers();
-			return $t_importer->importDataFromSource($this->getMediaPath('media', 'original'), $object_representation_mapping_id, [
+			return $t_mapping->importDataFromSource($path, $object_representation_mapping_id, [
 				'logLevel' => $this->_CONFIG->get('embedded_metadata_extraction_mapping_log_level'), 
 				'format' => $format, 'forceImportForPrimaryKeys' => [$this->getPrimaryKey(), 
 				'transaction' => $this->getTransaction()],
+				'reader' => caGetOption('reader', $options, null),
 				'environment' => ['original_filename' => $va_media_info['ORIGINAL_FILENAME'], '/original_filename' => $va_media_info['ORIGINAL_FILENAME']]
 			]); 
 		}
 		return false;
+	}
+	# ------------------------------------------------------
+	/**
+	 *
+	 */
+	private function _getEmbeddedMetadataMappingID(?array $options=null) : ?int {
+		$object_representation_mapping_id = null;
+		
+		$log = caGetOption('log', $options, null);
+		if(is_array($media_metadata_extraction_defaults = $this->_CONFIG->getAssoc('embedded_metadata_extraction_mapping_defaults'))) {
+			$media_mimetype = caGetOption('mimetype', $options, $this->get('mimetype'));
+			
+			foreach($media_metadata_extraction_defaults as $m => $importer_code) {
+				if(!trim($importer_code)) { continue; }
+				if(caCompareMimetypes($media_mimetype, $m)) {
+					if (!($object_representation_mapping_id = ca_data_importers::find(['importer_code' => $importer_code], ['returnAs' => 'firstId']))) {
+						if ($log) { $log->logInfo(_t('Could not find embedded metadata importer with code %1', $importer_code)); }
+					}
+					break;
+				}
+			}
+		}
+		return $object_representation_mapping_id;
 	}
 	# ------------------------------------------------------
 	/**

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -550,7 +550,6 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 			}
 		}
 		
-		// Do update
 		$reader = $media_path ? $this->_readEmbeddedMetadata($media_path) : null;
 		
 		if ($vn_rc = parent::update($options)) {


### PR DESCRIPTION
Normally all configured versions are generated when media is uploaded. In some cases it  may be desirable to not create a version if a file exceeds a certain size. For example, it  may not be practical to store large original, high-quality media files, but the derivatives of that file are still required. In this case you can specify in the media_processing.conf configuration file  that selected versions be skipped after a threshold is reached, and optionally that another, existing, version  is used in its place whenever it is referenced. The SKIP_WHEN_FILE_LARGER_THAN and REPLACE_WITH_VERSION  options may be set for this purpose.

PR implements options for situations where skipping versions must be dependent upon metadata in the representation record, rather than just file type and size. Rules can be specified using the new `skip_object_representation_versions_for_mimetype_when` directive. Rules are set by mime type and version. The example will skip the "original" version for video files if they  are larger than 500k and have their "ca_object_representations.access_pres" metadata value set to "Preservation".  When skipped the "medium" version will be used as a placeholder wherever "original" is referenced.