### PR TITLE
Add deduplicate option

### DIFF
--- a/app/models/ca_data_exporter_items.php
+++ b/app/models/ca_data_exporter_items.php
@@ -280,6 +280,20 @@ class ca_data_exporter_items extends BaseModel {
 			'label' => _t('Repeat element for multiple values'),
 			'description' => _t('If the current selector/template returns multiple values, this setting determines if the element is repeated for each value.')
 		);
+		
+		$va_settings['deduplicate'] = array(
+			'formatType' => FT_BIT,
+			'displayType' => DT_SELECT,
+			'width' => 40, 'height' => 1,
+			'takesLocale' => false,
+			'default' => 0,
+			'options' => array(
+				_t('yes') => 1,
+				_t('no') => 0
+			),
+			'label' => _t('Remove duplicate values'),
+			'description' => _t('Remove duplicate values from returned set of values for export.')
+		);
 
 		$va_settings['convertCodesToDisplayText'] = array(
 			'formatType' => FT_BIT,
@@ -675,7 +689,6 @@ class ca_data_exporter_items extends BaseModel {
 			}
 			foreach($regexes as $regex_index => $regex_info) {
 				if(!strlen($regex_info['match'])) { continue; }
-				if(!strlen($regex_info['replaceWith'])) { continue; }
 				$regex = "!".str_replace("!", "\\!", $regex_info['match'])."!u".((isset($regex_info['caseSensitive']) && (bool)$regex_info['caseSensitive']) ? '' : 'i');
 				
 				$value = preg_replace($regex , $regex_info['replaceWith'], $value);

--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1840,6 +1840,7 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 		$vs_source = $t_exporter_item->get('source');
 		$vs_element = $t_exporter_item->get('element');
 		$vb_repeat = $settings['repeat_element_for_multiple_values'];
+		$deduplicate = $settings['deduplicate'];
 
 		if($vs_skip_if_empty = $settings['skipIfEmpty']) {
 			if(!(strlen($t_instance->get($vs_source))>0)) {
@@ -2080,8 +2081,10 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 				}
 			} else {
 				if(!$vb_repeat) {
-					$vs_get = $t_instance->get($vs_source, $va_get_options);
-
+					$va_values = $t_instance->get($vs_source, array_merge($va_get_options, ['returnAsArray' => true]));
+					if($deduplicate) { $va_values = array_unique($va_values); } 
+					
+					$vs_get = join(caGetOption('delimiter', $va_get_opts, ';'), $va_values);
 					$o_log->logDebug(_t("Source is a simple get() for some bundle. Value for this mapping is '%1'", $vs_get));
 					$o_log->logDebug(_t("get() options are: %1", print_r($va_get_options,true)));
 
@@ -2093,6 +2096,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 				} else { // user wants current element repeated in case of multiple returned values
 					
 					$va_values = $t_instance->get($vs_source, array_merge($va_get_options, ['returnAsArray' => true]));
+					if($deduplicate) { $va_values = array_unique($va_values); } 
+					
 					if($return_raw_data) { $va_values_raw = $t_instance->get($vs_source, ['returnAsArray' => true]); }
 					$o_log->logDebug(_t("Source is a get() that should be repeated for multiple values. Value for this mapping is '%1'. It includes the custom delimiter ';#;' that is later used to split the value into multiple values.", $vs_values));
 					$o_log->logDebug(_t("get() options are: %1", print_r($va_get_options,true)));


### PR DESCRIPTION
PR added deduplicate option to exporter mappings. When enabled on a mapping that exports multiple values, the exported list will have duplicating values removed prior to output.