### PR TITLE
Remove default to set order in searches on sets

### DIFF
--- a/app/lib/BaseSearchBuilderController.php
+++ b/app/lib/BaseSearchBuilderController.php
@@ -137,9 +137,9 @@
 					}
 					
 					// ... and default the sort to the set
-					if ($vb_is_new_search) {
-						$this->opo_result_context->setCurrentSort($vs_sort = "ca_sets.set_id:{$vn_set_id}");
-					}
+					//if ($vb_is_new_search) {
+					//	$this->opo_result_context->setCurrentSort($vs_sort = "ca_sets.set_id:{$vn_set_id}");
+					//}
 				}
 				
 				$va_search_opts = array(

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -132,9 +132,9 @@
 					}
 					
 					// ... and default the sort to the set
-					if ($vb_is_new_search) {
-						$this->opo_result_context->setCurrentSort($vs_sort = "ca_sets.set_id:{$vn_set_id}");
-					}
+					//if ($vb_is_new_search) {
+					//	$this->opo_result_context->setCurrentSort($vs_sort = "ca_sets.set_id:{$vn_set_id}");
+					//}
 				}
 				
 				$va_search_opts = array(


### PR DESCRIPTION
PR remove behavior to default to set order in searches on sets, as this seems to confuse 8 out of 10 users.