### PR TITLE
Handle search builder query parser exceptions

### DIFF
--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -518,7 +518,7 @@ var caUI = caUI || {};
 					skipWhitespace(tokens);
 				}
 			} catch(error) {
-				console.log("error: " + error);
+				console.log("Query translator parse error: " + error);
 			}
 		}
 		return ruleSet;


### PR DESCRIPTION
PR wraps search builder query parse in try block to ensure parse exceptions don't result in a very confusing blank form.