### PR TITLE
Resolve movement-based location tracking failure to save when moving storage location within hierarchy

### DIFF
--- a/app/models/ca_storage_locations.php
+++ b/app/models/ca_storage_locations.php
@@ -573,8 +573,8 @@ class ca_storage_locations extends RepresentableBaseModel implements IBundleProv
 				}
 			}
 		}
-		if($we_set_transaction) { $this->removeTransaction($vn_rc); }
-		return $vn_rc;
+		if($we_set_transaction) { $this->removeTransaction(true); }
+		return true;
 	}
 	# ------------------------------------------------------
 }


### PR DESCRIPTION
PR resolves movement-based location tracking failure to save when moving storage location within hierarchy due to improper handling of return codes and transaction commit.