### PR TITLE
Explicitly assign admin role to default login

### DIFF
--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -2607,6 +2607,11 @@ class Installer {
 			$this->addError("Errors while adding the default administrator account: ".join("; ",$t_user->getErrors()));
 			return false;
 		}
+		
+		if(!$t_user->addRoles(['admin'])) {
+			$this->addError("Could not add the <em>admin</em> role to the default administrator account: ".join("; ",$t_user->getErrors()));
+			return false;
+		}
 
 		return $ps_password;
 	}


### PR DESCRIPTION
PR modifies installer to explicitly allocate "admin" role to default admin login.