### PR TITLE
Resolve issue preventing generation of Office-media page previews

### DIFF
--- a/app/conf/media_display.conf
+++ b/app/conf/media_display.conf
@@ -73,13 +73,13 @@ media_overlay = {
 	documents = {
 		mimetypes = {application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.ms-excel, 
 		application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation},
-		display_version = tilepic,
+		display_version = pdf,
 		alt_display_version = large,
 		viewer_width = 820, viewer_height = 520,
 		poster_frame_version = mediumlarge,
 		download_version = original,
 		
-		viewer = Mirador
+		viewer = pdfjs
 	},
 	postscript = {
 		mimetypes = {application/postscript},

--- a/app/lib/Plugins/Media/Office.php
+++ b/app/lib/Plugins/Media/Office.php
@@ -58,6 +58,8 @@ class WLPlugMediaOffice Extends BaseMediaPlugin Implements IWLPlugMedia {
 	
 	var $opa_metadata;
 	
+	private $media = null;
+	
 	var $info = array(
 		"IMPORT" => array(
 			"text/rtf" 								=> "rtf",
@@ -613,9 +615,9 @@ class WLPlugMediaOffice Extends BaseMediaPlugin Implements IWLPlugMedia {
 	 */
 	public function &writePreviews($ps_filepath, $pa_options) {
 		if ($vs_pdf_path = WLPlugMediaOffice::$s_pdf_conv_cache[$this->filepath]) {
-			$o_media = new Media();
-			if ($o_media->read($vs_pdf_path)) {
-				return $o_media->writePreviews(array_merge($pa_options, array('dontUseDefaultIcons' => true)));	
+			$this->media = new Media();
+			if ($this->media->read($vs_pdf_path)) {
+				return $this->media->writePreviews(array_merge($pa_options, array('dontUseDefaultIcons' => true)));	
 			}
 		
 		}


### PR DESCRIPTION
PR resolves issue preventing generation of Office-media (Word, Excel, Powerpoint) page previews due to premature deletion of interim preview render files. Also changes default viewer for Office-media to PDFJS.