### PR TITLE
Resolve issues with metadata element soft delete behavior

### DIFF
--- a/app/lib/ConfigurationExporter.php
+++ b/app/lib/ConfigurationExporter.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2019 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -388,7 +388,7 @@ final class ConfigurationExporter {
 
 		$vo_elements = $this->opo_dom->createElement("elementSets");
 
-		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id IS NULL ORDER BY element_id");
+		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id IS NULL AND deleted = 0 ORDER BY element_id");
 
 		$t_element = new ca_metadata_elements();
 
@@ -553,7 +553,7 @@ final class ConfigurationExporter {
 		$t_element = new ca_metadata_elements();
 		$t_list = new ca_lists();
 
-		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id = ? ORDER BY element_id",$pn_parent_id);
+		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id = ? AND deleted = 0 ORDER BY element_id",$pn_parent_id);
 		if(!$qr_elements->numRows()) {
 			return null;
 		}

--- a/install/inc/schema_mysql.sql
+++ b/install/inc/schema_mysql.sql
@@ -380,7 +380,7 @@ create table ca_metadata_elements
    datatype                       tinyint unsigned               not null,
    settings                       longtext                       not null,
    `rank`                           smallint unsigned              not null default 0,
-   deleted              tinyint unsigned     not null,
+   deleted              tinyint unsigned     not null default 0,
    hier_left                      decimal(30,20)                 not null,
    hier_right                     decimal(30,20)                 not null,
    hier_element_id                smallint unsigned              null,


### PR DESCRIPTION
PR addresses two issues with recently added metadata element soft delete behavior:

- Set schema default for delete flag to 0 (not deleted)
- Filter deleted elements when exporting configuration profile