### PR TITLE
Miscellaneous fixes

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2159,6 +2159,10 @@ document_preview_quality = 95
 # These previews are discrete audio/video files covering a given annotation.
 dont_generate_annotation_previews = 1
 
+# Set to display file sizes in mebibytes (MiB, GiB, TiB) rather than megabytes (mb, gb, tb)
+# 
+show_filesizes_in_mebibytes = 1
+
 # -----------------------------------
 # Batch media processing
 # -----------------------------------

--- a/app/controllers/administrate/setup/relationship_type_editor/RelationshipTypeEditorController.php
+++ b/app/controllers/administrate/setup/relationship_type_editor/RelationshipTypeEditorController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2011 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -45,15 +45,25 @@
  			$va_cur_result = $o_result_context->getResultList();
  			$vn_id = $this->request->getParameter('type_id', pInteger);
  			$vn_parent_id = $this->request->getParameter('parent_id', pInteger);
+ 			$vn_above_id = $this->request->getParameter('above_id', pInteger);
  				
  			// If we're creating a new record we'll need to establish the table_num
  			// from the parent (there's always a parent)
  			if (!$vn_id) {
- 				$t_parent = new ca_relationship_types($vn_parent_id);
- 				if (!$t_parent->getPrimaryKey()) {
- 					$this->postError(1230, _t("Invalid parent"),"RelationshipTypeEditorController->Edit()");
- 					return;
- 				}
+ 				if($vn_above_id) {
+ 					$t_parent = new ca_relationship_types($vn_above_id);
+					if (!$t_parent->getPrimaryKey()) {
+						$this->postError(1230, _t("Invalid child"),"RelationshipTypeEditorController->Edit()");
+						return;
+					}	
+					
+				} else {
+					$t_parent = new ca_relationship_types($vn_parent_id);
+					if (!$t_parent->getPrimaryKey()) {
+						$this->postError(1230, _t("Invalid parent"),"RelationshipTypeEditorController->Edit()");
+						return;
+					}
+				}
  				$this->request->setParameter('table_num', $t_parent->get('table_num'));
  			}
  			

--- a/app/lib/Attributes/Values/TextAttributeValue.php
+++ b/app/lib/Attributes/Values/TextAttributeValue.php
@@ -392,7 +392,7 @@
  					'value' => '{{'.$pa_element_info['element_id'].'}}', 
  					'maxlength' => $va_settings['maxChars'],
  					'class' => $vs_class,
- 					'id' => '{fieldNamePrefix}'.$pa_element_info['element_id'].'_{n}', 'class' => "{$vs_class}".($va_settings['usewysiwygeditor'] ? " ckeditor" : '')
+ 					'id' => '{fieldNamePrefix}'.$pa_element_info['element_id'].'_{n}', 'class' => "{$vs_class}".($va_settings['usewysiwygeditor'] ? " ckeditor-element" : '')
  				);
  			if (caGetOption('readonly', $pa_options, false)) { 
  				$va_opts['disabled'] = 1;

--- a/app/lib/Attributes/Values/TimeCodeAttributeValue.php
+++ b/app/lib/Attributes/Values/TimeCodeAttributeValue.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2009-2020 Whirl-i-Gig
+ * Copyright 2009-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -40,7 +40,7 @@
  	require_once(__CA_LIB_DIR__.'/Parsers/TimecodeParser.php');
  
  	global $_ca_attribute_settings;
- 	$_ca_attribute_settings['TimecodeAttributeValue'] = array(		// global
+ 	$_ca_attribute_settings['TimeCodeAttributeValue'] = array(		// global
 		'fieldWidth' => array(
 			'formatType' => FT_NUMBER,
 			'displayType' => DT_FIELD,
@@ -212,7 +212,7 @@
 			if (strlen($ps_value)) {
 				if ($o_tcp->parse($ps_value) === false) { 
 					// invalid timecode
-					$this->postError(1970, _t('%1 is invalid', $pa_element_info['displayLabel']), 'TimecodeAttributeValue->parseValue()');
+					$this->postError(1970, _t('%1 is invalid', $pa_element_info['displayLabel']), 'TimeCodeAttributeValue->parseValue()');
 					return false;
 				}
 				$vn_seconds = (float)$o_tcp->getParsedValueInSeconds();
@@ -265,7 +265,7 @@
  		public function getAvailableSettings($pa_element_info=null) {
  			global $_ca_attribute_settings;
  			
- 			return $_ca_attribute_settings['TimecodeAttributeValue'];
+ 			return $_ca_attribute_settings['TimeCodeAttributeValue'];
  		}
  		# ------------------------------------------------------------------
 		/**

--- a/app/lib/ConfigurationExporter.php
+++ b/app/lib/ConfigurationExporter.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012-2019 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -388,7 +388,7 @@ final class ConfigurationExporter {
 
 		$vo_elements = $this->opo_dom->createElement("elementSets");
 
-		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id IS NULL ORDER BY element_id");
+		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id IS NULL AND deleted = 0 ORDER BY element_id");
 
 		$t_element = new ca_metadata_elements();
 
@@ -553,7 +553,7 @@ final class ConfigurationExporter {
 		$t_element = new ca_metadata_elements();
 		$t_list = new ca_lists();
 
-		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id = ? ORDER BY element_id",$pn_parent_id);
+		$qr_elements = $this->opo_db->query("SELECT * FROM ca_metadata_elements WHERE parent_id = ? AND deleted = 0 ORDER BY element_id",$pn_parent_id);
 		if(!$qr_elements->numRows()) {
 			return null;
 		}

--- a/app/lib/Import/BaseDataReader.php
+++ b/app/lib/Import/BaseDataReader.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2013-2015 Whirl-i-Gig
+ * Copyright 2013-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -135,6 +135,9 @@ abstract class BaseDataReader {
 		switch($ps_field) {
 			case '__now__':
 				$vs_val = date("Y-m-d H:i:s");
+				break;
+			case '__date__':
+				$vs_val = date("Y-m-d");
 				break;
 			case '__row__':
 				$vs_val = $this->currentRow();

--- a/app/lib/Plugins/InformationService/BaseNomismaLODServicePlugin.php
+++ b/app/lib/Plugins/InformationService/BaseNomismaLODServicePlugin.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2018 Whirl-i-Gig
+ * Copyright 2018-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -150,7 +150,12 @@ abstract class BaseNomismaLODServicePlugin extends BaseInformationServicePlugin 
 			if(!isset($va_node['literal'])) { continue; }
 
 			$vs_uri_for_pull = isset($va_node['uri']) ? $va_node['uri'] : null;
-			$va_return[$vs_key] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull, $va_node));
+			
+			try {
+				$va_return[$vs_key] = str_replace('; ', ' ', self::getLiteralFromRDFNode($ps_url, $va_node['literal'], $vs_uri_for_pull, $va_node));
+			} catch (Exception $e) {
+				continue;
+			}
 		}
 
 		return $va_return;

--- a/tests/testsWithData/BaseTestWithData.php
+++ b/tests/testsWithData/BaseTestWithData.php
@@ -97,6 +97,29 @@ abstract class BaseTestWithData extends TestCase {
 		return $vn_return;
 	}
 	# -------------------------------------------------------
+	/**
+	 * @param string $ps_table Target table
+	 * @param array $pa_data Test data. Format of a single record is similar to the JSON format used in the
+	 * Web Service API, only that it's a PHP array, obviously. In fact, we use the same code to insert the data.
+	 *
+	 * @see http://docs.collectiveaccess.org/wiki/Web_Service_API#Creating_new_records
+	 * @see https://gist.githubusercontent.com/skeidel/3871797/raw/item_request.json
+	 * @return int the primary key of the newly created record
+	 */
+	protected function addTestRelationship$ps_table, $pa_data) {
+		if(!is_array($pa_data)) { return false; }
+
+		$o_itemservice = new ItemService($this->opo_request, $ps_table);
+		$va_return = $o_itemservice->addItem($ps_table, $pa_data);
+		if(!$va_return) {
+			$this->assertTrue(false, 'Inserting test data failed. API errors are: ' . join(' ', $o_itemservice->getErrors()));
+		}
+
+		$this->opa_record_map[$ps_table][] = $vn_return = array_shift($va_return);
+
+		return $vn_return;
+	}
+	# -------------------------------------------------------
 	protected function getRecordMap() {
 		return $this->opa_record_map;
 	}

--- a/themes/default/views/bundles/hierarchy_location.php
+++ b/themes/default/views/bundles/hierarchy_location.php
@@ -410,7 +410,7 @@
 						} else {
 							// for items without types
 							print "<div id='{$id_prefix}HierarchyBrowseAdd'>"._t("Add a new %1 %2 <em>%3</em>",  $t_subject->getProperty('NAME_SINGULAR'), caHTMLSelect('add_type', $va_add_types, array('id' => "{$id_prefix}addType"), ['value' => Session::getVar('default_hierarchy_add_mode')]), $vs_subject_label);
-							print " <a href='#' onclick='_navigateToNewForm(0, jQuery(\"#{$id_prefix}addType\").val(), (jQuery(\"#{$id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
+							print " <a href='#' onclick='_navigateToNewForm(0, jQuery(\"#{$id_prefix}addType\").val(), (jQuery(\"#{$id_prefix}addType\").val() == \"next_to\") ? ".intval($pn_parent_id)." : ".intval($pn_id).", ".intval($pn_id).")'>".caNavIcon(__CA_NAV_ICON_ADD__, '15px')."</a></div>";
 						}
 ?>
 					</div>
@@ -516,15 +516,19 @@
 ?>	
 	if (typeof  _navigateToNewForm != 'function') {
 		function _navigateToNewForm(type_id, action, id, after_id) {
+			if(!type_id) { type_id = ''; }
 			switch(action) {
 				case 'above':
-					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/above_id/' + id;
+					if(!id) { break; }
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>' + (type_id ? '/type_id/' + type_id : '') + '/above_id/' + id;
 					break;
 				case 'under':
-					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id;
+					if(!id) { break; }
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>' + (type_id ? '/type_id/' + type_id : '') + '/parent_id/' + id;
 					break;
 				case 'next_to':
-					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>/type_id/' + type_id + '/parent_id/' + id + '/after_id/' + after_id;
+					if(!after_id) { break; }
+					document.location = '<?= caEditorUrl($this->request, $t_subject->tableName(), 0); ?>' + (type_id ? '/type_id/' + type_id : '') + '/parent_id/' + id + '/after_id/' + after_id;
 					break;
 				default:
 					alert("Invalid action!");


### PR DESCRIPTION
PR implements miscellaneous fixes:

- Fix capitalization error that can prevent global settings from being displayed
- Add __date__ placeholder tag in importer. Returns current date without time.
- Prevent type errors when ids aren't set in hierarchy brower
- Add additional hierarchical add options for relationship types
- Prevent CKEditor warning about repeat initializations
- Prevent uncaught exceptions due to bad Nomisma service data
- Add method for adding of test relationships