### PR TITLE
Improve processing and sortable value generation for organization entity names

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4087,7 +4087,8 @@ function caFileIsIncludable($ps_file) {
 		$o_locale_settings = TimeExpressionParser::getSettingsForLanguage($ps_locale);
 
 		$vs_display_value = trim(preg_replace('![^\p{L}0-9 ]+!u', ' ', $ps_text));
-
+		$vs_display_value = preg_replace('![ ]+!', ' ', $vs_display_value);
+		
 		// Move articles to end of string
 		$va_articles = caGetArticlesForLocale($ps_locale) ?: [];
 

--- a/app/lib/Utils/DataMigrationUtils.php
+++ b/app/lib/Utils/DataMigrationUtils.php
@@ -746,6 +746,11 @@
 				}
 			}
 			
+			// Treat parentheticals as suffixes
+			if (preg_match("![,]*[ ]*([\(]+.*[ \)]+)$!i", $text, $matches)) {
+				$name['suffix'] = $matches[1];
+				$text = str_replace($matches[0], '', $text);
+			}
 			$name['surname'] = $text;
 			return $name;
 		}

--- a/app/models/ca_entity_labels.php
+++ b/app/models/ca_entity_labels.php
@@ -349,12 +349,12 @@ class ca_entity_labels extends BaseLabel {
 				$is_org = ($et->getSetting('entity_class') === 'ORG');
 			}
 			if($is_org) {
-				$n = $this->get('ca_entity_labels.surname');
+				parent::_generateSortableValue();
 			} else {
 				$n = DataMigrationUtils::splitEntityName($this->get($vs_display_field), ['displaynameFormat' => 'surnamecommaforename']);
 				$n = $n['displayname'];
+				$this->set($vs_sort_field, $n);
 			}
-			$this->set($vs_sort_field, $n);
 		}
 	}
 	# ------------------------------------------------------


### PR DESCRIPTION
PR modifies processing and sortable name generation:

1.  Treat parentheticals as suffixes when following surname
2. Pass organization names through standard sortable value processing to ensure stripping of articles.
3. Strip repeating spaces from sortable values, which can undesirably skew sort order
4. Add option to caUtils to limit rebuilding of sort values to specific tables.