### PR TITLE
Profile exporter improvements

### DIFF
--- a/app/controllers/administrate/maintenance/ExportConfigurationController.php
+++ b/app/controllers/administrate/maintenance/ExportConfigurationController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2012 Whirl-i-Gig
+ * Copyright 2012-2021 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -47,10 +47,11 @@ class ExportConfigurationController extends ActionController {
 	# ------------------------------------------------
 	public function Export(){
 		set_time_limit(3600);
-		$vs_xml = ConfigurationExporter::exportConfigurationAsXML($this->request->config->get('app_name'), _t('Profile created on %1 by %2', caGetLocalizedDate(), $this->request->user->get('fname').' '.$this->request->user->get('lname')), 'base', '');
+		$name = preg_replace("![^A-Za-z0-9_\-]+!", "_", __CA_APP_DISPLAY_NAME__);
+		$vs_xml = ConfigurationExporter::exportConfigurationAsXML($name, _t('Profile created on %1 by %2', caGetLocalizedDate(), $this->request->user->get('fname').' '.$this->request->user->get('lname')), 'base', '');
 		
 		$this->view->setVar('profile', $vs_xml);
-		$this->view->setVar('profile_file_name', $this->request->config->get('app_name').'_config.xml');
+		$this->view->setVar('profile_file_name', $name.'_config.xml');
 		$this->render('export_configuration_binary.php');
 		
 		return;

--- a/app/lib/ConfigurationExporter.php
+++ b/app/lib/ConfigurationExporter.php
@@ -1048,7 +1048,7 @@ final class ConfigurationExporter {
 						$vo_placement = $this->opo_dom->createElement("placement");
 						$vo_placements->appendChild($vo_placement);
 
-						$vo_placement->setAttribute("code", $vs_code = $this->makeIDNO($va_placement["placement_code"], 30, $va_used_codes));
+						$vo_placement->setAttribute("code", $vs_code = $this->makeIDNO($va_placement["placement_code"], 100, $va_used_codes));
 
 						if (isset($va_placement['settings']['bundleTypeRestrictions']) && (is_array($va_type_restrictions = $va_placement['settings']['bundleTypeRestrictions']) || strlen($va_type_restrictions))) {
 							if($va_type_restrictions && !is_array($va_type_restrictions)) { $va_type_restrictions = [$va_type_restrictions]; }
@@ -1871,7 +1871,7 @@ final class ConfigurationExporter {
 	# -------------------------------------------------------
 	// Utilities
 	# -------------------------------------------------------
-	private function makeIDNO($ps_idno, $pn_length = 30, $pa_used_list=null) {
+	private function makeIDNO($ps_idno, $pn_length = 100, $pa_used_list=null) {
 		if(strlen($ps_idno)>0) {
 			$vs_code =  substr(preg_replace("/[^_a-zA-Z0-9]/","_",$ps_idno),0, $pn_length);
 		} else {
@@ -1916,8 +1916,8 @@ final class ConfigurationExporter {
 	 */
 	private function makeIDNOFromInstance($po_model_instance, $ps_field_name, $pa_used_list=null) {
 		$va_length = $po_model_instance->getFieldInfo($ps_field_name, 'BOUNDS_LENGTH');
-		// Previously this was always 30, so let's be conservative
-		$vn_max_length = isset($va_length[1]) ? $va_length[1] : 30;
+		
+		$vn_max_length = isset($va_length[1]) ? $va_length[1] : 100;
 		$vs_value = $po_model_instance->get($ps_field_name);
 		return $this->makeIDNO($vs_value, $vn_max_length, $pa_used_list);
 	}


### PR DESCRIPTION
PR modifies profile exporter to prevent truncation of long (> 30 chars) identifiers, and provides exported profiles with more relevant <profileName> values.