### PR TITLE
caExtractTagsFromTemplate : broken for marc

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4378,8 +4378,8 @@ function caFileIsIncludable($ps_file) {
 
 			if ($vb_is_ca_tag && (strpos($vs_tag, '%') === false)) {
 				// ca_* tags that don't have modifiers always end whenever a non-alphanumeric character is encountered
-				$vs_tag = preg_replace("![^0-9\p{L}_]+$!u", "", $vs_tag);
-			} elseif(preg_match("!^([\d]+)[^0-9\p{L}_]+!", $vs_tag, $va_matches)) {
+				$vs_tag = preg_replace("![^0-9/\p{L}_]+$!u", "", $vs_tag);
+			} elseif(preg_match("!^([\d]+)[^0-9/\p{L}_]+!", $vs_tag, $va_matches)) {
 				// tags beginning with numbers followed by non-alphanumeric characters are truncated to number-only tags
 				$vs_tag = $va_matches[1];
 			}


### PR DESCRIPTION
Hi CA Team,

Adding the "/" to the not-to-be-removed parts of a template, as "^701/a" is a valid template, handled by method get inside MarcDataReader 
```
	public function get($ps_spec, $pa_options=null) {
		// [...]
		list($ps_code, $ps_subcode, $ps_indicators) = explode('/', $ps_spec);
```

I know these times marc tends to be more and more replaced by XMLmarc, but there are still some uses for example with Z9350 when SUTRS is not available.

Gautier