### PR TITLE
pass local locale from row options

### DIFF
--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1827,8 +1827,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 			// which is why we unset it here and restore it later
 			global $g_ui_locale;
 			$vs_old_ui_locale = $g_ui_locale;
-			$g_ui_locale = null;
 
+			$g_ui_locale = $vs_locale;
 			$va_get_options['locale'] = $vs_locale;
 		}
 		


### PR DESCRIPTION
Hi,

When locale is set as an option in the oai export mapping {"locale": "nl_BE",..} it looks like it does not get passed to the translation function, as reported by my colleague @aruijmen last week on gitter.

current situation:
The locale is picked up in ca_data_exporter, but not passed along to the translation function. The global locale is parked to reset later but nulled. As a result there is no preferred_language at translation time, only the fallback languages but in our multilang setup the selected fallback language does not necessarily reflect the user-selected locale in the mapping.

new situation:
the locale option is set to the global instead of nulled, so that it arrives to the translation function as the preferred language and gets priority in the normal language priority flow (preferred > fallback > desperation_mode). The global locale is still reset to the original (system) value later in your code.

follow up question:
it would be a nice-to-have to have a way to set this "locale filter" more globally (and not on a per-field basis). Unfortunately the OAI provider specification does not allow a language query_param (yet), but as an alternative it can be an option to have it in the oai_provider.conf or the mapping general settings perhaps (and thus available as a config or setting variable) ? That way end-users do not have to repeat the same locale option to all translatable fields individually (ie, sometimes hundreds of times). 
This solution does still require duplication of the mapping or oai endpoint for each language however (avoidable by having it as a more global query_param - but that would be breaking the provider protocol) but that duplication also needs to be done on a per-field implementation (as-is).

Would you prefer this as a provider configuration (oai_provider.conf) or a mapping setting (next to ouput format,..) ? 
I can make  a PR for this extra feature.
Or do you see other ways how to filter the output to a single user-selected language ?
(also: the non-allowed language queryparameter can be added relatively easy to the oai provider;  but thus breaking the oai specs :p)
