### PR TITLE
Small bug-fix for prepopulate

### DIFF
--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -338,7 +338,7 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 							}
 		
 							foreach(array_shift($source_values) as $attr_id => $attr) {
-								if ($vs_mode == 'merge') {
+								if (($vs_mode == 'merge') && (sizeof($va_attributes)>0)) {
 									// Merge mode
 									// Make a temporary copy of the original attribute
 									foreach($va_attributes[$i]->getValues() as $v) {


### PR DESCRIPTION
When the target array is empty, going inside merge mode will lead to errors due to the fact that it tries to use getValues() from an empty array. Now will fall back to overwrite mode if the target array is empty