### PR TITLE
fix fetching .url and .name in informationservice when in container

### DIFF
--- a/app/lib/Search/SearchResult.php
+++ b/app/lib/Search/SearchResult.php
@@ -2369,12 +2369,25 @@ class SearchResult extends BaseObject {
 								}
 
 								// support ca_objects.container.wikipedia.abstract
-								if(($vs_element_code == $va_path_components['subfield_name']) && ($va_path_components['num_components'] == 4)) {
-									$vs_val_proc = $o_value->getExtraInfo($va_path_components['components'][3]);
+								if(($vs_element_code == $va_path_components['subfield_name']) && ($va_path_components['num_components'] > 3)) {
+
+									switch($vs_final_path_key = end($va_path_components['components'])) {
+										case 'uri':
+										case 'url':
+											$vs_val_proc = $o_value->getUri();
+											break;
+										case 'name':
+											$vs_val_proc = $o_value->getDisplayValue(array_merge($pa_options, array('output' => $pa_options['output'])));
+											break;
+										default:
+											$vs_val_proc = $o_value->getExtraInfo($vs_final_path_key);
+											break;
+									}
+
 									$vb_dont_return_value = false;
 									break;
 								}
-							
+
 								// support ca_objects.wikipedia or ca_objects.container.wikipedia (Eg. no "extra" value specified)
 								if (($vs_element_code == $va_path_components['field_name']) || ($vs_element_code == $va_path_components['subfield_name'])) {
 									$vs_val_proc = $o_value->getDisplayValue(array_merge($pa_options, array('output' => $pa_options['output'])));


### PR DESCRIPTION
Hi, we were having problems getting the url from an InformationService when it was inside a container.
Apparently there was no specific workflow for that so I added it. I also tried to make it available for the case where there are multiple nested containers.

Maybe not the place to ask this follow-up question but since it is kind of related to this issue: are there any plans or can it be an idea to have the fieldnames unique by their full path, and not necessarily the field itself.
At the moment you can re-use a field over multiple entities (like ca_objects.dimensions and ca_entities.dimensions) but you would have to deduplicate the names when you want to re-use it otherwise (like ca_objects.frame.frame_dimensions and ca_objects.canvas.canvas_dimensions), it think it would make the accessability to the fields a lot more intuitive.