### PR TITLE
use indexing_tokenizer_regex for indexing

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch.php
@@ -2283,7 +2283,7 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 		
 			return preg_split('![ ]+!', trim(preg_replace("%((?<!\d)[".$this->ops_search_tokenizer_regex."]+(?!\d))%u", ' ', strip_tags($content))));
 		} else {
-			return preg_split('![ ]+!', trim(preg_replace("%((?<!\d)[".$this->ops_search_tokenizer_regex."]+|[".$this->ops_search_tokenizer_regex."]+(?!\d))%u", ' ', strip_tags($content))));
+			return preg_split('![ ]+!', trim(preg_replace("%((?<!\d)[".$this->ops_indexing_tokenizer_regex."]+(?!\d))%u", ' ', strip_tags($ps_content))));
 		}
 	}
 	# --------------------------------------------------


### PR DESCRIPTION
Hi, we were having problems searching for emailaddress because the address 'some.name@domain.com' was tokenized to [some name@domain com]. The current code did not use the indexing_tokenizer_regex for the indexing scenario (false:if ($for_search)) but another combination of the search_tokenizer_regex.

When I was making the code change I noticed there is ongoing rework of the code in SqlSearch2 that may cover this but I'm not sure if/how/when the switch is done to this alternative.

I noticed as well that there were multiple defaults declared (^\pL\pN\pNd/_#\@\&\- in search.conf, ^\pL\pN\pNd/_#\@\&\. in SqlSearch), I don't know if this a feature or an error ? I think the latter is only used when someone would (accidently ?) erase the config value, so in that case it can be a feature :) But maybe it is better to have them to the same value ?
I didn't make a specific commit for this one because in the end the defined search.conf value is used.

I had an asis_regex for emailaddress prepared, maybe that could be an addition to the app/conf/search.conf. I didn't make a commit for that one yet either because we can always provide that through our conf/local, but I can make a commit if you think that could be useful for Providence.