### PR TITLE
remove child navigation button in hierarchy browser for childless listitems

### DIFF
--- a/assets/ca/ca.hierbrowser.js
+++ b/assets/ca/ca.hierbrowser.js
@@ -480,7 +480,7 @@ var caUI = caUI || {};
 							if (that.uiStyle == 'horizontal') {
 								var moreButton = '';
 								if (that.editButtonIcon) {
-									if ((item.children > 0) || ((level == 0) && (item.children == null))){
+									if (item.children > 0) {
 										moreButton = "<div style='float: right;'><a href='#' id='hierBrowser_" + that.name + '_level_' + level + '_item_' + item['item_id'] + "_edit' aria-label='Expand hierarchy' >" + that.editButtonIcon + "</a></div>";
 									} else {
 										moreButton = "<div style='float: right;'><a href='#' id='hierBrowser_" + that.name + '_level_' + level + '_item_' + item['item_id'] + "_edit'  class='noChildren' aria-label='No children'>" + that.disabledButtonIcon + "</a></div>";


### PR DESCRIPTION
Hi,

The code was already modified before but can't the extra testing for level 0 be dropped altogether. It doesn't seem user-friendly/intuitive to have the arrow navigation for children when there are no child items to be expected (the first test). 
You still can select the item, and there doesn't seem to be other functionality to the childless button (other than clearing the (previous) next level) - or I may have missed that feature :p