### PR TITLE
Bug-Fix: Prepopulate restrictToRules and excludeRules not working

### DIFF
--- a/app/plugins/prepopulate/lib/applyPrepopulateRulesTool.php
+++ b/app/plugins/prepopulate/lib/applyPrepopulateRulesTool.php
@@ -114,7 +114,7 @@ class applyPrepopulateRulesTool extends BaseApplicationTool {
 				print CLIProgressBar::start($qr->numHits(), _t('Processing %1', $t));
 				while($qr->nextHit()) {
 					print CLIProgressBar::next(1, $qr->get("{$t}.preferred_labels"));
-					if (!$this->prepopulateInstance->prepopulateFields($qr->getInstance())) {
+					if (!$this->prepopulateInstance->prepopulateFields($qr->getInstance(),$options)) {
 						print "ERROR\n";
 					}
 				}

--- a/app/plugins/prepopulate/prepopulatePlugin.php
+++ b/app/plugins/prepopulate/prepopulatePlugin.php
@@ -91,8 +91,8 @@ class prepopulatePlugin extends BaseApplicationPlugin {
 	    	'Command' => 'apply-prepopulate-rules',
             'Options' => [
                         'restrictToTables|T-s' => _t('Apply rules only on specified tables. You can include multiple tables with a comma separated list (Ex: --restrictToTables="ca_objects,ca_entities". Cannot be used with excludeTables'),
-                        'excludeTables|t-s' => _t('Don\'apply rules on specified tables. You can exclude multiple tables with a comma separated list (Ex: --excludeTables="rule1,rule2". Cannot be used with restrictToTables'),
-                        'restrictToRules|R-s' => _t('Apply only specified rules. You can include multiple rules with a comma separated list (Ex: --restrictToRules="ca_objects,ca_entities". Cannot be used with excludeRules'),
+                        'excludeTables|t-s' => _t('Don\'apply rules on specified tables. You can exclude multiple tables with a comma separated list (Ex: --excludeTables="ca_objects,ca_entities". Cannot be used with restrictToTables'),
+                        'restrictToRules|R-s' => _t('Apply only specified rules. You can include multiple rules with a comma separated list (Ex: --restrictToRules="rule1,rule2". Cannot be used with excludeRules'),
                         'excludeRules|r-s' => _t('Don\'apply specified rules. You can exclude multiple rules with a comma separated list (Ex: --excludeRules="rule1,rule2". Cannot be used with restrictToRules'),
                         'findQuery|F-s' => _t("Accept an associative array of key and values in json format. Key can be an intrinsic or a metadata, used without table identifier. Ex: --findQuery='{\"idno\":\"foo\"}' to apply the rules to every record where idno=foo")],
 	        'Help' => _t('Applies rules defined in prepopulate.conf to all relevant records.'),


### PR DESCRIPTION
There was a missing parameter in app/plugins/prepopulate/lib/applyPrepopulateRulesTool.php that made the two rules broken. Meanwhile I fixed a typo in option's description