### PR TITLE
Include fix for tileviewer scrolling in master

### DIFF
--- a/assets/jquery/jquery-tileviewer/jquery.tileviewer.js
+++ b/assets/jquery/jquery-tileviewer/jquery.tileviewer.js
@@ -3298,10 +3298,11 @@ var methods = {
 						// Handle scrolling due to click on the overview
 						var tw = layer.thumb.width;
 						var th = layer.thumb.height;
+						var factor = Math.pow(2,layer.level);
 						
 						if ((x >= 0) && (x <= tw) && (y >= 0) && (y <= th)) {
-							view.pan.xdest = ((x/tw) * layer.info.width);
-							view.pan.ydest = ((y/th) * layer.info.height);
+							view.pan.xdest = ((x/tw) * layer.info.width / factor);
+							view.pan.ydest = ((y/th) * layer.info.height / factor);
 							view.pan.level = layer.level;
 							view.needdraw = true;
 							return;


### PR DESCRIPTION
All other parts of this system use a parabolic coefficient when calculating the relative position. It was missing here and simply needed to be added.