### PR TITLE
account for decimal separator while trailing zero cleaning

### DIFF
--- a/app/lib/Attributes/Values/WeightAttributeValue.php
+++ b/app/lib/Attributes/Values/WeightAttributeValue.php
@@ -193,11 +193,13 @@
 						$this->ops_text_value = $pa_value_array['value_longtext1'];
 					}
 					break;
- 			}	
- 			
- 			// Trim off trailing zeros in quantity
- 			$this->ops_text_value = preg_replace("!\.([1-9]*)[0]+([A-Za-z ]+)$!", ".$1$2", $this->ops_text_value);
- 			$this->ops_text_value = preg_replace("!\.([A-Za-z ]+)$!", "$1", $this->ops_text_value);
+ 			}
+
+		    // Trim off trailing zeros in quantity
+		    $symbols = Zend_Locale_Data::getList( $g_ui_locale, 'symbols');
+
+		    $this->ops_text_value = preg_replace(sprintf("!\%s([1-9]*)[0]+([A-Za-z ]+)$!",$symbols['decimal']), sprintf("%s$1$2",$symbols['decimal']), $this->ops_text_value);
+		    $this->ops_text_value = preg_replace(sprintf("!\%s([A-Za-z ]+)$!",$symbols['decimal']), "$1", $this->ops_text_value);
  			
  			$this->opn_decimal_value = $pa_value_array['value_decimal1'];
  		}


### PR DESCRIPTION
there is some cleaning done in Weight attribute for trailing zero's but that takes point as decimal separator hard coded, while some locales have comma as the decimal separator and that can give unwanted results.

For instance 1.160 is "cleaned" to 1.16 where is should stay as-is (1160,00 or 1.160 without decimals)

The registered value is always correct in the db (value_decimal), it's just this presentation that can be a bit off for some values (1.161 stays 1.161 because it doesn't go through the cleaning)