### PR TITLE
Fix search query builder fulltext search

### DIFF
--- a/app/conf/search_query_builder.conf
+++ b/app/conf/search_query_builder.conf
@@ -9,6 +9,7 @@ query_builder_global_options = {}
 query_builder_operators = {
 	select = [ equal, not_equal, is_empty, is_not_empty ],
 	string = [ equal, not_equal, begins_with, not_begins_with, ends_with, not_ends_with, contains, is_empty, is_not_empty ],
+	fulltext = [ contains ],
 	integer = [ equal, not_equal, between, not_between, is_empty, is_not_empty, less, less_or_equal, greater, greater_or_equal ],
 	double = [ equal, not_equal, between, not_between, is_empty, is_not_empty, less, less_or_equal, greater, greater_or_equal ],
 	date = [ equal, not_equal, is_empty, is_not_empty, less, less_or_equal, greater, greater_or_equal ],

--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -2094,6 +2094,9 @@
 		} elseif(preg_match("!^count[/\.]{1}!", $va_name[1]))  {
 			// counts are always ints
 			$va_result['type'] = 'integer';
+		} elseif ($vs_name === '_fulltext') {
+			# Mark type as fulltext so that correct operator(s) get made available.
+			$va_result['type'] = 'fulltext';
 		}
 		
 		// Use the relevant input field type and operators based on type.
@@ -2120,6 +2123,10 @@
 			$va_result['operators'] = array_merge($va_operators_by_type['select'], ['between']);
 		} else {
 			$va_result['input'] = 'text';
+		}
+		if ($va_result['type'] === 'fulltext') {
+			// Now mark type to be a valid type that is supported by Query Builder
+			$va_result['type'] = 'string';
 		}
 		
 		// Set up option groups

--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -382,10 +382,10 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 	 	}
 	 	$ap = $field ? $this->_getElementIDForAccessPoint($subject_tablenum, $field) : null;
 	 	$words = [$term->text];
-		if($field && $ap && !is_array($ap)) {
-			array_unshift($words, $field);
-			$field = null;
-		}
+	 	if($field && !is_array($ap)) {
+	 		array_unshift($words, $field);
+	 		$field = null;
+	 	}
 	 	$indexing_options = caGetOption('indexing_options', $ap, null);
 	 	
 	 	$blank_val = caGetBlankLabelText($subject_tablenum);

--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -382,10 +382,10 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 	 	}
 	 	$ap = $field ? $this->_getElementIDForAccessPoint($subject_tablenum, $field) : null;
 	 	$words = [$term->text];
-	 	if($field && !is_array($ap)) {
-	 		array_unshift($words, $field);
-	 		$field = null;
-	 	}
+		if($field && $ap && !is_array($ap)) {
+			array_unshift($words, $field);
+			$field = null;
+		}
 	 	$indexing_options = caGetOption('indexing_options', $ap, null);
 	 	
 	 	$blank_val = caGetBlankLabelText($subject_tablenum);


### PR DESCRIPTION
In older versions of Providence it was possible to perform searches such as `_fulltext:foobar` via the API or as a part of search query syntax and in the search query builder.

This restores that ability.