### PR TITLE
Fix always_create_new_movement/always_create_new_loan quickadds

### DIFF
--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -788,8 +788,8 @@ if($show_entity_controls) {
 <?php	
 			if(caGetOption('always_create_new_loan', $settings, false)) {
 ?>
-				jQuery('#<?= $vs_id_prefix; ?>AddLoan<?= $vn_type_id; ?>').on('click', function(e) { 
-					caRelationBundle<?= $vs_id_prefix; ?>_ca_loans_<?= $vn_type_id; ?>.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true }); 
+				jQuery('#<?= $vs_id_prefix; ?>AddLoan').on('click', function(e) {
+					caRelationBundle<?= $vs_id_prefix; ?>_ca_loans.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true });
 				});
 <?php
 			}
@@ -835,7 +835,7 @@ if($show_entity_controls) {
 <?php	
 			if(caGetOption('always_create_new_movement', $settings, false)) {
 ?>
-				jQuery('#<?= $vs_id_prefix; ?>AddMovement<?= $vn_type_id; ?>').on('click', function(e) { 
+				jQuery('#<?= $vs_id_prefix; ?>AddMovement').on('click', function(e) {
 					caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true }); 
 				});
 <?php


### PR DESCRIPTION
* Previously this was expecting a $vn_type_id to be defined for movements but this is not done in a similar manner to ca_occurrences, ca_collections and ca_entities which loop over occurrence types
* Reading the code I see that loans are also not broken out by types so fixing the resulting JS error there as well