### PR TITLE
Only add a single related item when always quick adding in history tracking

### DIFF
--- a/themes/default/views/bundles/history_tracking_chronology.php
+++ b/themes/default/views/bundles/history_tracking_chronology.php
@@ -791,6 +791,8 @@ if($show_entity_controls) {
 ?>
 				jQuery('#<?= $vs_id_prefix; ?>AddLoan').on('click', function(e) {
 					caRelationBundle<?= $vs_id_prefix; ?>_ca_loans.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true });
+					e.preventDefault();
+					return false;
 				});
 <?php
 			}
@@ -837,7 +839,9 @@ if($show_entity_controls) {
 			if(caGetOption('always_create_new_movement', $settings, false)) {
 ?>
 				jQuery('#<?= $vs_id_prefix; ?>AddMovement').on('click', function(e) {
-					caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true }); 
+					caRelationBundle<?= $vs_id_prefix; ?>_ca_movements.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true });
+					e.preventDefault();
+					return false;
 				});
 <?php
 			}
@@ -925,7 +929,9 @@ if($show_entity_controls) {
 			if(caGetOption('always_create_new_occurrence', $settings, false)) {
 ?>
 				jQuery('#<?= $vs_id_prefix; ?>AddOcc<?= $vn_type_id; ?>').on('click', function(e) { 
-					caRelationBundle<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true }); 
+					caRelationBundle<?= $vs_id_prefix; ?>_ca_occurrences_<?= $vn_type_id; ?>.triggerQuickAdd('', 'new_0', { usePolicy: <?= json_encode($policy); ?> }, {'addBundle': true });
+					e.preventDefault();
+					return false;
 				});
 <?php
 			}


### PR DESCRIPTION
* Previously a quick add would create two inputs with the related movement/loan/occurrence

Before: 
![image](https://user-images.githubusercontent.com/12571/197689638-8cbb11df-5f21-464e-a763-ed46fc7701bb.png)

After:
![image](https://user-images.githubusercontent.com/12571/197689537-d94bd168-1743-4150-93b5-e15ca5a14c3b.png)
