### PR TITLE
fix Uncaught TypeError: Cannot access offset of type string on string

### DIFF
--- a/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
+++ b/app/plugins/relationshipGenerator/relationshipGeneratorPlugin.php
@@ -102,7 +102,7 @@ class relationshipGeneratorPlugin extends BaseApplicationPlugin {
 						$this->_testConfigurationSection(
 							_t('trigger field %1 on rule %2', $vs_trigger_field, $vn_rule_index),
 							self::_getTriggerConfigurationRequirements(),
-							function ($key) use ($va_trigger) { return $va_trigger[$key]; },
+							function ($key) use ($va_triggers) { return $va_triggers[$key]; },
 							$va_errors
 						);
 					}


### PR DESCRIPTION
Hi,

We got this Uncaught TypeError: Cannot access offset of type string on string on the relationshipGenerator plugin

$va_trigger[$key], looks indeed that the current trigger (looped from $va_triggers) is already a string, and cannot be read with index key, so without knowing all context keeping the original $va_triggers seems the only choice here ? (makes you wonder how forgiving php<8 was if that wasn't a problem earlier - dates 2014)

So not completely sure this will "solve" the problem, but it clears the obvious typeError.

Peter