### PR TITLE
fix user_volatile_vars array corrupted by _changed boolean

### DIFF
--- a/app/models/ca_users.php
+++ b/app/models/ca_users.php
@@ -699,13 +699,13 @@ class ca_users extends BaseModel {
 			if (isset($pa_options['volatile']) && $pa_options['volatile']) {
 				$va_vars =& $this->opa_volatile_user_vars;
 				$vb_has_changed =& $this->opa_volatile_user_vars_have_changed;
-				
-				unset($this->opa_user_vars[$ps_key]);
+
+				if(is_array($this->opa_user_vars) && isset($this->opa_user_vars[$ps_key])) unset($this->opa_user_vars[$ps_key]);
 			} else {
 				$va_vars =& $this->opa_user_vars;
 				$vb_has_changed =& $this->opa_user_vars_have_changed;
 				
-				unset($this->opa_volatile_user_vars_have_changed[$ps_key]);
+				if(is_array($this->opa_volatile_user_vars) && isset($this->opa_volatile_user_vars[$ps_key])) unset($this->opa_volatile_user_vars[$ps_key]);
 			}
 			
 			if (isset($pa_options["ENTITY_ENCODE_INPUT"]) && $pa_options["ENTITY_ENCODE_INPUT"]) {


### PR DESCRIPTION
hi,

We got a fatal error Uncaught Error: Cannot unset offset in a non-array variable where there is attempt to unset on opa_volatile_user_vars_have_changed (the boolean) and that probably needs to be opa_volatile_user_vars (the array)??

Added more verbose (array/existingkey) test-before-unset while being there, and the neighbouring unset as well.