### PR TITLE
define and set boolean use item values

### DIFF
--- a/app/models/ca_bundle_displays.php
+++ b/app/models/ca_bundle_displays.php
@@ -578,6 +578,7 @@ if (!$pb_omit_editing_info) {
 								}
 							}
 
+							$vb_use_item_values = false;
 							switch($t_subject->getFieldInfo($va_bundle_name[1], 'DISPLAY_TYPE')) {
 								case 'DT_SELECT':
 									if ($vs_list_code = $t_subject->getFieldInfo($va_bundle_name[1], 'LIST')) {


### PR DESCRIPTION
boolean use item values only defined and set in one if condition, used twice later but possibly without existing. Might as well define as default false then?