### PR TITLE
no postError field existance on non-fields

### DIFF
--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -2070,7 +2070,7 @@ class BaseModel extends BaseObject {
 				}
 
 				if (!$this->hasField($vs_field)) {
-					$this->postError(716,_t("Field '%1' does not exist", $vs_field), "BaseModel->load()");
+					if(!is_numeric($vs_field)) $this->postError(716,_t("Field '%1' does not exist", $vs_field), "BaseModel->load()");
 					return false;
 				}
 


### PR DESCRIPTION
when debug_output enabled we get postErrors on non-errors.

in this case going from a set to the batch editor the BaseModel is loaded for instance with pm_id array(2) { [21]=> int(28) ["__all__"]=> int(14) }

The condition here is tested for vs_field 21 that is not a field. It is probably 'correct' that is not a field, but not important feedback either ?

I'm guessing here that the routine can be exited too, so kept the return (false) as-is