### PR TITLE
fix remote address (ip) for cli utils

### DIFF
--- a/app/lib/Controller/Request/RequestHTTP.php
+++ b/app/lib/Controller/Request/RequestHTTP.php
@@ -1043,7 +1043,7 @@ class RequestHTTP extends Request {
 	static public function ip() {
 		if (isset($_SERVER['HTTP_X_REAL_IP']) && $_SERVER['HTTP_X_REAL_IP']) { return $_SERVER['HTTP_X_REAL_IP']; }
 		if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && $_SERVER['HTTP_X_FORWARDED_FOR']) { return $_SERVER['HTTP_X_FORWARDED_FOR']; }
-		return $_SERVER['REMOTE_ADDR'];
+		return $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
 	}
 	# ----------------------------------------
 }


### PR DESCRIPTION
during cli actions like rebuilding search index via caUtils, a lot of warnings are generated because $_SERVER['REMOTE_ADDR'] is not defined. Maybe localhost can be returned for that final return in that circumstance.