### PR TITLE
Add php-http/discovery to composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,8 @@
     "scholarslab/bagit": "~0.2"
   },
   "config": {
-  	"discard-changes": true
+    "discard-changes": true,
+  "allow-plugins": {
+    "php-http/discovery": true
   }
 }


### PR DESCRIPTION
From Composer 2.2.0 there is a mechanism to permit certain plugins to execute code during a composer run.
https://getcomposer.org/doc/06-config.md#allow-plugins

This change gives php-http/discovery that permission to stop composer stopping mid run to ask for permission.