### PR TITLE
update iconclass API lookup

### DIFF
--- a/app/lib/Plugins/InformationService/Iconclass.php
+++ b/app/lib/Plugins/InformationService/Iconclass.php
@@ -86,20 +86,25 @@ class WLPlugInformationServiceIconclass Extends BaseInformationServicePlugin Imp
 		} else {
 			$vs_lang = 'en';
 		}
-		
-		
-		$vs_content = caQueryExternalWebservice(
-            $vs_url = 'http://iconclass.org/rkd/9/?q='.urlencode($ps_search).'&q_s=1&fmt=json'
-		);
+
+		$vs_url = 'https://iconclass.org/api/search?q='.urlencode($ps_search).'&lang='.$vs_lang.'&size=999&page=1&sort=rank&keys=0';
+
+		$vs_content = caQueryExternalWebservice($vs_url);
 
 		$va_content = @json_decode($vs_content, true);
-		if(!isset($va_content['records']) || !is_array($va_content['records'])) { return []; }
+		if(!isset($va_content['result']) || !is_array($va_content['result'])) { return []; }
+
 
 		// the top two levels are 'diagnostic' and 'records'
-		$va_results = $va_content['records'];
+		$va_results = $va_content['result'];
 		$va_return = [];
 
-		foreach($va_results as $va_result) {
+		foreach($va_results as $vs_result) {
+
+			$vs_url = 'https://iconclass.org/'.urlencode($vs_result).'.json';
+			$va_result = json_decode(caQueryExternalWebservice($vs_url),true);
+
+
 			$va_return['results'][] = [
 				'label' => isset($va_result['txt'][$vs_lang]) ? $va_result['txt'][$vs_lang] : $va_result['txt']['en'],
 				'url' => 'http://iconclass.org/'.$va_result['n'],


### PR DESCRIPTION
The iconclass service old API endpoint seems to redirect to an html landingpage now, ie.:

http://iconclass.org/rkd/9/?q=europa&q_s=1&fmt=json

and no longer to a json with records/results.


I tried to stay as close to the original implementation with the (new?) documented API's https://iconclass.org/docs

What appeared to have worked in the past in one request, is now to be done in subsequent requests, the first (language based) search to get results with key, the next to get the (language based) labels for the resulting keys/ids.

https://iconclass.org/api/search?q=europa&lang=en&size=999&page=1&sort=rank&keys=0
[
https://iconclass.org/92B1218.json,
..
]


It works on both php7 as php8 installations.


PS
I've kept the implementation simple, but I would like to propose a variation in a later PR(s).
For some InformationServices the feedback/suggestions you get can be overwelming to select from (like picking the correct Mozart if you have a dozen WA Mozarts). The jQuery autocompletion allows both 'label' and 'value', and we currently only use one of them, but it would be nicer to have some useful extra metadata alongside the (dropdown)label to aid the selection, yet keep the value(label) simple and concise in the end. I've done it for another IService we cannot disclose yet and it didn't need many changes without loosing compatibility to existing services.