### PR TITLE
NOJIRA Make non-filtered metadata alerts trigger

### DIFF
--- a/app/lib/MetadataAlerts/TriggerTypes/Modification.php
+++ b/app/lib/MetadataAlerts/TriggerTypes/Modification.php
@@ -104,8 +104,7 @@ class Modification extends Base {
 						$is_modified = false;
 					}
 				}
-				
-				if(!is_null($is_modified)) {
+				if($is_modified !== false) {
 					$is_modified = $t_instance->attributeDidChange($code);
 				}
 			}


### PR DESCRIPTION
* Prior to this the attributeDidChange call was only called if there was a matching filter. If the alert didn't have a filter (only list elements have a filter) then this was being ignored.
* Now only disable checking for changes if the element was being filtered and the value of the element wasn't one of the filter values.