### PR TITLE
NOJIRA Add support for template for contents display in history tracking policy

### DIFF
--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -2565,13 +2565,16 @@
 				case 'history_tracking_current_contents':
 					if (method_exists($this, "getContents")) {
 					    $policy = caGetOption('policy', $pa_options, null);
-						if ($qr = $this->getContents($policy, ['row_id' => $pn_row_id])) { 
-							$contents = [];
-							$p = self::getHistoryTrackingCurrentValuePolicy($policy);
-							while($qr->nextHit()) {
-							    $contents[] = $qr->getWithTemplate("<l>^".$p['table'].".preferred_labels</l>");
+						$p = self::getHistoryTrackingCurrentValuePolicy($policy);
+						$contents_config = caGetOption('contents', $p, []);
+						$pa_options['expandHierarchically'] = caGetOption('expandHierarchically', $contents_config, false);
+						if ($qr = $this->getContents($policy, ['row_id' => $pn_row_id], $pa_options)) {
+							$template = caGetOption('template', $contents_config, "<l>$p[table].preferred_labels </l>");
+							$delimiter = caGetOption('delimiter', $contents_config, "; ");
+							while($qr->nextHit()) { 
+								$contents[] = $qr->getWithTemplate($template);
 							}
-							return join("; ", $contents);
+							return join($delimiter, $contents);
 						}
 					}
 					return null;


### PR DESCRIPTION
* Default to current behaviour which renders a delimited list of preferred labels
* Requires config in app.conf:
```
history_tracking_policies = {
	defaults = {
		ca_objects = current_location
	},
	policies = {
		current_location = {
			name = _(Location),
			table = ca_objects,
			contents = {
				delimiter = ,
				expandHierarchically = 1,
				template = "^ca_object_representations.media.icon ^ca_objects.preferred_labels"
			},
			elements = {
				ca_movements = {
					__default__ = {
						date = ca_movements.removal_date,
						setInterstitialElementsOnAdd = [],
						# TODO: Confirm these templates
						template = "
							<unit relativeTo='ca_movements'>^ca_movements.removal_date</td> ^ca_storage_locations.hierarchy.preferred_labels.name%maxLevelsFromBottom=6&delimiter=_➜_</unit>",
						trackingRelationshipType = part,

						# useRelated = for browsing purposes log the current value as the first related item in this table
						useRelated = ca_storage_locations,
						# useRelatedRelationshipType = relationship type used when logging current value against related table
						useRelatedRelationshipType = part,
					}
				}
			}
		}
	}
}
```