### PR TITLE
update key setting for jwt decode

### DIFF
--- a/app/lib/Controller/Request/Session.php
+++ b/app/lib/Controller/Request/Session.php
@@ -384,7 +384,7 @@ class Session {
 	 */
 	public static function decodeJWT(string $jwt, string $key) {
 		if (!$key) { $key = Configuration::load()->get('jwt_token_key'); }
-		return JWT::decode($jwt, $key, ['HS256']);
+		return JWT::decode($jwt, new Firebase\JWT\Key($key, 'HS256'));
 	}
 	# ----------------------------------------
 }


### PR DESCRIPTION
was playing with GraphQL and got "\"kid\" empty, unable to lookup correct key" from the Firebase php-jwt, where getKey expects a jwt Key or an array of Keys with kid; but it currently got a string, not a key. Apparently the signature got changed where decode gets the Key directly.

PS: documentation wasn't clear (or no longer valid) where the jwt token should go, I think I used to pass it as a query parameter but now it has to be passed as an argument in the body. Maybe it got there automagically in earlier php7 ?
Passing via Authorization Bearer {token} Header still works.

`{"query":"query {get(jwt:\"eyJ0eXA..., table:'ca_objects', identifier:...`