### PR TITLE
correct count on browse summaries

### DIFF
--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -4338,7 +4338,7 @@
 					        $va_params[] = $va_container_ids[$vs_container_code];
 					    }
 						$vs_sql = "
-							SELECT COUNT(*) as _count, ca_attribute_values.value_longtext1, ca_attribute_values.value_decimal1, ca_attribute_values.value_longtext2, ca_attribute_values.value_integer1, ca_attribute_values.element_id
+							SELECT COUNT(distinct ca_attributes.row_id) as _count, ca_attribute_values.value_longtext1, ca_attribute_values.value_decimal1, ca_attribute_values.value_longtext2, ca_attribute_values.value_integer1, ca_attribute_values.element_id
 							FROM ca_attributes
 
 							{$vs_join_sql}


### PR DESCRIPTION
when there are many ACL rules, and more than one fits your user and group memberships, count can be higher than it should (ie. equal to the the filtered results) because the acl joins duplicates rows.
Not a fan of distinct but I think it is appropriate here.

(item_id could be part of that values list, but I think that value -like a listitem- is always duplicated in longtext1 ?)