### PR TITLE
Width of display name

### DIFF
--- a/themes/default/views/bundles/ca_entity_labels_nonpreferred.php
+++ b/themes/default/views/bundles/ca_entity_labels_nonpreferred.php
@@ -139,7 +139,7 @@
 								</td>
 							</tr>
 							<tr>
-								<td colspan="5"><?= $t_label->htmlFormElement('displayname', null, array('name' => "{fieldNamePrefix}displayname_{n}", 'id' => "{fieldNamePrefix}displayname_{n}", "value" => "{{displayname}}", 'no_tooltips' => false, 'tooltip_namespace' => 'bundle_ca_entity_labels_nonpreferred', 'textAreaTagName' => 'textentry', 'readonly' => $read_only)); ?></td>
+								<td colspan="5"><?= $t_label->htmlFormElement('displayname', null, array('width' => '670px', 'name' => "{fieldNamePrefix}displayname_{n}", 'id' => "{fieldNamePrefix}displayname_{n}", "value" => "{{displayname}}", 'no_tooltips' => false, 'tooltip_namespace' => 'bundle_ca_entity_labels_nonpreferred', 'textAreaTagName' => 'textentry', 'readonly' => $read_only)); ?></td>
 							</tr>
 							<tr>
 								<td colspan="5">


### PR DESCRIPTION
The Display Name for the non-preferred label in entity (for IND_SM) was inconsistent with the width for the preferred label. This brings them both to the same width.