### PR TITLE
NOJIRA : hookAddDomainSecurityPolicy allowing plugins to register CDNs

### DIFF
--- a/index.php
+++ b/index.php
@@ -79,8 +79,16 @@
 		// Security headers
 		$resp->addHeader("X-XSS-Protection", "1; mode=block");
 		$resp->addHeader("X-Frame-Options", "SAMEORIGIN");
-		$resp->addHeader("Content-Security-Policy", "script-src 'self' maps.googleapis.com cdn.knightlab.com nominatim.openstreetmap.org  ajax.googleapis.com tagmanager.google.com www.googletagmanager.com www.google-analytics.com www.google.com/recaptcha/ www.gstatic.com 'unsafe-inline' 'unsafe-eval';"); 
-		$resp->addHeader("X-Content-Security-Policy", "script-src 'self' maps.googleapis.com cdn.knightlab.com nominatim.openstreetmap.org  ajax.googleapis.com  tagmanager.google.com www.googletagmanager.com www.google-analytics.com www.google.com/recaptcha/ www.gstatic.com 'unsafe-inline' 'unsafe-eval';"); 
+
+		$vt_app_plugin_manager = new ApplicationPluginManager();
+		if($vt_app_plugin_manager->hookAddDomainSecurityPolicy(null) && is_array($vt_app_plugin_manager->hookAddDomainSecurityPolicy(null))) {
+			$vs_security_policy_domains = implode(" ",$vt_app_plugin_manager->hookAddDomainSecurityPolicy());
+		} else {
+			$vs_security_policy_domains = "";
+		}
+
+		$resp->addHeader("Content-Security-Policy", "script-src 'self' maps.googleapis.com cdn.knightlab.com nominatim.openstreetmap.org  ajax.googleapis.com tagmanager.google.com www.googletagmanager.com www.google-analytics.com www.google.com/recaptcha/ www.gstatic.com ".$vs_security_policy_domains." 'unsafe-inline' 'unsafe-eval';"); 
+		$resp->addHeader("X-Content-Security-Policy", "script-src 'self' maps.googleapis.com cdn.knightlab.com nominatim.openstreetmap.org  ajax.googleapis.com  tagmanager.google.com www.googletagmanager.com www.google-analytics.com www.google.com/recaptcha/ www.gstatic.com ".$vs_security_policy_domains." 'unsafe-inline' 'unsafe-eval';"); 
 
 		//
 		// Don't try to authenticate when doing a login attempt or trying to access the 'forgot password' feature


### PR DESCRIPTION
Hi CA team & Seth,

This PR adds the ability to register a CDN for plugins inside Providence, I'll do the same feat inside Paw in the next days/weeks. The intend is to allow a plugin to register its own CDNS, I usually use wavesurfer-js to display audio waveforms in audio related projects (https://wavesurfer-js.org/) that uses cdnjs.cloudflare.com as CDN, or D3, datatables...