### PR TITLE
check for generated idno

### DIFF
--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -620,7 +620,7 @@
 					}
 				}
 				if (is_array($pa_values)) {
-					if (isset($pa_values['idno'])) {
+					if (isset($pa_values['idno']) && !empty($pa_values['idno']) && empty($t_rep->get('idno')) ) {
 						$t_rep->set('idno', $pa_values['idno']);
 						unset($pa_values['idno']);
 					}


### PR DESCRIPTION
Hi,

We noticed a bug when using the media quick add (manually upload single media file from local source) where idno's where created blank, thus resulting in the duplicate idno warning, even when using multipart ids. On the short-term we could solve this by allowing duplicate idno's but the better option would be to have curated idno's as intended.

It appears the quick add form does not use the idno form element (like at other places with next idno suggestion), however it does gets added to the $pa_values['idno'] anyway through request getParameter (without form presence shouldn't be ??)

The idno multiparting is handled properly in $t_rep->setIdnoWithTemplate, but gets blanked out again by $t_rep->set('idno'). Without knowing with certainty all scenarios that could lead here (import, bulk edits,..) probably the easiest solution is to test for a generated idno and give advantage to that value there unless the $pa_values['idno'] is indeed set with a value (like maybe from import ?) ?

Other options include (not) handling the idno setting from the form request, or unsetting the $pa_values['idno'] with setting the multipart idno; but that could perhaps create unforseen side effects elsewhere ??