### PR TITLE
"borrowed from" should be "borrowed by"

### DIFF
--- a/install/profiles/xml/base.xml
+++ b/install/profiles/xml/base.xml
@@ -4056,11 +4056,11 @@
         <type code="borrower" default="1">
           <labels>
             <label locale="en_US">
-              <typename>is borrowed from</typename>
+              <typename>is borrowed by</typename>
               <typename_reverse>is borrower of</typename_reverse>
             </label>
             <label locale="en_CA">
-              <typename>is borrowed from</typename>
+              <typename>is borrowed by</typename>
               <typename_reverse>is borrower of</typename_reverse>
             </label>
             <label locale="fr_FR">


### PR DESCRIPTION
Because the typename refers here to the entity, not to the loan, the correct expression is "borrowed by".  What we want is [loan] is borrowed by [borrower].  The existing phrase was wrong: [loan] is borrowed from [borrower].

Fixes #1426 