### PR TITLE
Fix Multipart IDNO generation for imports

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -722,8 +722,14 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 		}
 		
 		if ($this->opo_idno_plugin_instance) {
+			if ($this->isChild()) {
+				$parent_idno = self::getIdnoForID($this->get($parent_id_fld));
+			}
+			if (($vs_parent_id_fld = $this->getProperty('HIERARCHY_PARENT_ID_FLD')) && isset($pa_fields[$vs_parent_id_fld]) && ($pa_fields[$vs_parent_id_fld] > 0)) {
+				$parent_idno = self::getIdnoForID($pa_fields[$vs_parent_id_fld]);
+			}
 			// If attempting to set parent_id, then flag record as child for id numbering purposes
-			$this->opo_idno_plugin_instance->isChild(((($vs_parent_id_fld = $this->getProperty('HIERARCHY_PARENT_ID_FLD')) && isset($pa_fields[$vs_parent_id_fld]) && ($pa_fields[$vs_parent_id_fld] > 0)) || ($this->isChild())) ? true : null);
+			$this->opo_idno_plugin_instance->isChild(isset($parent_idno) ? true : null, isset($parent_idno) ? $parent_idno : null);
 		
 			if (in_array($this->getProperty('ID_NUMBERING_ID_FIELD'), $pa_fields)) {
 				if (!$this->_validateIncomingAdminIDNo(true, false)) { 

--- a/app/lib/Service/ItemService.php
+++ b/app/lib/Service/ItemService.php
@@ -775,6 +775,13 @@ class ItemService extends BaseJSONService {
 
 		// intrinsic fields
 		if(is_array($pa_data["intrinsic_fields"]) && sizeof($pa_data["intrinsic_fields"])) {
+			// Ensure Parent field set before generating IDNO
+			if ($vs_parent_field_name = $t_instance->getProperty('HIERARCHY_PARENT_ID_FLD')) {
+				if (isset($pa_data["intrinsic_fields"][$vs_parent_field_name])) {
+					$t_instance->set( $vs_parent_field_name, $pa_data["intrinsic_fields"][$vs_parent_field_name]);
+				}
+			}
+			
 			foreach($pa_data["intrinsic_fields"] as $vs_field_name => $vs_value) {
 				if (($vs_field_name === $t_instance->getProperty('ID_NUMBERING_ID_FIELD')) && (strpos($vs_value, '%') !== false)) {
 					$t_instance->setIdnoWithTemplate($vs_value);


### PR DESCRIPTION
We were having issues where the IDNO was being incorrectly generated for items imported or created using itemService as the parent_value was not being set before trying generate.