### PR TITLE
Inspector headline show only 'viewing' if only one record type

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -1009,7 +1009,7 @@ jQuery(document).ready(function() {
 		} else {
 			if ($vn_item_id) {
 				if(!$po_view->request->config->get("{$vs_priv_table_name}_inspector_disable_headline")) {
-					if($po_view->request->user->canDoAction("can_edit_".$vs_priv_table_name) && (sizeof($t_item->getTypeList()) > 1)){
+					if($po_view->request->user->canDoAction("can_edit_".$vs_priv_table_name) && (sizeof($t_item->getTypeList()) > 0)){
 						$vs_buf .= "<strong>"._t("Editing %1", $vs_type_name).": </strong>\n";
 					}else{
 						$vs_buf .= "<strong>"._t("Viewing %1", $vs_type_name).": </strong>\n";


### PR DESCRIPTION
I noticed in one if my systems that object records were showing 'viewing .... ' where collections where showing 'editing ...'  I tracked it down to this line that would only pick 'editing ...' if there was more than 1 type.    Not sure if there is a reason for this to be 1, but changing it to 0 fixed the issue.