### PR TITLE
NOJIRA : fix sort order for getObjectHistory for movements

### DIFF
--- a/app/models/ca_objects.php
+++ b/app/models/ca_objects.php
@@ -1083,7 +1083,7 @@ class ca_objects extends BaseObjectLocationModel implements IBundleProvider {
 						$va_date_bits = explode('.', $vs_date_element);
 						$vs_date_spec = (Datamodel::tableExists($va_date_bits[0])) ? $vs_date_element : "ca_movements.{$vs_date_element}";
 						$va_dates[] = array(
-							'sortable' => $qr_movements->get($vs_date_spec, array('sortable' => true)),
+							'sortable' => end(explode("/", $qr_movements->get($vs_date_spec, array('sortable' => true)))),
 							'bounds' => explode("/", $qr_movements->get($vs_date_spec, array('sortable' => true))),
 							'display' => $qr_movements->get($vs_date_spec)
 						);


### PR DESCRIPTION
When movements have a start and an en date, the array returned by method ca_objects::getObjectHistory use dates like  "2023.07010000000000000000/2023.10212359590000000000". Problem is that the ksort function at the end orders date by the first part only, using only the starting date. For a better location history it should be done on the end part.

This is what we had before :
```
array(3) {
  ["2023.08091134000000000000"]=>
  array(1) {
    [0]=>
    array(13) {
      ["type"]=>
      string(20) "ca_storage_locations"
      ["id"]=>
      string(3) "203"
      ["relation_id"]=>
      string(5) "12476"
      ["display"]=>
      string(30) "R1 ➜ Etagère 2.44 (E. 2.44)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(16) "storage location"
      ["typename_plural"]=>
      string(17) "storage locations"
      ["type_id"]=>
      string(3) "165"
      ["rel_type_id"]=>
      string(3) "160"
      ["icon"]=>
      string(171) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">storage location</div></div></div>"
      ["date"]=>
      string(22) "August 9 2023 at 11:34"
      ["hasChildren"]=>
      int(0)
    }
  }
  ["2023.07010000000000000000/2023.10212359590000000000"]=>
  array(1) {
    [0]=>
    array(11) {
      ["type"]=>
      string(12) "ca_movements"
      ["id"]=>
      string(2) "23"
      ["display"]=>
      string(148) "Prêt Musée départemental de la Résistance et de la Déportation de la Haute-Garonne (1er juillet - 21 octobre 2023) (Prêt juillet-octobre 2023)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(9) "Mouvement"
      ["typename_plural"]=>
      string(10) "Mouvements"
      ["type_id"]=>
      string(2) "98"
      ["icon"]=>
      string(164) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">Mouvement</div></div></div>"
      ["date"]=>
      string(21) "01.07.2023-21.10.2023"
      ["hasChildren"]=>
      int(0)
    }
  }
  ["2022.04140000000000000000/2022.10312359590000000000"]=>
  array(1) {
    [0]=>
    array(11) {
      ["type"]=>
      string(12) "ca_movements"
      ["id"]=>
      string(2) "10"
      ["display"]=>
      string(131) "Prêt Musée de la Résistance et de la Déportation de la Haute-Garonne (26 juin - 16 octobre 2022) (Prêt juin 2022-octobre 2022)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(9) "Mouvement"
      ["typename_plural"]=>
      string(10) "Mouvements"
      ["type_id"]=>
      string(2) "98"
      ["icon"]=>
      string(164) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">Mouvement</div></div></div>"
      ["date"]=>
      string(25) "14/04/2022 - Octobre 2022"
      ["hasChildren"]=>
      int(0)
    }
  }
}
```

This is what we have after : 
```
array(3) {
  ["2023.10212359590000000000"]=>
  array(1) {
    [0]=>
    array(11) {
      ["type"]=>
      string(12) "ca_movements"
      ["id"]=>
      string(2) "23"
      ["display"]=>
      string(148) "Prêt Musée départemental de la Résistance et de la Déportation de la Haute-Garonne (1er juillet - 21 octobre 2023) (Prêt juillet-octobre 2023)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(9) "Mouvement"
      ["typename_plural"]=>
      string(10) "Mouvements"
      ["type_id"]=>
      string(2) "98"
      ["icon"]=>
      string(164) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">Mouvement</div></div></div>"
      ["date"]=>
      string(21) "01.07.2023-21.10.2023"
      ["hasChildren"]=>
      int(0)
    }
  }
  ["2023.08091134000000000000"]=>
  array(1) {
    [0]=>
    array(13) {
      ["type"]=>
      string(20) "ca_storage_locations"
      ["id"]=>
      string(3) "203"
      ["relation_id"]=>
      string(5) "12476"
      ["display"]=>
      string(30) "R1 ➜ Etagère 2.44 (E. 2.44)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(16) "storage location"
      ["typename_plural"]=>
      string(17) "storage locations"
      ["type_id"]=>
      string(3) "165"
      ["rel_type_id"]=>
      string(3) "160"
      ["icon"]=>
      string(171) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">storage location</div></div></div>"
      ["date"]=>
      string(22) "August 9 2023 at 11:34"
      ["hasChildren"]=>
      int(0)
    }
  }
  ["2022.10312359590000000000"]=>
  array(1) {
    [0]=>
    array(11) {
      ["type"]=>
      string(12) "ca_movements"
      ["id"]=>
      string(2) "10"
      ["display"]=>
      string(131) "Prêt Musée de la Résistance et de la Déportation de la Haute-Garonne (26 juin - 16 octobre 2022) (Prêt juin 2022-octobre 2022)"
      ["color"]=>
      string(6) "ffffff"
      ["icon_url"]=>
      bool(false)
      ["typename_singular"]=>
      string(9) "Mouvement"
      ["typename_plural"]=>
      string(10) "Mouvements"
      ["type_id"]=>
      string(2) "98"
      ["icon"]=>
      string(164) "<div class="caUseHistoryIconContainer" style="background-color: #ffffff"><div class="caUseHistoryIcon"><div class="caUseHistoryIconText">Mouvement</div></div></div>"
      ["date"]=>
      string(25) "14/04/2022 - Octobre 2022"
      ["hasChildren"]=>
      int(0)
    }
  }
}
```

Sorry if we missed the spot, but it seemed us the only proper way to fix.