### PR TITLE
Update sets.css

### DIFF
--- a/themes/default/css/sets.css
+++ b/themes/default/css/sets.css
@@ -25,6 +25,7 @@
 	padding:0px;
 }
 .setItem {
+    cursor: move;
 	position: relative;
 	display: block;
 	list-style-type: none;
@@ -39,10 +40,6 @@
 
 .setItem:hover {
 	border: solid 1px #ccc;
-}
-
-.setItems a{
-	cursor:move;
 }
 
 .setItems a{


### PR DESCRIPTION
Removed the move cursor from the .setItems a element and put it into the top .setItems class.  This is to make the cursor change when on the item and not if you add a `<l> </l>` into the sets item display template (which looks strange when the move icon only shows on the link back to the record).