### PR TITLE
Fixed bug with filenaming for summary print templates

### DIFF
--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -846,7 +846,7 @@ class BaseEditorController extends ActionController {
                     $o_pdf->setPage(caGetOption('pageSize', $va_template_info, 'letter'), caGetOption('pageOrientation', $va_template_info, 'portrait'), caGetOption('marginTop', $va_template_info, '0mm'), caGetOption('marginRight', $va_template_info, '0mm'), caGetOption('marginBottom', $va_template_info, '0mm'), caGetOption('marginLeft', $va_template_info, '0mm'));
             
             		if (!$filename_template = $this->request->config->get($t_subject->tableName().'_summary_file_naming')) {
-            			$filename_template = $this->view->getVar('filename') ? $filename_template : caGetOption('filename', $va_template_info, 'print_summary');
+            			$filename_template = $this->view->getVar('filename') ?: caGetOption('filename', $va_template_info, 'print_summary');
             		}
             		if (!($filename = caProcessTemplateForIDs($filename_template, $t_subject->tableName(), [$vn_subject_id]))) {
             			$filename = 'print_summary';


### PR DESCRIPTION
Hi @collectiveaccess,
I found a bug when trying to configure the file name in a summary print template.
It seems like the value was not properly assigned to $this->view->getVar('filename') when it exists.