### PR TITLE
Enabled client-side caching in the IIIF service.

### DIFF
--- a/app/lib/Service/IIIFService.php
+++ b/app/lib/Service/IIIFService.php
@@ -45,6 +45,8 @@ class IIIFService {
 	 * @throws Exception
 	 */
 	public static function dispatch($ps_identifier, $po_request, $po_response) {
+		$po_response->addHeader('Cache-Control', 'max-age=3600, private', true); // Cache all responses for 1 hour.
+
 		$va_path = array_slice(explode("/", $po_request->getPathInfo()), 3);
 		$vs_key = $ps_identifier."/".join("/", $va_path);
 		


### PR DESCRIPTION
Fixes #1552.

Arbitrary value of 1 hour allows web browsers to close and re-open overlay viewers without requesting image tiles every time.  This patch will need to be copied to Pawtucket as well.