### PR TITLE
Display changes to relationship tables in Global Change Log (1.8rc5)

### DIFF
--- a/app/controllers/logs/GlobalChangeController.php
+++ b/app/controllers/logs/GlobalChangeController.php
@@ -86,7 +86,7 @@ class GlobalChangeController extends ActionController {
 		
 		$start = (int)($page * self::$log_entries_per_page);
 
-		$log_entries = $params_set ? ApplicationChangeLog::getChangeLog(['limitByUnit' => true, 'groupBySubject' => true, 'tables' => $filter_table ? $filter_table : array_values($table_list), 'start' => $start, 'limit' => self::$log_entries_per_page, 'daterange' => ($filter_daterange !== _t('any time')) ? $filter_daterange : null, 'user_id' => $filter_user_id, 'changetype' => (empty($filter_change_type) ? null : $filter_change_type)]) : [];
+		$log_entries = $params_set ? ApplicationChangeLog::getChangeLog(['limitByUnit' => true, 'groupBySubject' => true, 'tables' => $filter_table ? $filter_table : array_values(caGetPrimaryTables(true)), 'start' => $start, 'limit' => self::$log_entries_per_page, 'daterange' => ($filter_daterange !== _t('any time')) ? $filter_daterange : null, 'user_id' => $filter_user_id, 'changetype' => (empty($filter_change_type) ? null : $filter_change_type)]) : [];
 		$this->view->setVar('change_log_list', $log_entries);
 
 		$this->render('global_change_log_html.php');


### PR DESCRIPTION
Hi @collectiveaccess,
I would like to suggest here a small improvement which would be very helpful to us and maybe to others too.
This allows to display changes to relationship tables in the global change log when no specific table is selected.