### PR TITLE
Allow parentheses in object representation file names (dev/php8)

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -5401,7 +5401,7 @@ function caGetRepresentationDownloadFileName(string $table, array $data, ?array 
 	} 
 
 	$filename = html_entity_decode($filename);
-	return preg_replace("![^A-Za-z0-9_\-\.&]+!", "_", $filename);
+	return preg_replace("![^A-Za-z0-9_\-\.&()]+!", "_", $filename);
 }
 # ------------------------------------------------------------------
 /**

--- a/themes/default/views/bundles/download_file_binary.php
+++ b/themes/default/views/bundles/download_file_binary.php
@@ -32,7 +32,7 @@
 	header("Cache-Control: post-check=0, pre-check=0", false);
 	header("Pragma: no-cache");
 	header("Cache-control: private");
-	header("Content-Disposition: attachment; filename=".preg_replace('![^A-Za-z0-9\.\-&]+!', '_', $this->getVar('archive_name')));
+	header("Content-Disposition: attachment; filename=".preg_replace('![^A-Za-z0-9\.\-&()]+!', '_', $this->getVar('archive_name')));
 	
 	set_time_limit(0);
 	


### PR DESCRIPTION
@collectiveaccess 
This small change is to allow file names for object representations to support parentheses, since they are allowed special characters on any file system.
This is something we would like to have, and it might be beneficial for others as well.