### PR TITLE
Allow parentheses in object representation file names (1.8rc5)

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -5232,8 +5232,9 @@ jQuery(document).ready(function() {
 				}
 				break;
 		} 
-
-		return preg_replace("![^A-Za-z0-9_\-\.]+!", "_", $filename);
+		
+		$filename = html_entity_decode($filename);
+		return preg_replace("![^A-Za-z0-9_\-\.&()]+!", "_", $filename);
 	}
 	# ------------------------------------------------------------------
 	/**

--- a/themes/default/views/bundles/download_file_binary.php
+++ b/themes/default/views/bundles/download_file_binary.php
@@ -32,7 +32,7 @@
 	header("Cache-Control: post-check=0, pre-check=0", false);
 	header("Pragma: no-cache");
 	header("Cache-control: private");
-	header("Content-Disposition: attachment; filename=".preg_replace('![^A-Za-z0-9\.\-]+!', '_', $this->getVar('archive_name')));
+	header("Content-Disposition: attachment; filename=".preg_replace('![^A-Za-z0-9\.\-&()]+!', '_', $this->getVar('archive_name')));
 	
 	set_time_limit(0);
 	


### PR DESCRIPTION
Same as https://github.com/collectiveaccess/providence/pull/1381 but for 1.8rc5 branch