### PR TITLE
Fix SyntaxError & TypeError in ca.labelbundle.js

### DIFF
--- a/assets/ca/ca.labelbundle.js
+++ b/assets/ca/ca.labelbundle.js
@@ -133,7 +133,7 @@ var caUI = caUI || {};
                 }
             } else {
                 const isDefaultLocale = (element) => element.value == options.defaultLocaleID;
-                defaultLocaleSelectedIndex = localeList.findIndex(templateValues.locale_id));
+                defaultLocaleSelectedIndex = localeList.findIndex((element) => element.value == templateValues.locale_id);
                 if(!defaultLocaleSelectedIndex) {
                      defaultLocaleSelectedIndex = localeList.findIndex(isDefaultLocale);
                 }


### PR DESCRIPTION
@collectiveaccess 
Bug fix for ca.labelbundle.js:
I removed the extra parenthesis which causes a SyntaxError and I converted the variable passed as an argument to a callback function to avoid a TypeError.