### PR TITLE
Fixed Bug with locale of non preferred labels

### DIFF
--- a/assets/ca/ca.labelbundle.js
+++ b/assets/ca/ca.labelbundle.js
@@ -134,7 +134,7 @@ var caUI = caUI || {};
             } else {
                 const isDefaultLocale = (element) => element.value == options.defaultLocaleID;
                 defaultLocaleSelectedIndex = localeList.findIndex((element) => element.value == templateValues.locale_id);
-                if(!defaultLocaleSelectedIndex) {
+                if(defaultLocaleSelectedIndex === -1) {
                      defaultLocaleSelectedIndex = localeList.findIndex(isDefaultLocale);
                 }
             }


### PR DESCRIPTION
@collectiveaccess 
Fixed a bug with the locale of non preferred labels caused by a wrong interpretation of the result of findIndex(). findIndex() returns -1 when no index is found.