### PR TITLE
Correct the installer link to documentation about profiles

### DIFF
--- a/install/inc/page1.php
+++ b/install/inc/page1.php
@@ -84,7 +84,7 @@
 ?>
 					<div class='profileNotes'>
 <?php
-						_p('More information about standard installation profiles is available on the CollectiveAccess <a href="http://docs.collectiveaccess.org/wiki/Installation_profile" target="_blank">project wiki</a>.');
+						_p('More information about standard installation profiles is available on the CollectiveAccess <a href="https://manual.collectiveaccess.org/providence/user/dataModelling/profiles/MetadataStandards.html" target="_blank">project wiki</a>.');
 ?>
 						<br/><br/>
 <?php


### PR DESCRIPTION
The existing link redirects to the documentation main index