### PR TITLE
Update simplesaml load path

### DIFF
--- a/app/lib/Auth/Adapters/Shibboleth.php
+++ b/app/lib/Auth/Adapters/Shibboleth.php
@@ -29,7 +29,7 @@
  *
  * ----------------------------------------------------------------------
  */
-require_once('/var/simplesamlphp/lib/_autoload.php');
+require_once(__CA_BASE_DIR__.'/vendor/simplesamlphp/simplesamlphp/lib/_autoload.php');
 require_once(__CA_LIB_DIR__.'/Auth/BaseAuthAdapter.php');
 require_once(__CA_MODELS_DIR__.'/ca_users.php');
 


### PR DESCRIPTION
When installed via composer (the recommended method), simplesamlphp will be placed under CA's vendor directory.  Installing under /var/simplesamlphp is only suggested by upstream for source installs.
Because of that this PR moves the include path used by CA away from /var/simplesamlphp in to CA's vendor location.

Closes #1573.