### PR TITLE
Upgrade github-api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "guzzlehttp/psr7": "2.4.*",
     "james-heinrich/getid3": "^1.9.20",
     "joshralph/password-policy": "~0.2",
-    "knplabs/github-api": "3.7",
+    "knplabs/github-api": "^3.14",
     "laminas/laminas-stdlib": "*",
     "laminas/laminas-escaper": "*",
     "league/climate": ">=1.0.0",


### PR DESCRIPTION
This API package has a transitive dependency on php-http/message-factory which is considered abandoned.

This change upgrades github-api to the first version which depends on php-cache-plugin v2 and allows the message-factory dependency to be changed.