### PR TITLE
Add simplesamlphp and update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,11 @@
     "ext-simplexml": "*",
     "phpseclib/phpseclib": "^2.0",
     "ankitpokhrel/tus-php": "^2.0",
-    "tedivm/stash": "0.17.*",
+    "tedivm/stash": "^1.0",
     "cache/predis-adapter": "^1.1",
     "cache/filesystem-adapter": "^1.1",
     "firebase/php-jwt": "^6.0",
-    "softonic/graphql-client": "^1.3",
+    "softonic/graphql-client": "^2.1",
     "whikloj/bagittools": "^3.0",
     "voku/stop-words": "^2.0",
     "tecnickcom/tc-lib-barcode": "^1.17",
@@ -59,6 +59,7 @@
   },
   "suggest": {
     "binaryoung/jieba-php": "^0.1.0"
+    "simplesamlphp/simplesamlphp": "^2.2"
   },
   "config": {
     "discard-changes": true,


### PR DESCRIPTION
The current graphql-client and stash depended on the old version of psr/cache while simplesamlphp depends on newer versions of psr/cache. To resolve that conflict grapql-client and stash are being upgraded to a newer version which supports at least psr/cache v2.0

For stash, this makes its minimum supported PHP version 8.

SimpleSAMLphp version 2.0 will end its security support later this year, so newer versions should be used where possible. To aid in identifying simplesamlphp for future users it has been added to the suggests section in composer.