### PR TITLE
Fixed Bug in getBundleAccessLevel()

### DIFF
--- a/app/models/ca_users.php
+++ b/app/models/ca_users.php
@@ -3529,6 +3529,7 @@ class ca_users extends BaseModel {
 				$va_vars = $va_role_info['vars'];
 				
 				if (is_array($va_vars['bundle_access_settings'] ?? null)) {
+					$ps_bundle_name = preg_replace("!^ca_attribute_!", "", $ps_bundle_name);
 					if (isset($va_vars['bundle_access_settings'][$ps_table_name.'.'.$ps_bundle_name]) && ((int)$va_vars['bundle_access_settings'][$ps_table_name.'.'.$ps_bundle_name] > $vn_access)) {
 						$vn_access = (int)$va_vars['bundle_access_settings'][$ps_table_name.'.'.$ps_bundle_name];
 						


### PR DESCRIPTION
@collectiveaccess 
This Bug fix solves the problem I encountered while trying to save a change to a metadata field of one of our objects using a user account with sufficient permission (read & write / access level _CA_BUNDLE_ACCESS_EDIT_).

When Saving, the change was not taken into account, and when debugging I found out that the bundle access level was not properly interpreted. For our metadata bundle named "material_technique", the method **_getBundleAccessLevel()_** only checked the access level for bundle names **"ca_attribute_material_technique"** & **"ca_attribute_ca_attribute_material_technique"** (prefix ca_attribute_ repeated 2 times!) (**ca_users.php** lines 3532 to 3534 & lines 3537 to 3542) which resulted in not finding any access level while  it did not check the access level for the bundle name "material_technique" without ca_attribute_ prefix.

However in CA 2.0, **RolesController.php** was modified so that the access level of bundles are no longer saved with the ca_attribute_ prefix (see **preg_replace("!^ca_attribute_!", "", $vs_bundle_name)** in **RolesController.php** line 172)

That why I also introduced a preg_replace to remove any ca_attribute_ prefix from the bundle name before checking the access level and it solved the issue.
With this fix, **_getBundleAccessLevel()_** checked the access level for bundles names **"material_technique"** and **"ca_attribute_material_technique"**, with the first check returning the right result.
