### PR TITLE
Remove incorectly parsed comma

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -291,7 +291,7 @@ shibboleth_field_map = {
 }
 
 # Lists of roles and groups that are *always* added to automatically created new users
-shibboleth_users_default_roles = [cataloguer],
+shibboleth_users_default_roles = [cataloguer]
 shibboleth_users_default_groups = [cataloguer]
 
 # Specific users to be granted administrative privledges in the system, identified by their usernames


### PR DESCRIPTION
Having a comma after shibboleth_users_default_roles = [cataloguer] meant CA configuration had an entry for shibboleth_users_default_groups prefixed by a comma.

`',shibboleth_users_default_groups' => array ( 0 => 'cataloguer', )`

Removing the comma shibboleth_users_default_groups is named correctly and can be overridden locally.

This change is unlikely to have a behavioural change but hasn't been tested.