### PR TITLE
Improve error checking for Shib field map

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -282,7 +282,8 @@ shibboleth_service_provider = default-sp
 # Name of Shibboleth token cookie
 shibboleth_token_cookie = shib_test
 
-# Mapping of CA user fields to Shibboleth attributes. Required fields are marked
+# Mapping of CA user fields (on the left) to Shibboleth attributes (on the right).
+# uid and email are required fields (as marked)
 shibboleth_field_map = {
 	uid = uid, #REQUIRED
 	email = eduPersonPrincipalName, #REQUIRED

--- a/app/lib/Auth/Adapters/Shibboleth.php
+++ b/app/lib/Auth/Adapters/Shibboleth.php
@@ -57,8 +57,17 @@ class ShibbolethAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
             $this->opo_shibAuth = new \SimpleSAML\Auth\Simple($shibSP);
             session_write_close();
         } catch (Exception $e) {
-            throw new ShibbolethException("Could not create SimpleSAML auth object");
+            throw new ShibbolethException("Could not create SimpleSAML auth object: {$e}");
         }
+
+        if (!array_key_exists('uid', $this->auth_config->get('shibboleth_field_map'))) {
+          throw new ShibbolethException(_t("uid not found in attribute map"));
+        }
+
+        if (!array_key_exists('email', $this->auth_config->get('shibboleth_field_map'))) {
+          throw new ShibbolethException(_t("email not found in attribute map"));
+        }
+
     }
 	# --------------------------------------------------------------------------------
 	/**
@@ -71,14 +80,10 @@ class ShibbolethAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
 		} catch (Exception $e){
 			die("Shibboleth error: {$e}");
 		}
-		
+
 		if(!$this->opo_shibAuth->isAuthenticated()){
 			return false;
 		}
-		if (!($attrs = $this->opo_shibAuth->getAttributes())) { return false; }
-		$uid = $this->mapAttribute('uid', $attrs);
-	
-	    if (!$uid) { return false; }
 	    return true;
 	}
     # --------------------------------------------------------------------------------


### PR DESCRIPTION
Previously error checking was almost non existant and performed its task completely silently.
This change brings missing elements in the map right to the fore by refusing to continue while uid and email are missing.

Rounding out the change is adding a stacktrace to "Could not create SimpleSAML auth object", we've been carrying this change locally for some time and its a great help in debugging.