### PR TITLE
Make HTMLPurifier path configurable

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -3127,6 +3127,10 @@ purify_all_text_input = 1
 purify_allow_external_references = 0
 
 
+# Override path to HTMLPurifier working directory.
+# Set to null to disable caching
+purify_serializer_path = <ca_app_dir>/tmp/purifier
+
 
 # -----------------------------------
 # Paths to other config files

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -4910,6 +4910,7 @@ function caFileIsIncludable($ps_file) {
 	function caGetHTMLPurifier(?array $options=null) : HTMLPurifier {
 		$config = HTMLPurifier_Config::createDefault();
 		$config->set('URI.DisableExternalResources', !Configuration::load()->get('purify_allow_external_references'));
+		$config->set('Cache.SerializerPath', Configuration::load()->get('purify_serializer_path'));
 		return new HTMLPurifier($config); 
 	}
 	# ----------------------------------------

--- a/app/lib/ConfigurationCheck.php
+++ b/app/lib/ConfigurationCheck.php
@@ -340,7 +340,7 @@ final class ConfigurationCheck {
 	 * Does the HTMLPurifier DefinitionCache dir exist and is it writable?
 	 */
 	public static function htmlPurifierDirQuickCheck() {
-		$vs_purifier_path = __CA_BASE_DIR__.'/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer';
+		$vs_purifier_path = self::$opo_config->get('purify_serializer_path'));
 
 		if(!file_exists($vs_purifier_path) || !is_writable($vs_purifier_path)){
 			self::addError(_t("It looks like the directory for HTML filtering caches is not writable by the webserver. Please change the permissions of %1 and enable the user which runs the webserver to write to this directory.", $vs_purifier_path));

--- a/app/tmp/purifier/.htaccess
+++ b/app/tmp/purifier/.htaccess
@@ -1,0 +1,2 @@
+Order allow,deny
+Deny from all


### PR DESCRIPTION
This removes the only writeable path under vendor/, allowing the full directory path to be marked read only

To enable the change a new subdirectory is created in tmp to hold serialisers working data.