### PR TITLE
Enabled client-side caching in the IIIF service.

### DIFF
--- a/app/lib/Service/IIIFService.php
+++ b/app/lib/Service/IIIFService.php
@@ -46,6 +46,8 @@ class IIIFService {
 			throw new AccessException(_t('Not logged in'));
 		}
 		
+		$response->addHeader('Cache-Control', 'max-age=3600, private', true); // Cache all responses for 1 hour.
+
 		$va_path = array_filter(array_slice(explode("/", $request->getPathInfo()), 3), 'strlen');
 		$vs_key = $identifier."/".join("/", $va_path);
 		


### PR DESCRIPTION
Fixes #1605

Arbitrary value of 1 hour allows web browsers to close and re-open overlay viewers without requesting image tiles every time. This patch will need to be copied to Pawtucket as well.