### PR TITLE
NOJIRA BatchProcessor : handles hookSaveItem after a batch processing

### DIFF
--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -139,6 +139,16 @@ class BatchProcessor {
 						'label' => $t_subject->getLabelForDisplay(),
 						'status' => 'SUCCESS'
 					);
+
+					$opo_app_plugin_manager = new ApplicationPluginManager() ;
+					$opo_app_plugin_manager->hookSaveItem(
+						array(
+							'id' => $vn_row_id,
+							'table_num' => $t_subject->tableNum(),
+							'table_name' => $t_subject->tableName(),
+							'instance' => $t_subject
+						)
+					);
 				}
 
 				if (isset($pa_options['progressCallback']) && ($ps_callback = $pa_options['progressCallback'])) {


### PR DESCRIPTION
hookSaveItem is fired after a Save event in the interface, allowing to prepopulate metadatas for example. If you batch process records on those metadatas, the subsequent computes are not executed.

This PR aims to fire hookSaveItem after a batch treatment.