### PR TITLE
Update phpoffice/phpspreadsheet version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "monolog/monolog": "~3.7",
     "opis/json-schema": "^1.0",
     "pear/file_marc": "~1.2",
-    "phpoffice/phpspreadsheet": "v1.22",
+    "phpoffice/phpspreadsheet": "v1.29.1",
     "phpoffice/phpword": "v0.18.*",
     "phpoffice/phppresentation": "dev-master",
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
There are 2 known vulnerabilities in phpoffice/phpspreadsheet https://www.cve.org/CVERecord?id=CVE-2024-45046
https://www.cve.org/CVERecord?id=CVE-2024-45048

Version 1.29.1 is the security patched version for these.

I have done preliminary tests on php 8.1 and seems to be working ok.

I tested (not sure if all of these use this library or not):  
- Viewing/Editing search results in spreadsheet view
- Export search results in spreadsheet
- Importing XLSX
- Downloading an import mapping