### PR TITLE
Allow retrieval of any .properties file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,7 +14,7 @@ AddType text/srt .srt
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico|gltf|mtl|bin|js|txt|mov|glb|usdz)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico|gltf|mtl|bin|js|txt|mov|glb|usdz|properties)$">
         Allow from all
 </FilesMatch>
 


### PR DESCRIPTION
Fixes #1621

Changes to `.htaccess` were needed to permit `assets/pdfjs/viewer/locale` file retrieval.