### PR TITLE
fix for Attempt to assign property on array (re: #1714)

### DIFF
--- a/app/service/controllers/ItemController.php
+++ b/app/service/controllers/ItemController.php
@@ -279,7 +279,7 @@ class ItemController extends \GraphQLServices\GraphQLServiceController {
 						$targets = [];
 						if(is_array($args['targets'])) {
 							$targets = array_map(function ($obj) {
-								$obj->checkAccess = $check_access ?? null;
+								$obj['checkAccess'] = $check_access ?? null;
 								return $obj;
 							}, $args['targets']);
 						} elseif($target = $args['target']) {
@@ -428,7 +428,7 @@ class ItemController extends \GraphQLServices\GraphQLServiceController {
 						$targets = [];
 						if(is_array($args['targets'])) {
 							$targets = array_map(function ($obj) {
-								$obj->checkAccess = $check_access ?? null;
+								$obj['checkAccess'] = $check_access ?? null;
 								return $obj;
 							}, $args['targets']);
 						} elseif($target = $args['target']) {

--- a/app/service/helpers/ItemHelpers.php
+++ b/app/service/helpers/ItemHelpers.php
@@ -273,7 +273,7 @@ function processItemRelationships(string $table, array $identifer, ?array $optio
 	$targets = [];
 	if(is_array($args['targets'])) {
 		$targets = array_map(function ($obj) {
-			$obj->checkAccess = $check_access ?? null;
+			$obj['checkAccess'] = $check_access ?? null;
 			return $obj;
 		}, $args['targets']);
 	} elseif($target = $args['target']) {


### PR DESCRIPTION
I realized that I had this error in the code I originally pull requested. However, even with these changes, it's not correctly filtering to only the public relations.

On my server, the code running that actually filters correctly is more like this:

https://github.com/collectiveaccess/providence/commit/25beec5cb00f67da2729f52ff269cbc45fbac34c

I thought originally that it would be simpler to not change the API of processTarget so that checkAccess goes in opts, but I kind of think that the solution in the above diff is cleaner.

Let me know what you think