### PR TITLE
provide $check_access to the array_map closure with use

### DIFF
--- a/app/service/controllers/ItemController.php
+++ b/app/service/controllers/ItemController.php
@@ -278,7 +278,7 @@ class ItemController extends \GraphQLServices\GraphQLServiceController {
 						
 						$targets = [];
 						if(is_array($args['targets'])) {
-							$targets = array_map(function ($obj) {
+							$targets = array_map(function ($obj) use($check_access) {
 								$obj['checkAccess'] = $check_access ?? null;
 								return $obj;
 							}, $args['targets']);
@@ -427,7 +427,7 @@ class ItemController extends \GraphQLServices\GraphQLServiceController {
 						
 						$targets = [];
 						if(is_array($args['targets'])) {
-							$targets = array_map(function ($obj) {
+							$targets = array_map(function ($obj) use($check_access) {
 								$obj['checkAccess'] = $check_access ?? null;
 								return $obj;
 							}, $args['targets']);


### PR DESCRIPTION
Following on this PR #1716 -- the `checkAccess` param was still not working as expected.

It turns out I didn't quite understand how closures in PHP work - I needed to call use($check_access) so that the closure could access the variable from the parent context.

It's working correctly now.