### PR TITLE
Read correct attribute on sourceLevelAccessControl

### DIFF
--- a/install/inc/Parsers/XMLProfileParser.php
+++ b/install/inc/Parsers/XMLProfileParser.php
@@ -847,7 +847,7 @@ class XMLProfileParser extends BaseProfileParser {
 
 						$source_level_access_control[] = [
 							'table' => $permission_table,
-							'bundle' => $permission_bundle,
+							'source' => $permission_bundle,
 							'access' => $permission_access,
 							'default' => $permission_default
 						];


### PR DESCRIPTION
Correcting an error where the code for the source wasn't being read by the installer. The parser was saving this as 'bundle' while installer was trying to read 'source'. Updating parser to 'source' solves this.