### PR TITLE
Create log path define

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -2622,12 +2622,12 @@ batch_media_import_match_on = [idno]
 # -----------------------------------
 # Batch metadata import
 # -----------------------------------
-batch_metadata_import_log_directory = <ca_base_dir>/app/log
+batch_metadata_import_log_directory = <ca_log_dir>
 
 # -----------------------------------
 # Reprocess media
 # -----------------------------------
-reprocess_media_log_directory = <ca_base_dir>/app/log
+reprocess_media_log_directory = <ca_log_dir>
 
 
 # -----------------------------------
@@ -2724,7 +2724,7 @@ taskqueue_max_items_processed_per_session = 100
 media_uploader_enabled = 0
 
 # Directory for media upload logging
-media_uploader_log_directory = <ca_base_dir>/app/log
+media_uploader_log_directory = <ca_log_dir>
 
 # Directory to write user-uploaded files into
 media_uploader_root_directory = <ca_base_dir>/uploads
@@ -3114,7 +3114,7 @@ dont_use_search_log = 0
 #
 
 # Location of warning log
-warning_log = <ca_app_dir>/log/warning_log.txt
+warning_log = <ca_log_dir>/warning_log.txt
 
 # Log PHP warnings?
 log_warnings = 1
@@ -3352,4 +3352,4 @@ idno_element_display_format_without_label = <div class='formLabel'>^ELEMENT <spa
 # web_services_proxy_url = tcp://127.0.0.1:8080
 
 # Log directory for external export activity
-external_export_log_directory = <ca_base_dir>/app/log
+external_export_log_directory = <ca_log_dir>

--- a/app/conf/global.conf
+++ b/app/conf/global.conf
@@ -57,6 +57,8 @@ ca_app_dir =  __CA_APP_DIR__
 ca_lib_dir =  __CA_LIB_DIR__
 ca_models_dir = __CA_MODELS_DIR__
 
+ca_log_dir = __CA_LOG_DIR__
+
 # You MUST change these next three entries to match your web setup.
 site_protocol = __CA_SITE_PROTOCOL__
 site_hostname = __CA_SITE_HOSTNAME__

--- a/app/conf/replication.conf
+++ b/app/conf/replication.conf
@@ -1,6 +1,6 @@
 # Location of replication log files
-replication_log = <ca_base_dir>/app/log/replication.log
-replication_debug_log = <ca_base_dir>/app/log/replication_debug.log
+replication_log = <ca_log_dir>/replication.log
+replication_debug_log = <ca_log_dir>/replication_debug.log
 
 # Maximum size of a log sync "chunk" transaction (as number of log entries)
 chunk_size = 100

--- a/app/helpers/logHelpers.php
+++ b/app/helpers/logHelpers.php
@@ -83,7 +83,7 @@ function caGetLogger($options=null, $opt_name=null) {
  */
 function caGetLogPath($options=null, $opt_name=null) {
 	$config = Configuration::load();
-	if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $opt_name ? $config->get($opt_name) : __CA_APP_DIR__.'/log'))) {
+	if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $opt_name ? $config->get($opt_name) : __CA_LOG_DIR__))) {
 		$log_dir = '.';
 	}
 	

--- a/app/helpers/post-setup.php
+++ b/app/helpers/post-setup.php
@@ -60,6 +60,11 @@ if (!defined("__CA_CONF_DIR__")) {
 	define("__CA_CONF_DIR__", __CA_APP_DIR__."/conf");
 }
 
+# Allow overriding log directory via setup.php
+if (!defined("__CA_LOG_DIR__")) {
+	define("__CA_LOG_DIR__", __CA_APP_DIR__."/app/log");
+}
+
 # --------------------------------------------------------------------------------------------
 # Caching configuration
 # The default file-based caching should work fine in most setups

--- a/app/helpers/supportHelpers.php
+++ b/app/helpers/supportHelpers.php
@@ -52,7 +52,7 @@
 		require_once(__CA_MODELS_DIR__.'/ca_list_items_x_list_items.php');
 		require_once(__CA_MODELS_DIR__.'/ca_relationship_types.php');
 
-		$o_log = new KLogger(__CA_APP_DIR__.'/log', KLogger::INFO);
+		$o_log = new KLogger(__CA_LOG_DIR__, KLogger::INFO);
 		
 		if (!file_exists($ps_path_to_aat_data)) {
 			die("ERROR: cannot find AAT data.\n");
@@ -460,7 +460,7 @@
 	 */
 	function caLoadULAN($ps_path_to_ulan_data=null, $ps_path_to_ulan_config=null, $pa_options=null) {
 		$t = new Timer();
-		$o_log = new KLogger(__CA_APP_DIR__.'/log', KLogger::INFO);
+		$o_log = new KLogger(__CA_LOG_DIR__, KLogger::INFO);
 	
 		$va_parent_child_links = array();
 		$va_item_item_links = array();

--- a/app/helpers/systemHelpers.php
+++ b/app/helpers/systemHelpers.php
@@ -47,7 +47,7 @@
 		global $system_helpers_debug_logger;
 
 		if (!isset($system_helpers_debug_logger) || $system_helpers_debug_logger === null){
-			$system_helpers_debug_logger = caGetLogger( array( 'logDirectory' => __CA_APP_DIR__ . "/log", 'logLevel' => 'DEBUG' ) );
+			$system_helpers_debug_logger = caGetLogger( array( 'logDirectory' => __CA_LOG_DIR__, 'logLevel' => 'DEBUG' ) );
 		}
 		return $system_helpers_debug_logger;
 	}

--- a/app/lib/BatchProcessor.php
+++ b/app/lib/BatchProcessor.php
@@ -500,7 +500,7 @@ class BatchProcessor {
 		
 		BatchProcessor::$s_import_error_list = [];
 
-		$vs_log_dir = caGetOption('log', $pa_options, __CA_APP_DIR__."/log");
+		$vs_log_dir = caGetOption('log', $pa_options, __CA_LOG_DIR__;
 		$vs_log_level = caGetOption('logLevel', $pa_options, "INFO");
 
 		if (!is_writeable($vs_log_dir)) { $vs_log_dir = caGetTempDirPath(); }

--- a/app/lib/ConfigurationCheck.php
+++ b/app/lib/ConfigurationCheck.php
@@ -156,8 +156,8 @@ final class ConfigurationCheck {
 		//
 		// Check app/log
 		//
-		if (!is_writeable(__CA_APP_DIR__.'/log')) {
-			self::addError(_t('The CollectiveAccess <i>app/log</i> directory is NOT writeable by the installer. This may result in installation errors. It is recommended that you change permissions on this directory (<i>%1</i>) to allow write access prior to installation. You can reload the installer to verify that the changed permissions are correct.', __CA_APP_DIR__.'/log'));
+		if (!is_writeable(__CA_LOG_DIR__)) {
+			self::addError(_t('The CollectiveAccess log directory (default <i>app/log</i>) is NOT writeable by the installer. This may result in installation errors. It is recommended that you change permissions on this directory (<i>%1</i>) to allow write access prior to installation. You can reload the installer to verify that the changed permissions are correct.', __CA_LOG_DIR__));
 		}
 
 		//
@@ -321,7 +321,7 @@ final class ConfigurationCheck {
 	}
 	# -------------------------------------------------------
 	public static function logDirQuickCheck() {
-		$vs_log_path = __CA_APP_DIR__."/log";
+		$vs_log_path = __CA_LOG_DIR__;
 		if(!file_exists($vs_log_path) || !is_writable($vs_log_path)){
 			self::addError(_t("It looks like the log directory is not writable by the webserver. Please change the permissions of %1 (or create it if it doesn't exist already) and enable the user which runs the webserver to write to this directory.",$vs_log_path));
 		}

--- a/app/lib/Db/mysqli.php
+++ b/app/lib/Db/mysqli.php
@@ -326,7 +326,7 @@ class Db_mysqli extends DbDriverBase {
 		$logger = null;
 		$prefix = "[{$db_seq}::".getmypid()."] ";
 		if(defined('__CA_LOG_DATABASE_QUERIES__') && __CA_LOG_DATABASE_QUERIES__) {
-			$logger = caGetLogger(['logDirectory' => __CA_APP_DIR__.'/log', 'logName' => 'queries'], null);
+			$logger = caGetLogger(['logDirectory' => __CA_LOG_DIR__, 'logName' => 'queries'], null);
 			
 			$db_seq++;
 			$logger->logInfo(caPrintStacktrace((defined('__CA_SHOW_FULL_STACKTRACE_IN_DATABASE_QUERY_LOG__') && __CA_SHOW_FULL_STACKTRACE_IN_DATABASE_QUERY_LOG__) ? [] : ['skip' => 3, 'head' => 1]));
@@ -352,7 +352,7 @@ class Db_mysqli extends DbDriverBase {
 		if($is_error) {
 			$po_statement->postError($this->nativeToDbError($error_num), $error_message, "Db->mysqli->execute()");
 				
-			if($err_logger = caGetLogger(['logDirectory' => __CA_APP_DIR__.'/log', 'logName' => 'db_errors'], null)) {
+			if($err_logger = caGetLogger(['logDirectory' => __CA_LOG_DIR__, 'logName' => 'db_errors'], null)) {
 				$err_logger->logError($prefix.json_encode(['code' => $this->nativeToDbError($error_num), 'errorNumber' => $error_num, 'errorMessage' => $error_message, 'sql' => $vs_sql, 'stacktrace' => caPrintStacktrace()]));
 			}
 			throw new DatabaseException($error_message, $error_num, "Db->mysqli->execute()");

--- a/app/lib/Db/pdo_mysql.php
+++ b/app/lib/Db/pdo_mysql.php
@@ -196,7 +196,7 @@ class Db_pdo_mysql extends DbDriverBase {
 		
 		$logger = null;
 		if(defined('__CA_LOG_DATABASE_QUERIES__') && __CA_LOG_DATABASE_QUERIES__) {
-			$logger = caGetLogger(['logDirectory' => __CA_APP_DIR__.'/log', 'logName' => 'queries'], null);
+			$logger = caGetLogger(['logDirectory' => __CA_LOG_DIR__, 'logName' => 'queries'], null);
 			$logger->logInfo(
 				caPrintStacktrace(defined('__CA_SHOW_FULL_STACKTRACE_IN_DATABASE_QUERY_LOG__') && __CA_SHOW_FULL_STACKTRACE_IN_DATABASE_QUERY_LOG__) ? [] : ['skip' => 3, 'head' => 1]
 			);

--- a/app/lib/Utils/BaseApplicationTool.php
+++ b/app/lib/Utils/BaseApplicationTool.php
@@ -119,7 +119,7 @@ abstract class BaseApplicationTool implements IApplicationTool {
 		if (is_array($settings)) { $this->setSettings($settings); }
 		if ($tool_config_path) { $this->ops_tool_config_path = $tool_config_path; }
 		
-		if (!$log_path) { $log_path = __CA_APP_DIR__.'/log'; }
+		if (!$log_path) { $log_path = __CA_LOG_DIR__; }
 		if ($log_path) { $this->setLogPath($log_path); }
 		if ($mode) { $this->setMode($mode); }
 	}

--- a/app/lib/Utils/CLIUtils/Maintenance.php
+++ b/app/lib/Utils/CLIUtils/Maintenance.php
@@ -509,8 +509,8 @@ trait CLIUtilsMaintenance {
 			chmod($vs_path, 0770);
 		}
 		
-		if (!$po_opts->getOption("quiet")) { CLIUtils::addMessage(_t("Fixing permissions for the log directory (app/log) for ownership by \"%1\"...", $vs_user)); }
-		$va_files = caGetDirectoryContentsAsList(__CA_APP_DIR__.'/log', true, true, false, true, ['includeRoot' => true]);
+		if (!$po_opts->getOption("quiet")) { CLIUtils::addMessage(_t("Fixing permissions for the log directory for ownership by \"%1\"...", $vs_user)); }
+		$va_files = caGetDirectoryContentsAsList(__CA_LOG_DIR__, true, true, false, true, ['includeRoot' => true]);
 
 		foreach($va_files as $vs_path) {
 			chown($vs_path, $vs_user);

--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -2125,7 +2125,7 @@ itemOutput:
 		global $g_ui_locale_id;
 		$locale_id = (isset($options['locale_id']) && (int)$options['locale_id']) ? (int)$options['locale_id'] : $g_ui_locale_id;
 
-        $log_dir = caGetOption('logDirectory', $options, __CA_APP_DIR__."/log");
+        $log_dir = caGetOption('logDirectory', $options, __CA_LOG_DIR__);
 		if(!file_exists($log_dir) || !is_writable($log_dir)) {
 			$log_dir = caGetTempDirPath();
 		}

--- a/app/plugins/pawtucketMediaImport/pawtucketMediaImportPlugin.php
+++ b/app/plugins/pawtucketMediaImport/pawtucketMediaImportPlugin.php
@@ -34,7 +34,7 @@ class pawtucketMediaImportPlugin extends BaseApplicationPlugin {
 	public function __construct($ps_plugin_path) {
 		$this->description = _t('Pawtucket Media Import Processor');
 		$this->opo_config = Configuration::load($ps_plugin_path . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'plugin.conf');
-		$this->opo_log = caGetLogger(['logDirectory' => __CA_APP_DIR__.'/log']);
+		$this->opo_log = caGetLogger(['logDirectory' => __CA_LOG_DIR__]);
 		parent::__construct();
 	}
 	# -------------------------------------------------------

--- a/app/service/controllers/json/ModelController.php
+++ b/app/service/controllers/json/ModelController.php
@@ -76,7 +76,7 @@ class ModelController extends BaseServiceController {
 		$vs_post_data = $this->getRequest()->getRawPostData();
 		require_once(__CA_LIB_DIR__.'/Logging/KLogger/KLogger.php');
 		// @todo make this configurable or get from app.conf?
-		$o_log = new KLogger(__CA_BASE_DIR__ . '/app/log', KLogger::DEBUG);
+		$o_log = new KLogger(__CA_LOG_DIR__, KLogger::DEBUG);
 		try {
 			$o_log->logInfo(_t('Got incoming updateConfig request from %1', $this->getRequest()->getClientIP()));
 			$o_log->logInfo(_t('Raw payload is %1', $vs_post_data));

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -134,7 +134,7 @@ class Installer {
 		if($log_output) {
 			require_once(__CA_LIB_DIR__.'/Logging/KLogger/KLogger.php');
 			// @todo make this configurable or get from app.conf?
-			$this->log = new \KLogger(__CA_BASE_DIR__ . '/app/log', \KLogger::DEBUG);
+			$this->log = new \KLogger(__CA_LOG_DIR__, \KLogger::DEBUG);
 			$this->logging_status = true;
 		}
 	}

--- a/install/inc/Parsers/BaseProfileParser.php
+++ b/install/inc/Parsers/BaseProfileParser.php
@@ -70,7 +70,7 @@ abstract class BaseProfileParser {
 	 * @param string $profile Name (with or without extension) of profile to parse
 	 */
 	public function __construct(?string $directory=null, ?string $profile=null) {
-		$this->log = new \KLogger(__CA_BASE_DIR__ . '/app/log', \KLogger::DEBUG);
+		$this->log = new \KLogger(__CA_LOG_DIR__, \KLogger::DEBUG);
 		$this->notices = $this->warnings = $this->errors = [];
 		$this->debug = true;
 		if($profile) {


### PR DESCRIPTION
This change allows moving the destination of CA logs. They can be changed
- via setup.php (all paths)
- via global.conf (all paths)
- individually in various conf files (as before) 

this allows trivially logging to different locations than is default.