### PR TITLE
Update test for length of log directory string

### DIFF
--- a/app/helpers/logHelpers.php
+++ b/app/helpers/logHelpers.php
@@ -84,7 +84,7 @@ function caGetLogger($options=null, $opt_name=null) {
  */
 function caGetLogPath($options=null, $opt_name=null) {
 	$config = Configuration::load();
-	if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $opt_name ? $config->get($opt_name) : __CA_APP_DIR__.'/log'))) {
+	if(!strlen(trim($log_dir = caGetOption('logDirectory', $options, $opt_name ? $config->get($opt_name) : __CA_APP_DIR__.'/log')))) {
 		$log_dir = '.';
 	}
 	


### PR DESCRIPTION
I have not tested this change yet but I'm proactively making it available for review.

I've been trying to track down an anomaly with logging on our system where some lines (like those below) end up logged to our CA temp directory. These logs come from different parts of the codebase and have different entry points but both end up at `caGetLogger`.

```
2025-05-14 13:15:29 - DEBUG --> Executing command: '/usr/bin/pdftotext -v 2> /dev/null'
2025-05-14 23:19:50 - INFO --> [LOGF] Failed login with redirect for user id '' [...]
```

I've followed it through various layers of CA and the bug appears to be in `caGetLogger` (https://github.com/collectiveaccess/providence/blob/master/app/helpers/logHelpers.php#L87).

It appears that `!trim()` results in an empty string, causing `log_dir` to be set to `.`.

```
root@testhost:~# cat test.php 
<?php

$log_dir = '/tmp/test';

print(trim($log_dir));
print ("\n");
print(!trim($log_dir));
print ("\n");

root@testhost:~# php test.php 
/tmp/test

```

In our environment `.` is not writeable so the logs end up in temp.

Adding `strlen` in to the test makes if behave as expected.
```
root@testhost:~# cat test.php 
<?php

$log_dir = '/tmp/test';

if(!strlen(trim($log_dir))) { echo 'yes'; } else { echo 'no'; }
print ("\n");

$log_dir = '  ';
if(!strlen(trim($log_dir))) { echo 'yes'; } else { echo 'no'; }
print ("\n");
root@testhost:~# php test.php 
no
yes
```