### PR TITLE
Legistar import - catch GuzzleHttp exceptions by using global namespace

### DIFF
--- a/app/lib/Clients/LegistarClient.php
+++ b/app/lib/Clients/LegistarClient.php
@@ -89,7 +89,7 @@ class LegistarClient {
 				
 				break;
 				
-			} catch(Exception $e) {
+			} catch(\Exception $e) {
 				print "[WARNING] Network connection to ".$this->base_url." FAILED; retrying...\n";	
 				$logger->logWarn("When calling {$type} connection FAILED; retry {$retry_count}: {$e}");
 				$retry_count++;


### PR DESCRIPTION
The import script had been crashing instead of catching HTTP exceptions until adding a blackslash before Exception to widen the net.