### PR TITLE
fix empty controller (sub)paths not leading to double slash paths

### DIFF
--- a/app/lib/Controller/RequestDispatcher.php
+++ b/app/lib/Controller/RequestDispatcher.php
@@ -184,19 +184,20 @@ class RequestDispatcher extends BaseObject {
 			do {
 				$this->response->clearContent();
 				$vs_classname = ucfirst($this->ops_controller).'Controller';
-				
+				$ops_module_path = $this->opa_module_path ? join('/', $this->opa_module_path)."/" : '';
+
 				// first check for controller in theme...
-				if (!defined('__CA_THEME_DIR__') || !file_exists(__CA_THEME_DIR__.'/controllers/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php') || !include_once(__CA_THEME_DIR__.'/controllers/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php')) {
+				if (!defined('__CA_THEME_DIR__') || !file_exists(__CA_THEME_DIR__.'/controllers/'.$ops_module_path.$vs_classname.'.php') || !include_once(__CA_THEME_DIR__.'/controllers/'.$ops_module_path.$vs_classname.'.php')) {
 					// then check controllers directory...
-					if (!file_exists($this->ops_controller_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php') || !include_once($this->ops_controller_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php')) {
+					if (!file_exists($this->ops_controller_path.'/'.$ops_module_path.$vs_classname.'.php') || !include_once($this->ops_controller_path.'/'.$ops_module_path.$vs_classname.'.php')) {
 						// ... next check theme plugins
-						if (!file_exists($this->ops_theme_plugins_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php') || !include_once($this->ops_theme_plugins_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php')) {
+						if (!file_exists($this->ops_theme_plugins_path.'/'.$ops_module_path.$vs_classname.'.php') || !include_once($this->ops_theme_plugins_path.'/'.$ops_module_path.$vs_classname.'.php')) {
 							// ... next check application plugins
-							if (!file_exists($this->ops_application_plugins_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php') || !include_once($this->ops_application_plugins_path.'/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php')) {
+							if (!file_exists($this->ops_application_plugins_path.'/'.$ops_module_path.$vs_classname.'.php') || !include_once($this->ops_application_plugins_path.'/'.$ops_module_path.$vs_classname.'.php')) {
 						
 								// ... next check the generic "_root_" plugin directory
 								// plugins in here act as if they are in the app/controllers directory
-								if (!file_exists($this->ops_application_plugins_path.'/_root_/controllers/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php') || !include_once($this->ops_application_plugins_path.'/_root_/controllers/'.join('/', $this->opa_module_path).'/'.$vs_classname.'.php')) {					
+								if (!file_exists($this->ops_application_plugins_path.'/_root_/controllers/'.$ops_module_path.$vs_classname.'.php') || !include_once($this->ops_application_plugins_path.'/_root_/controllers/'.$ops_module_path.$vs_classname.'.php')) {
 									// ... next check for root controllers in plugins 
 									$o_app_plugin_manager = new ApplicationPluginManager();
 									$va_app_plugin_names = $o_app_plugin_manager->getPluginNames();


### PR DESCRIPTION
fixes paths potentially containing double slashes that could lead to improper file detection, that could lead to unnecessary log flooding (ERROR Invalid controller path)

so 
app/controllers/DashboardController.php
instead of 
app/controllers//DashboardController.php