### PR TITLE
recalculate leftNavSidebar height

### DIFF
--- a/themes/default/views/pageFormat/sideBar.php
+++ b/themes/default/views/pageFormat/sideBar.php
@@ -1,6 +1,7 @@
 <script type="text/javascript">
 	jQuery(document).ready(function() {
 		caResizeSideNav();
+		$("#leftNav").on("click", caResizeSideNav);
 	});
 	function caResizeSideNav() {
 		jQuery("#leftNavSidebar").animate({'height': (jQuery("#leftNav").height() - jQuery("#widgets").height() - 70) + "px"}, 300);


### PR DESCRIPTION
We sometimes experience that the leftNavSideBar height is calculated incorrectly (usually on the smaller side), what makes accessing that menu and thus tabs very hard for authors.

This fix binds the calculate function to the leftNav wrapper div, so that the somewhat intuitive gesture of clicking somewhere in the leftnav can recalculate the height (hopefully better).