### PR TITLE
NOJIRA : avoid to make doHighlighting on null

### DIFF
--- a/app/lib/Parsers/DisplayTemplateParser.php
+++ b/app/lib/Parsers/DisplayTemplateParser.php
@@ -204,10 +204,10 @@ class DisplayTemplateParser {
 		}
 
 		$qr_res = caMakeSearchResult($ps_tablename, $pa_row_ids, ['sort' => caGetOption('sort', $pa_options, null), 'sortDirection' => caGetOption('sortDirection', $pa_options, null)]);
+		if(!$qr_res) { return $pb_return_as_array ? array() : ""; }
+		
 		$qr_res->doHighlighting($do_highlighting);
 		$qr_res->autoConvertLineBreaks($autoconvert_linebreaks);
-		
-		if(!$qr_res) { return $pb_return_as_array ? array() : ""; }
 
         $filter_non_primary_reps = self::_setPrimaryRepresentationFiltering($qr_res, caGetOption('filterNonPrimaryRepresentations', $pa_options, null));
 


### PR DESCRIPTION
NOJIRA : avoid to make doHighlighting on null

This prevents an error when saving UI in Providence : 

````
Fatal error: Uncaught Error: Call to a member function doHighlighting() on null in /Users/gautier/www/unito.acusteme.test/providence/app/lib/Parsers/DisplayTemplateParser.php:207 Stack trace: #0 /Users/gautier/www/unito.acusteme.test/providence/app/lib/Parsers/DisplayTemplateParser.php(62): DisplayTemplateParser::process('^ca_editor_ui_s...', 'ca_editor_ui_sc...', Array, Array) #1 /Users/gautier/www/unito.acusteme.test/providence/app/helpers/displayHelpers.php(2895): DisplayTemplateParser::evaluate('^ca_editor_ui_s...', 'ca_editor_ui_sc...', Array, Array) #2 /Users/gautier/www/unito.acusteme.test/providence/app/lib/BundlableLabelableBaseModelWithAttributes.php(842): caProcessTemplateForIDs('^ca_editor_ui_s...', 'ca_editor_ui_sc...', Array, Array) #3 /Users/gautier/www/unito.acusteme.test/providence/app/plugins/prepopulatePHPBrowseDatesAndPlaces/prepopulatePHPBrowseDatesAndPlacesPlugin.php(24): BundlableLabelableBaseModelWithAttributes->getWithTemplate('^ca_editor_ui_s...') #4 /Users/gautier/www/unito.acusteme.test/providence/app/lib/ApplicationPluginManager.php(65): prepopulatePHPBrowseDatesAndPlacesPlugin->hookSaveItem(Array) #5 /Users/gautier/www/unito.acusteme.test/providence/app/lib/BaseEditorController.php(437): ApplicationPluginManager->__call('hookSaveItem', Array) #6 /Users/gautier/www/unito.acusteme.test/providence/app/lib/Controller/RequestDispatcher.php(289): BaseEditorController->Save(Array) #7 /Users/gautier/www/unito.acusteme.test/providence/app/lib/Controller/AppController.php(108): RequestDispatcher->dispatch(Array) #8 /Users/gautier/www/unito.acusteme.test/providence/index.php(137): AppController->dispatch(true) #9 {main} thrown in /Users/gautier/www/unito.acusteme.test/providence/app/lib/Parsers/DisplayTemplateParser.php on line 207
````