### PR TITLE
allow dynamic configuration of authentication adapter

### DIFF
--- a/app/conf/authentication.conf
+++ b/app/conf/authentication.conf
@@ -12,7 +12,7 @@
 #	ExternalDB : Authentication using an external database
 #   Shibboleth: Authentication via the Shibboleth SSO service
 #	HTTPHeader : User info in HTTP Headers - web server handles login
-auth_adapter = CaUsers
+auth_adapter = __CA_AUTH_ADAPTER__
 
 # User different authentication method for service calls?
 #auth_adapter_for_services = CaUsers

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -71,6 +71,11 @@ if (!defined("__CA_ADMIN_EMAIL__")) {
 	define("__CA_ADMIN_EMAIL__", 'info@put-your-domain-here.com');
 }
 
+# __CA_AUTH_ADAPTER__ = the auth adapter for login
+#
+if (!defined("__CA_AUTH_ADAPTER__")) {
+	define("__CA_AUTH_ADAPTER__", 'CaUsers');
+}
 
 # Outgoing email
 #


### PR DESCRIPTION
For one of our projects we need both local users and simplesaml logins. Part of the users have access through their university IdP, part of the users can't have those accounts.
This change allows this variable to be handled through a new __CA__ const (__CA_AUTH_ADAPTER__) so that we can define this earlier on in custom setup.php. Users can select their adapter in a custom login screen (or get previously chosen adapter immediately through for instance session). Defaults to CaUsers, and existing conf/local/authentication.conf using one of the defined 'string' adapters shouldn't be affected.

We could do with just our own custom setup and custom conf/local, but maybe others could benefit from this (alternative to the allow_fallback_to_ca_users_auth)

<img width="961" height="432" alt="image" src="https://github.com/user-attachments/assets/7675933c-eb3a-4c3a-8f2d-8031f4106880" />
