### PR TITLE
fence against not activated user

### DIFF
--- a/app/lib/Controller/Request/RequestHTTP.php
+++ b/app/lib/Controller/Request/RequestHTTP.php
@@ -958,7 +958,10 @@ class RequestHTTP extends Request {
 		} else {		
 			$user_name = ($this->user && $this->user->getUserID()) ? $this->user->get('user_name') : ($pa_options["user_name"] ?? null);
 			$msg = "Successful login for '{$user_name}'; IP=".RequestHTTP::ip()."; user agent=".($_SERVER['HTTP_USER_AGENT'] ?? null);
+			if($this->user->get("active") == 0) $msg .= "; but user is not active";
+
 			caLogEvent('LOGIN', $msg, 'Auth');	// write logins to text log
+			if($this->user->get("active") == 0) return false;
 			
 			require_once(__CA_LIB_DIR__."/Logging/Eventlog.php");
 		    Eventlog::add(['CODE' => 'LOGN', 'MESSAGE' => $msg, 'SOURCE' => 'Auth']);	// Write logins to old table-based event log


### PR DESCRIPTION
when using shibboleth the users activity setting is not checked, causing all valid shibboleth logins to enter. 
It's probably better to let the CA setting control access in the end.

Other places to invalidate authentication (like authenticate() where CaUsers adapter does the check-up) would get the user in endless login redirects (because re-attempts to login would redirect to the IdP, and re-authenticate). 
getUserInfo() looked like a candidate too, but the fixed active=1 there doubles for new user registrations.
At this request level we can log the valid authentication with invalid activity setting feedback.
Currently the request is then 'broken' stranding the user on a blank page, not ideally but otherwise the redirects would start again.
There is no (too many) failed logins page to redirect to, an alternative could be a redirect to the logged out page where the user could get the smell that something is off with the login (but would probably trigger the user to endless manual retries).
