### PR TITLE
Can the "Cans ...", for consistency in user_actions.conf

### DIFF
--- a/app/conf/user_actions.conf
+++ b/app/conf/user_actions.conf
@@ -84,15 +84,15 @@ user_actions = {
 				description = _("Allow user to manage user defined sort field combinations")
 			},
 			can_use_plugin_tools = {
-				label = _("Can use plugin tools"),
+				label = _("Use plugin tools"),
 				description = _("Allow user to use tool plugins")
 			},
 			can_view_system_statistics = {
-				label = _("Can view system statistics"),
+				label = _("View system statistics"),
 				description = _("Allow user to use system statistics dashboard")
 			},
 			can_view_non_local_system_statistics = {
-				label = _("Can view non-local system statistics"),
+				label = _("View non-local system statistics"),
 				description = _("Allow user to view statistics fetched from other systems on the system statistics dashboard")
 			}
 		}
@@ -103,15 +103,15 @@ user_actions = {
 		description = _("Actions required for check out of library items. Only users to handle library-style check in/out should have access to these actions."),
 		actions = {
 			can_do_library_checkin	= { 
-				label = _("Can do library check in"), 
+				label = _("Do library check in"), 
 				description = _("Indicates user is allowed to check in library items.")
 			},
 			can_do_library_checkout	= { 
-				label = _("Can do library check out"), 
+				label = _("Do library check out"), 
 				description = _("Indicates user is allowed to check out library items.")
 			},
 			can_do_library_checkinout_for_anyone = { 
-				label = _("Can do library check in/out for any user"), 
+				label = _("Do library check in/out for any user"), 
 				description = _("Indicates user is allowed to check in/out library items for other users.")
 			}
 		}
@@ -162,11 +162,11 @@ user_actions = {
 		description = _("Actions allowing upload of media to server for subsequent import. Only users allowed to upload and import media should have access to these actions."),
 		actions = {
 			can_upload_media	= { 
-				label = _("Can use media uploader"), 
+				label = _("Use media uploader"), 
 				description = _("Indicates user is allowed to upload media using the media uploader interface.")
 			},
 			is_media_uploader_administrator	= { 
-				label = _("Can administer media uploader"), 
+				label = _("Administer media uploader"), 
 				description = _("Indicates user is allowed to administer the media uploader interface.")
 			}
 		}
@@ -359,15 +359,15 @@ user_actions = {
 				description = _("Allow user to edit lists of objects in the spreadsheet editor")
 			},
 			can_see_current_location_in_inspector_ca_objects = {
-				label = _("Can see current location of object in inspector"),
+				label = _("See current location of object in inspector"),
 				description = _("Allow user to see current location of object in editor inspector panel")
 			},
 			can_set_home_location_ca_objects = {
-				label = _("Can set home location of object in inspector"),
+				label = _("Set home location of object in inspector"),
 				description = _("Allow user to set home (default) location of object in editor inspector panel")
 			},
 			can_access_deaccessioned_ca_objects = {
-				label = _("Can access deaccessioned objects"),
+				label = _("Access deaccessioned objects"),
 				description = _("Allow user to search, browse or access deaccessioned objects"),
 				default = 1
 			},
@@ -431,11 +431,11 @@ user_actions = {
 				description = _("Allow user to edit lists of object representations in the spreadsheet editor")
 			},
 			can_see_current_location_in_inspector_ca_object_representations = {
-				label = _("Can see current location of object representation in inspector"),
+				label = _("See current location of object representation in inspector"),
 				description = _("Allow user to see current location of object representation in editor inspector panel")
 			},
 			can_set_home_location_ca_object_representations = {
-				label = _("Can set home location of object representation in inspector"),
+				label = _("Set home location of object representation in inspector"),
 				description = _("Allow user to set home (default) location of object representation in editor inspector panel")
 			},
 			can_view_change_log_ca_object_representations = {
@@ -541,15 +541,15 @@ user_actions = {
 				description = _("Allow user to delete batches of object lots")
 			},
 			can_set_home_location_ca_object_lots = {
-				label = _("Can set home location of object lot in inspector"),
+				label = _("Set home location of object lot in inspector"),
 				description = _("Allow user to set home (default) location of object lot in editor inspector panel")
 			},
 			can_see_current_location_in_inspector_ca_object_lots = {
-				label = _("Can see current location of object lot in inspector"),
+				label = _("See current location of object lot in inspector"),
 				description = _("Allow user to see current location of object lot in editor inspector panel")
 			},
 			can_access_deaccessioned_ca_object_lots = {
-				label = _("Can access deaccessioned object lots"),
+				label = _("Access deaccessioned object lots"),
 				description = _("Allow user to search, browse or access deaccessioned object lots"),
 				default = 1
 			},
@@ -806,15 +806,15 @@ user_actions = {
 				description = _("Allow user to delete batches of collections")
 			},
 			can_see_current_location_in_inspector_ca_collections = {
-				label = _("Can see current location of collection in inspector"),
+				label = _("See current location of collection in inspector"),
 				description = _("Allow user to see current location of collection in editor inspector panel")
 			},
 			can_set_home_location_ca_collections = {
-				label = _("Can set home location of collection in inspector"),
+				label = _("Set home location of collection in inspector"),
 				description = _("Allow user to set home (default) location of collection in editor inspector panel")
 			},
 			can_access_deaccessioned_ca_collections = {
-				label = _("Can access deaccessioned collections"),
+				label = _("Access deaccessioned collections"),
 				description = _("Allow user to search, browse or access deaccessioned collections"),
 				default = 1
 			},
@@ -878,7 +878,7 @@ user_actions = {
 				description = _("Allow user to edit lists of storage locations in the spreadsheet editor")
 			},
 			can_set_home_location_ca_storage_locations = {
-				label = _("Can set home location of storage location in inspector"),
+				label = _("Set home location of storage location in inspector"),
 				description = _("Allow user to set home (default) location of storage location in editor inspector panel")
 			},
 			can_batch_delete_ca_storage_locations = {
@@ -1188,7 +1188,7 @@ user_actions = {
 				description = _("Allow user to use JSON browse service.")
 			},
 			can_use_xml_config_updater = {
-				label = _("Can use config updater service"),
+				label = _("Use config updater service"),
 				description = _("Note that users with this permission can potentially destroy data in your system!")
 			}
 			can_use_json_simple_service = {
@@ -1258,7 +1258,7 @@ user_actions = {
 				description = _("Indicates user is allowed to edit site pages displayed in the current theme.")
 			},
 			can_edit_theme_global_values	= { 
-				label = _("Can edit global values for theme"), 
+				label = _("Can dit global values for theme"), 
 				description = _("Indicates user is allowed to edit global values displayed in the current theme.")
 			}
 		}


### PR DESCRIPTION
Looks like the newer permission labels did not follow the previous pattern. In case it is just an unintended inconsistency, this eliminates the "Can ..." from the labels that have them.

Except... I've left the pawtucket_prefs alone, just in case they are more deliberate (some weird uppercases though).