### PR TITLE
DEBUG : allow txt files, at least to unblock Robots.txt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,7 +14,7 @@ AddType text/srt .srt
 <FilesMatch "^(index|service|tilepic)\.php$">
         Allow from all
 </FilesMatch>
-<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|webp|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico|gltf|mtl|bin|js|txt|mov|glb|usdz|properties)$">
+<FilesMatch "^.*\.(css|gif|jpg|png|js|woff|woff2|ttf|swf|map|tif|tiff|webp|m4v|xml|ply|stl|html|json|mp3|wav|aiff|obj|bmp|mp4|pdf|svg|vtt|srt|ico|gltf|mtl|bin|js|txt|mov|glb|usdz|properties|txt)$">
         Allow from all
 </FilesMatch>
 


### PR DESCRIPTION
DEBUG : allow txt files, at least to unblock Robots.txt

Actually the line 57 is of no use : 
````
RewriteCond %{REQUEST_URI} !=/robots.txt
````
as the txt files are not allowed by the filter on line 17.