### PR TITLE
Fix: broken “duplicate identifier” link in IDNo checker (ca.idnochecker.js)

### DIFF
--- a/assets/ca/ca.idnochecker.js
+++ b/assets/ca/ca.idnochecker.js
@@ -86,7 +86,7 @@ var caUI = caUI || {};
                                     msg = that.pluralAlreadyInUseMessage.replace('%1', '' + data.matches.length);
                                 }
                                 if (that.searchUrl) {
-                                    msg = "<a href='" + that.searchUrl + idno + "'>" + msg + "</a>";
+                                    msg = "<a href='" + that.searchUrl + "?search=" + encodeURIComponent(idno) + "'>" + msg + "</a>";
                                 }
                                 jQuery('#' + that.idnoStatusID).html((that.errorIcon ? that.errorIcon + ' ' : '') + msg).show(0);
                             }


### PR DESCRIPTION
When creating a new ObjectLot (Zugang) and entering an existing inventory number, CollectiveAccess correctly shows the warning “Identifikator wird schon verwendet”.
However, clicking on the generated link did not open the corresponding record, but instead redirected the user to an empty simple search or caused a 404 error.

**Root cause:**
The JavaScript file ca.idnochecker.js built the link by concatenating the raw identifier directly into the search path, for example:

/find/SearchObjectLots/Index/search/FM-2002/356


Because identifiers in many installations include slash characters (/), Apache interpreted these as part of the URL path instead of a search term.
This caused the route not to match and resulted in an empty search page or a “Not Found” error.

**Fix implemented:**
The link creation has been updated to use a query parameter instead of a raw path segment, ensuring that identifiers containing special characters (e.g. /, +, #) are safely encoded and always produce valid links:

`msg = <a href='" + that.searchUrl + "?search=" + encodeURIComponent(idno) + "'>" + msg + "</a>
`

Result:

Clicking “Identifikator wird schon verwendet” now correctly performs a search for the matching record, even if the identifier contains /.

Works consistently for all record types (ObjectLots, Objects, etc.) using the duplicate identifier check.