### PR TITLE
escape css selectors

### DIFF
--- a/assets/ca/ca.bundlelisteditor.js
+++ b/assets/ca/ca.bundlelisteditor.js
@@ -80,7 +80,7 @@ var caUI = caUI || {};
 			jQuery('#' + that.availableListID).html(displayListText);
 			if(tooltipTargets.length) {
 			    for(let i in tooltipTargets) {
-			        jQuery('#' + tooltipTargets[i]).tooltip({tooltipClass: 'tooltipFormat', show: 150, hide: 150});
+			        jQuery('#' + CSS.escape(tooltipTargets[i])).tooltip({tooltipClass: 'tooltipFormat', show: 150, hide: 150});
 			    }
 			}
 			that._makeDisplayListsSortable();


### PR DESCRIPTION
users noticed the quicksearch "searches to display" user preferences where no longer draggable.

it appears the js broke on the selectors containing unfit characters. for instance #displayElement_ca_objects**/**manuscripts_0

easiest 'modern' way to solve this is to escape that kind of characters (! " # $ % & ' ( ) * + , . / : ; < = > ? @ [ \ ] ^ ` { | } ~), and should be fine for modern browsers (most but IE <=11)

alternatives are to use the jquery helper $.escapeSelector, or to change the selector to $('[id="displayElement_ca_objects/manuscripts_0"]'), or to escape at setting the list values displayElement_ca_objects\\/manuscripts_0 or to make the entire selector low profile altogether displayElement_ca_objects_manuscripts_0.
Mostly comes down to the eternal IE dilemma :p if we must handle those it is probably better to use $.escapeSelector (> jQuery 3.0) or [id=x]



After that (and cache busting the js file) we could drag the selection to re-order again, we could not yet drop the selected options back into the 'available' column - I have not figured that one out yet.