### PR TITLE
fix overlapping menu flyouts

### DIFF
--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -143,7 +143,7 @@ h5 {
 #navWrapper {
 	position: absolute;
 	float: right;
-	right: 20px;
+	left: 50%;
 }
 #logo {
     background-repeat: no-repeat;
@@ -758,7 +758,7 @@ ul.sf-menu li li.sfHover li ul {
 }
 ul.sf-menu li li li:hover ul,
 ul.sf-menu li li li.sfHover ul {
-    left:			12em; /* match ul width */
+    left:			14em; /* match ul width */
     top:			0;
 }
 


### PR DESCRIPTION
We are experiencing not so practical menu situations 

<img width="643" height="482" alt="image" src="https://github.com/user-attachments/assets/64b0157c-7db7-402c-ac0b-1a8ed21a8489" />

when we keep the left positioning identical to the ul width, we have far better results (stock-like superfish), especially when combined with the nav/search bar not completely positioned to the far right, because it clears available space for the flyout for longer (the somewhat centered position with 50% is just a suggestion, most situations can be fine with right above 300px)


<img width="856" height="469" alt="image" src="https://github.com/user-attachments/assets/6256d3a6-c240-4add-989c-af44f53d27ba" />
