### PR TITLE
pass options to manifest

### DIFF
--- a/app/service/controllers/IIIFController.php
+++ b/app/service/controllers/IIIFController.php
@@ -56,8 +56,9 @@ class IIIFController extends BaseServiceController {
 	 */
 	public function manifest() {
 		$path = explode('/', $this->request->getPathInfo()); // path = /IIIF/manifest/<identifier> ; identifier index = 3
+		$options = $this->getRequest()->getParameters();
 		try {
-			$manifest = IIIFService::manifest($path[3], $this->getRequest());
+			$manifest = IIIFService::manifest($path[3], $options);
 		} catch(IIIFAccessException $e) {
 			$this->getView()->setVar('errors', array($e->getMessage()));
 			$this->render('json_error.php');


### PR DESCRIPTION
fatal error on manifest (../service.php/IIIF/manifest/ca_objects:1234)

Fatal error: Uncaught TypeError: IIIFService::manifest(): Argument #2 ($options) must be of type ?array, RequestHTTP given

fixed by passing options instead of the request
(although not entirely sure what options should pass from the request)