### PR TITLE
Ticket[KULTMMS-1289] Fix hierarchy toggle label not updating correctly

### DIFF
--- a/themes/default/views/find/Search/search_controls_html.php
+++ b/themes/default/views/find/Search/search_controls_html.php
@@ -138,18 +138,30 @@ if (!$this->request->isAjax()) {
 						}
 					}
 				);
-				jQuery("#browseToggle").click(function() {
-					jQuery("#browse").slideToggle(350, function() { 
-						stateCookieJar.set('<?= $vs_table; ?>BrowserIsClosed', (this.style.display == 'block') ? 0 : 1); 
-						jQuery("#browseToggle").html((this.style.display == 'block') ? '<?= '<span class="form-button">'.addslashes(_t('Hide hierarchy ')).'</span>';?>' : '<?= '<span class="form-button">'._t('Show hierarchy').'</span>';?>');
-					}); 
-					return false;
+				jQuery("#browseToggle").off("click").on("click", function(e) {
+					e.preventDefault();
+
+					var $browse = jQuery("#browse");
+
+					$browse.stop(true, true).slideToggle(350, function() {
+						var isOpen = $browse.is(":visible");
+
+						stateCookieJar.set('<?= $vs_table; ?>BrowserIsClosed', isOpen ? 0 : 1);
+
+						jQuery("#browseToggle").html(
+							isOpen
+								? '<?= '<span class="form-button">'.addslashes(_t('Hide hierarchy')).'</span>';?>'
+								: '<?= '<span class="form-button">'.addslashes(_t('Show hierarchy')).'</span>';?>'
+						);
+					});
 				});
-				
+
+				var $browse = jQuery("#browse");
+
 				if (<?= ($this->getVar('force_hierarchy_browser_open') ? 'true' : "!stateCookieJar.get('{$vs_table}BrowserIsClosed')"); ?>) {
 					jQuery("#browseToggle").html('<?= '<span class="form-button">'.addslashes(_t('Hide hierarchy')).'</span>';?>');
 				} else {
-					jQuery("#browse").hide();
+					$browse.hide();
 					jQuery("#browseToggle").html('<?= '<span class="form-button">'.addslashes(_t('Show hierarchy')).'</span>';?>');
 				}
 			});


### PR DESCRIPTION
find/SearchStorageLocations/ViewHierarchy

The hierarchy toggle text did not reliably update after the first interaction.
The previous implementation determined the open/closed state by checking
this.style.display inside the slideToggle callback.

During jQuery animations, style.display is not a reliable indicator of the
final visibility state (it may be empty or temporarily inconsistent).
As a result, the hierarchy panel was opened or closed correctly, but the
toggle label ("Show hierarchy" / "Hide hierarchy") became out of sync.

We changed the logic to determine the state using jQuery’s :visible selector
and updated the toggle label and cookie based on the actual rendered state.
This keeps the UI text and the hierarchy browser state consistent on every
toggle.
