### PR TITLE
fix typo ca_loans breakout

### DIFF
--- a/app/conf/navigation.conf
+++ b/app/conf/navigation.conf
@@ -3234,7 +3234,7 @@ navigation = {
 					action:can_browse_ca_loans = OR,
  					configuration:!ca_loans_disable = AND,
 					configuration:!ca_loans_breakout_find_by_type_in_menu = AND,
-					configuration:!ca_loand_breakout_find_by_type_in_submenu = AND,
+					configuration:!ca_loans_breakout_find_by_type_in_submenu = AND,
 					availableTypes:ca_loans:__CA_BUNDLE_ACCESS_READONLY__ = AND
 				},
 				"parameters" = {


### PR DESCRIPTION
typo navigation.conf, 

causes double entries in find menu when using loans breakout