### PR TITLE
Ticket[KULTMMS-2143] : Fix TimelineJS loading issue caused by HTML re…

### DIFF
--- a/app/lib/BaseFindController.php
+++ b/app/lib/BaseFindController.php
@@ -1005,9 +1005,15 @@ class BaseFindController extends ActionController {
 		
 		$this->view->setVar('t_item', Datamodel::getInstanceByTableName($this->ops_tablename, true));
 		$this->view->setVar('num_items_rendered', (int)$o_viz->numItemsRendered());
-		
+
 		if ($pb_render_data) {
-			$this->response->addContent($o_viz->getDataForVisualization($ps_viz, array('request' => $this->request)));
+			$this->response->setContentType('application/json');
+			$this->response->addContent(
+				$o_viz->getDataForVisualization(
+					$ps_viz,
+					array('request' => $this->request)
+				)
+			);
 			return;
 		}
 		$this->render('Results/viz_html.php');


### PR DESCRIPTION
Before:

Opening the Timeline in Search → Objects stayed stuck on Loading.

The TimelineJS data endpoint (renderData=1) returned a full HTML page (<!DOCTYPE html>) instead of JSON.

This caused a JSON.parse error on the client side, so TimelineJS could not render any events.

Fix:

Updated BaseFindController::Viz() to explicitly return JSON when renderData=1:

Set Content-Type: application/json

Return only the output of getDataForVisualization() and skip HTML rendering.

After:

The endpoint now returns valid JSON.

TimelineJS parses the data correctly and the timeline renders as expected.

Any remaining missing images are related to representation/primary filtering and are independent of this fix.