### PR TITLE
Ticket [KULTMMS-1309] Translate saved search type dynamically via get…

### DIFF
--- a/themes/default/views/manage/saved_searches_list_html.php
+++ b/themes/default/views/manage/saved_searches_list_html.php
@@ -122,7 +122,7 @@ print caFormControlBox(
 							<?= $display_table; ?>
 						</td>
 						<td>
-							<?= str_replace("_", " ", $search_type); ?>
+							<?= _t(ucfirst(str_replace("_", " ", $search_type))); ?>
 						</td>
 						<td>
 							<?= caNavLink($this->request, $search, "", "find", $bits['controller'], 'doSavedSearch', ["saved_search_key" => $key]); ?>


### PR DESCRIPTION
Previously, the "Search Type" column in the saved searches list displayed
raw internal identifiers (e.g. "basic search", "advanced search") by
manually replacing underscores with spaces.

Because these values were not passed through gettext, they were not
localized and always appeared in English, even when translations were
available.

This change generates the display label dynamically and passes it through
_t(), enabling proper localization via messages.po without hardcoding
individual labels.

As a result, search type labels are now correctly translated according to
the active user locale.