### PR TITLE
load linked data config directly

### DIFF
--- a/app/lib/Plugins/InformationService/BaseGettyLODServicePlugin.php
+++ b/app/lib/Plugins/InformationService/BaseGettyLODServicePlugin.php
@@ -40,7 +40,7 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 	public function __construct() {
 		parent::__construct(); // sets app.conf
 
-		$this->opo_linked_data_conf = Configuration::load( $this->opo_config->get( 'linked_data_config' ) );
+		$this->opo_linked_data_conf = Configuration::load('linked_data.conf');
 	}
 
 	# ------------------------------------------------


### PR DESCRIPTION
linked_data_conf is no longer a config parameter pointing to the linked_data.conf in app.conf
followed BaseNonismaLOD that uses direct loading of linked_data.conf