### PR TITLE
guard against null for array_keys

### DIFF
--- a/themes/default/views/bundles/ca_search_form_placements.php
+++ b/themes/default/views/bundles/ca_search_form_placements.php
@@ -75,7 +75,7 @@ print caEditorBundleMetadataDictionary($this->request, $vs_id_prefix, $settings)
 				
 				availableDisplayList: <?= json_encode($va_available_display_items); ?>,
 				initialDisplayList: 	<?= json_encode($va_to_display_items); ?>,
-				initialDisplayListOrder : <?= json_encode(array_keys($va_to_display_items)); ?>,
+				initialDisplayListOrder : <?= json_encode(array_keys($va_to_display_items ?? [])); ?>,
 				
 				availableSearchID: 'bundleEditorAvailableListSearch',
 				


### PR DESCRIPTION
we experienced the same as https://github.com/collectiveaccess/providence/issues/1839

it comes down to the $va_to_display_items being null after cancel instead of an empty array, this fix does the null coalescing.
After that the we have a sort of empty search form again (without any selectable items however - maybe it is better to redirect the cancel to the search form list instead ? other variables seem lacking there like search type [1103] error, but probably not that relevant when landing on a blanked search form)