### PR TITLE
filter current user from other users

### DIFF
--- a/app/models/ca_sets.php
+++ b/app/models/ca_sets.php
@@ -655,6 +655,7 @@ class ca_sets extends BundlableLabelableBaseModelWithAttributes implements IBund
 			$va_sql_wheres[] = "(cs.user_id IN (SELECT user_id FROM ca_users))";
 		} elseif (isset($pa_options['allUsers']) && $pa_options['allUsers']) {
 			$va_sql_wheres[] = "(cs.user_id IN (SELECT user_id FROM ca_users WHERE userclass IN (0, 255)))";
+			if (!is_null($pn_user_id)) $va_sql_wheres[] = "(cs.user_id != $pn_user_id)";
 		} elseif (isset($pa_options['publicUsers']) && $pa_options['publicUsers']) {
 			$va_sql_wheres[] = "(cs.user_id IN (SELECT user_id FROM ca_users WHERE userclass = 1))";
 		} else {


### PR DESCRIPTION
when browsing sets some users are troubled by seeing their own sets listed among the "by other users" functionality.

There are a few inconsistencies still (like the 'allUsers' option key, and the navigation manage>my sets>All sets vs User Sets) but since you can have your own sets listed separately, it would make sense to have the other users sets separately (without the noise of your own sets) ?