### PR TITLE
use both label and value in lookup autocomplete

### DIFF
--- a/app/lib/Attributes/Values/InformationServiceAttributeValue.php
+++ b/app/lib/Attributes/Values/InformationServiceAttributeValue.php
@@ -444,10 +444,12 @@ class InformationServiceAttributeValue extends AttributeValue implements IAttrib
 											});
 									},
                                     html: true,
-                                    select: function(event, ui) {".((!$pb_for_search) ? "
-                                        jQuery('#{fieldNamePrefix}".$pa_element_info['element_id']."_{n}').val(ui.item.label + '|' + ui.item.idno + '|' + ui.item.url);" : 
-                                        "jQuery('#{fieldNamePrefix}".$pa_element_info['element_id']."_{n}').val(ui.item.label);"
-                                    )."
+                                    select: function(event, ui) {
+                                        if(ui.item.value=='')ui.item.value=ui.item.label;
+                                        ".((!$pb_for_search) ? "
+                                        jQuery('#{fieldNamePrefix}".$pa_element_info['element_id']."_{n}').val(ui.item.value + '|' + ui.item.idno + '|' + ui.item.url);" :
+		                                "jQuery('#{fieldNamePrefix}".$pa_element_info['element_id']."_{n}').val(ui.item.value);"
+	                                    )."
                                     }
                                 }
                             ).click(function() { this.select(); });


### PR DESCRIPTION
The CA implementation of the jQuery autocomplete lookup field is sort of incomplete and in a way backwards, in that the autocomplete element allows both label and value options. https://api.jqueryui.com/autocomplete/#:~:text=The%20label%20property%20is%20displayed,into%20the%20input%20element

"Label" was intended to go in the lookup results, "value" used as the elements real value upon user selection.
This allows that the "suggestions/results" can be a bit more verbose (provide context information for proper selection, especially useful when the results are hard to disambigue), than the actual value you want to store for the item. 
It is allowed to only use (either) one, and in that case the jQuery element handles them idempotent.

But having them both is super useful, and we use them alot in our informationservices. When you search for my (regionally quite common) name in Wikidata, you get at least three namesakes and then it helps to differ them, not only by Q12345 as the wiki-identifier, but perhaps descriptions (composer, researcher, photographer) or year of birth,... while not having that metadata in the actual stored label (value: 'Peter Janssens').

Another example is "Catalogue of Life" where metadata reveals in what dataset the occurrence is found, with what taxon id, status of the term (accepted, provisionally, archived,,..)
<img width="673" height="208" alt="image" src="https://github.com/user-attachments/assets/7e530278-4634-4a00-956e-e72bf9507dba" />
After selection the plain label is kept as the value label (and that other metadata can be stored in detail in the extra info if needed/useful; cfr. the dot-style notation PR https://github.com/collectiveaccess/providence/pull/1415)


This commit allows to "co-exist" with the current implementation, because proper change would require all informationservices to add or toggle the intent of value and label; and for that there are too many informationservices, and probably many more custom services in users repos.

There is one caveat though, that we stumbled upon later with bulk actions (imports, utils,..) where there is supposed to be one value but there is no user 'select' that handles the label/value negociation of jQuery itself.
We need to handle those ourselves by sniffing where we are (import, util/cli) and swap the value, otherwise the value is empty and then gets the label (with the added metadata).


We can keep this change local, but still wanted to share because it makes the informationservices more powerful.
Also want to use this PR to "check the pulse" on the upcoming v3.x, where you mentionned UI changes; if that would be dropping jQuery that makes this remark shortlived :p

