### PR TITLE
Fix: Properly handle clearing of scalar attributes in editRepresentation()

### DIFF
--- a/app/lib/RepresentableBaseModel.php
+++ b/app/lib/RepresentableBaseModel.php
@@ -857,8 +857,16 @@ class RepresentableBaseModel extends BundlableLabelableBaseModelWithAttributes {
 					} elseif($t_rep->hasField($vs_element)) {
 						$t_rep->set($vs_element, $va_value);
 					} else {
-						// scalar value (simple single value attribute)
-						if ($va_value) {
+						// scalar attribute
+						if ($va_value === '' || is_null($va_value)) {
+							// remove attribute if cleared
+							if ($t_element = ca_metadata_elements::getInstance($vs_element)) {
+								$t_rep->removeAttributes(
+									$t_element->getPrimaryKey(),
+									['force' => true]
+								);
+							}
+						} else {
 							$t_rep->replaceAttribute(array(
 								'locale_id' => $pn_locale_id,
 								$vs_element => $va_value


### PR DESCRIPTION
Previously, scalar attribute values in RepresentableBaseModel::editRepresentation()
were only updated if the submitted value was truthy. As a result, clearing a field
in the UI (e.g. setting "remark" to an empty string) did not remove the existing
attribute value, since empty strings were ignored.

This change updates the scalar attribute handling logic to explicitly support
clearing values:

- If a scalar attribute is submitted as an empty string or null,
  existing attributes for that element are removed.
- Otherwise, replaceAttribute() is called as before.

This ensures consistent and expected behavior when users clear fields in the
object representation editor.

No changes were made to addRepresentation() to avoid altering new representation
creation behavior.