### PR TITLE
Ticket[KULTMMS-782]: Enable media download by representation type in …

### DIFF
--- a/app/lib/BaseFindController.php
+++ b/app/lib/BaseFindController.php
@@ -792,8 +792,9 @@ class BaseFindController extends ActionController {
 	/**
 	 * 
 	 * 
-	 */ 
+	 */
 	public function DownloadMedia() {
+
 		if ($t_subject = Datamodel::getInstanceByTableName($this->ops_tablename, true)) {
 			$o_md_conf = Configuration::load('media_metadata');
 
@@ -801,27 +802,27 @@ class BaseFindController extends ActionController {
 			if (($ids = trim($this->request->getParameter($t_subject->tableName(), pString))) || ($ids = trim($this->request->getParameter($t_subject->primaryKey(), pString)))) {
 				if ($ids !== 'all') {
 					$id_list = explode(';', $ids);
-					
+
 					foreach($id_list as $i => $id) {
 						if (!trim($id) || !(int)$id) { unset($id_list[$i]); }
 					}
 				}
 			}
-	
-			if (!is_array($id_list) || !sizeof($id_list)) { 
+
+			if (!is_array($id_list) || !sizeof($id_list)) {
 				$id_list = $this->opo_result_context->getResultList();	// get media for entire result set
 			}
-			
+
 			if (($limit = (int)$t_subject->getAppConfig()->get('maximum_download_file_count')) > 0) {	// truncate to maximum
 				$id_list = array_slice($id_list, 0, $limit);
 			}
-			
+
 			$o_view = new View($this->request, $this->request->getViewsDirectoryPath().'/bundles/');
-					
+
 			$download_list = [];
 			if (is_array($id_list) && sizeof($id_list)) {
 				$preferred_version = $this->request->getParameter('version', pString);
-				
+				$pn_type_id = $this->request->getParameter('type', pString);
 				$element_code = null;
 				if (preg_match('!^attribute([\d]+)$!', $preferred_version, $m)) {
 					// Derive get() spec for FT_MEDIA metadata attribute
@@ -833,17 +834,17 @@ class BaseFindController extends ActionController {
 				if ($qr_res = $t_subject->makeSearchResult($t_subject->tableName(), $id_list, array('filterNonPrimaryRepresentations' => false))) {
 					if (!($limit = ini_get('max_execution_time'))) { $limit = 30; }
 					set_time_limit($limit * 10);	// allow extra time to process files
-					
+
 					while($qr_res->nextHit()) {
 						if(!$element_code) {
 							// representation
 							$version = (!is_array($version_list = $qr_res->getMediaVersions('ca_object_representations.media')) || !in_array($preferred_version, $version_list)) ? 'original' : $preferred_version;
-						
+
 							$paths = $qr_res->getMediaPaths('ca_object_representations.media', $version);
 							$infos = $qr_res->getMediaInfos('ca_object_representations.media');
 							$representation_ids = $qr_res->get('ca_object_representations.representation_id', array('returnAsArray' => true));
 							$representation_types = $qr_res->get('ca_object_representations.type_id', array('returnAsArray' => true));
-						
+
 							foreach($paths as $i => $path) {
 								$ext = array_pop(explode(".", $path));
 								$idno = $qr_res->get($t_subject->tableName().'.idno');
@@ -851,11 +852,12 @@ class BaseFindController extends ActionController {
 								$index = (sizeof($paths) > 1) ? ($i + 1) : '';
 								$representation_id = $representation_ids[$i];
 								$representation_type = caGetListItemIdno($representation_types[$i]);
+								if ($pn_type_id && ((int)$representation_types[$i] !== (int)$pn_type_id)) { continue; }
 
 								// make sure we don't download representations the user isn't allowed to read
 								if(!caCanRead($this->request->user->getPrimaryKey(), 'ca_object_representations', $representation_id)){ continue; }
-									
-								$filename = caGetRepresentationDownloadFileName($this->ops_tablename, ['idno' => $idno, 'index' => $index, 'version' => $version, 'extension' => $ext, 'original_filename' => $original_name, 'representation_id' => $representation_id]);				
+
+								$filename = caGetRepresentationDownloadFileName($this->ops_tablename, ['idno' => $idno, 'index' => $index, 'version' => $version, 'extension' => $ext, 'original_filename' => $original_name, 'representation_id' => $representation_id]);
 
 								if($o_md_conf->get('do_metadata_embedding_for_search_result_media_download')) {
 									if($path_with_embedding = caEmbedMediaMetadataIntoFile($qr_res, $version, ['path' => $path])) {
@@ -870,13 +872,13 @@ class BaseFindController extends ActionController {
 							$paths = $qr_res->get("{$element_code}.{$version}.path", ['returnAsArray' => true]);
 							$idno = $qr_res->get($t_subject->tableName().'.idno');
 							$original_filename = pathinfo($qr_res->get($element_code.'.original_filename'), PATHINFO_BASENAME);
-						
+
 							foreach($paths as $i => $path) {
 								$ext = array_pop(explode(".", $path));
-							
+
 								$index = (sizeof($paths) > 1) ? ($i + 1) : '';
-								$filename = caGetRepresentationDownloadFileName($this->ops_tablename, ['idno' => $idno, 'index' => $index, 'version' => $version, 'extension' => $ext, 'original_filename' => $original_filename], ['mode' => $original_filename ? 'original_filename' : 'idno']);	
-								
+								$filename = caGetRepresentationDownloadFileName($this->ops_tablename, ['idno' => $idno, 'index' => $index, 'version' => $version, 'extension' => $ext, 'original_filename' => $original_filename], ['mode' => $original_filename ? 'original_filename' : 'idno']);
+
 								if (!file_exists($path)) { continue; }
 								$download_list[$path] = $filename;
 							}
@@ -884,14 +886,14 @@ class BaseFindController extends ActionController {
 					}
 				}
 			}
-		
-			$file_count = sizeof($download_list);			
+
+			$file_count = sizeof($download_list);
 			if ($file_count > 1) {
 				$o_zip = new ZipStream();
 				foreach($download_list as $path => $filename) {
 					$o_zip->addFile($path, $filename);
 				}
-				
+
 				$o_view->setVar('zip_stream', $o_zip);
 				$o_view->setVar('archive_name', 'media_for_'.mb_substr(preg_replace('![^A-Za-z0-9]+!u', '_', $this->getCriteriaForDisplay()), 0, 20).'.zip');
 
@@ -905,11 +907,23 @@ class BaseFindController extends ActionController {
 					break;
 				}
 			} else {
+				if ($pn_type_id) {
+					$this->notification->addNotification(
+						_t('Could not generate ZIP file for download'),
+						__NOTIFICATION_TYPE_ERROR__
+					);
+
+					$this->response->setRedirect(
+						caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'Index')
+					);
+					return;
+				}
+
 				$this->response->setHTTPResponseCode(204, _t('No files to download'));
 			}
 			return;
 		}
-		
+
 		// post error
 		$this->postError(3100, _t("Could not generate ZIP file for download"),"BaseFindController->DownloadMedia()");
 	}

--- a/themes/default/views/find/Search/search_tools_html.php
+++ b/themes/default/views/find/Search/search_tools_html.php
@@ -92,8 +92,31 @@ $table = $t_subject->tableName();
 	<br class='clear'/>
 <?php
 	if($this->request->user->canDoAction('can_download_ca_object_representations')) {
-		$options = []; 
-		
+		$options = [];
+		$options_types = [];
+
+		$t_list = new ca_lists();
+		$va_representation_types = $t_list->getItemsForList('object_representation_types');
+
+
+		if (is_array($va_representation_types) && sizeof($va_representation_types)) {
+			foreach ($va_representation_types as $item_id => $va_type_by_locale) {
+				if (!is_array($va_type_by_locale)) { continue; }
+
+				$vn_locale_id = $this->request->getUser()->getPreferredUILocaleID();
+				if (isset($va_type_by_locale[$vn_locale_id])) {
+					$va_type = $va_type_by_locale[$vn_locale_id];
+				} else {
+					$va_type = reset($va_type_by_locale);
+				}
+
+				if (!empty($va_type['name_singular']) && !empty($va_type['item_id'])) {
+					$label = _t('All results: %1 (representation)', $va_type['name_singular']);
+					$options_types[$label] = 'type_'.$va_type['item_id'];
+				}
+			}
+		}
+
 		if($this->request->user->canDoAction('can_download_ca_object_representations') && in_array($table, $this->request->config->get('allow_representation_downloads_from_find_for'))) {
 			foreach($this->getVar('ca_object_representation_download_versions') as $version) {
 				foreach([
@@ -116,8 +139,10 @@ $table = $t_subject->tableName();
 				$options[$label] = "{$mode}_attribute{$element['element_id']}";
 			}
 		}
-		
-		ksort($options);
+
+		uksort($options_types, 'strnatcasecmp');
+		uksort($options, 'strnatcasecmp');
+		$options = $options + $options_types;
 		
 		if(sizeof($options)) {
 ?>	
@@ -222,7 +247,13 @@ $table = $t_subject->tableName();
 		var tmp = mode.split('_');
 		if(tmp[0] == 'all') {	// download all search results
 			jQuery(window).attr('location', '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'DownloadMedia'); ?>' + '/<?= $table; ?>/all/version/' + tmp[1] + '/download/1');
-		} else {
+		}
+		else if (tmp[0] === 'type') {
+
+			jQuery(window).attr('location', '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'DownloadMedia'); ?>' + '/<?= $table; ?>/all/type/' + tmp[1] + '/download/1');
+
+		}
+		else {
 			jQuery(window).attr('location', '<?= caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), 'DownloadMedia'); ?>' + '/<?= $table; ?>/' + caGetSelectedItemIDsToAddToSet().join(';') + '/version/' + tmp[1] + '/download/1');
 		}
 	}


### PR DESCRIPTION
## Summary
This change adds support for downloading media from search results by representation type.

## Background
Users needed a way to export only media of a specific type (for example Onlinequalität) from a result set, instead of downloading all media files and filtering them manually afterward.

## Changes
- added representation type options to the "Download media as" dropdown
- added frontend support for type-based download requests
- extended `BaseFindController::DownloadMedia()` to filter representations by `type_id`
- kept existing version-based and attribute-based download options unchanged

## Result
Users can now download media for all search results filtered by a selected representation type.