### PR TITLE
Update .gitignore to ignore all themes except default theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ build
 /app/lib/core/Parsers/dompdf/lib/fonts/*fm.php
 /app/log/log*.txt
 /app/log/*.log
+/themes/*
+!/themes/default
 /themes/default/css/local.css
 /themes/default/views/bundles/inspector_info.php
 /support/scripts/*.php


### PR DESCRIPTION
This change allows custom themes inside the Providence themes/ folder without Git tracking. setup.php and post-setup.php intentionally leave __CA_THEMES_DIR__ pointing at the standard themes/ folder so `setViewPath` function (in app/lib/View.php) can resolve inherited theme paths from __CA_THEME_DIR__ and __CA_THEMES_DIR__; overriding that constant breaks automatic lookup of the stock default theme and forces copying the full default theme into the new location to preserve inheritance.