### PR TITLE
Fix incorrect default for for_duplication flag preventing prepopulate execution

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -304,7 +304,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 					'table_name' => $table, 
 					'instance' => $this, 
 					'is_insert' => true, 
-					'for_duplication' => caGetOption('forDuplication', $pa_options, true)
+					'for_duplication' => caGetOption('forDuplication', $pa_options, false)
 				]
 			);
 		}
@@ -415,7 +415,7 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 					'table_num' => $this->tableNum(), 
 					'table_name' => $this->tableName(), 
 					'instance' => $this, 'is_insert' => false, 
-					'for_duplication' => caGetOption('forDuplication', $pa_options, true)
+					'for_duplication' => caGetOption('forDuplication', $pa_options, false)
 				]
 			);
 		}


### PR DESCRIPTION
The for_duplication flag was defaulting to true when not explicitly set in $pa_options:

    caGetOption('forDuplication', $pa_options, true)

This caused all insert/update operations to be treated as duplication,
even when no duplication was intended.

As a result, plugins (such as prepopulate) that rely on the for_duplication
flag incorrectly skipped execution.

This change updates the default value to false:

    caGetOption('forDuplication', $pa_options, false)

This ensures:
- Normal insert/update operations are not treated as duplication
- Prepopulate rules execute correctly on save
- Actual duplication behavior remains unaffected, as duplication code explicitly sets:
    ['forDuplication' => true]

This fix restores the intended behavior without impacting existing duplication workflows