### PR TITLE
Fix theme inheritance on login and logout views

### DIFF
--- a/themes/default/views/system/logged_out_html.php
+++ b/themes/default/views/system/logged_out_html.php
@@ -32,7 +32,7 @@
 		<title><?= $this->request->config->get("app_display_name"); ?></title>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 		
-		<link href="<?= caGetThemeUrlPath() ?>/css/login.css" rel="stylesheet" type="text/css" />
+		<link href="<?= $this->request->getDefaultThemeUrlPath() ?>/css/login.css" rel="stylesheet" type="text/css" />
 		<?= AssetLoadManager::getLoadHTML($this->request); ?>
 
 		<script type="text/javascript">

--- a/themes/default/views/system/login_html.php
+++ b/themes/default/views/system/login_html.php
@@ -34,7 +34,7 @@
 		<title><?= $this->request->config->get("app_display_name"); ?></title>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 		
-		<link href="<?= caGetThemeUrlPath() ?>/css/login.css" rel="stylesheet" type="text/css" />
+		<link href="<?= $this->request->getDefaultThemeUrlPath() ?>/css/login.css" rel="stylesheet" type="text/css" />
 		<?= AssetLoadManager::getLoadHTML($this->request); ?>
 
 		<script type="text/javascript">


### PR DESCRIPTION
This change replaces the global `caGetThemeUrlPath()` helper from `app/helpers/errorHelpers.php` with `getDefaultThemeUrlPath()`, which is already available through the request context in the login and logout views.

Using `getDefaultThemeUrlPath()` is more robust because it correctly handles theme inheritance and resolves the appropriate asset path dynamically. With the previous implementation, any custom theme would require duplicating the login and logout templates just to adjust asset references, leading to unnecessary copy/paste.