### PR TITLE
Fix importer upload error caused by PhpSpreadsheet getCell() API change

### DIFF
--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -833,23 +833,30 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 		global $g_ui_locale_id;
 		$vn_locale_id = (isset($pa_options['locale_id']) && (int)$pa_options['locale_id']) ? (int)$pa_options['locale_id'] : $g_ui_locale_id;
 		$pa_errors = array();
-		
+
 		$is_new = true;
-		
+
 		$o_log = caGetImportLogger($pa_options);
-		
+
 		$o_excel = \PhpOffice\PhpSpreadsheet\IOFactory::load($ps_source);
 		$o_excel->setActiveSheetIndex(0);	// we assume the mapping is in the first sheet
 		$o_sheet = $o_excel->getActiveSheet();
-		
+
+		$fn_get_cell = function($po_sheet, $pm_coordinate) {
+			if (is_array($pm_coordinate)) {
+				$pm_coordinate = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($pm_coordinate[0]) . $pm_coordinate[1];
+			}
+			return $po_sheet->getCell($pm_coordinate);
+		};
+
 		$vn_row = 0;
-		
+
 		$va_settings = array();
 		$va_rules = array();
 		$va_environment = array();
-		
+
 		$va_refineries = RefineryManager::getRefineryNames();
-		
+
 		$va_refinery_ci_map = array();
 		foreach($va_refineries as $vs_refinery) {
 			$va_refinery_ci_map[strtolower($vs_refinery)] = $vs_refinery;
@@ -861,11 +868,11 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				$vn_row++;
 				continue;
 			}
-			
+
 			$vn_row_num = $o_row->getRowIndex();
-			$o_cell = $o_sheet->getCell([1, $vn_row_num]);
+			$o_cell = $fn_get_cell($o_sheet, [1, $vn_row_num]);
 			$vs_mode = strtolower(trim((string)$o_cell->getValue()));
-			
+
 			switch($vs_mode) {
 				default:
 				case 'skip':
@@ -873,42 +880,42 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					break;
 				case 'mapping':
 				case 'constant':
-					$o_source = $o_sheet->getCell([2, $o_row->getRowIndex()]);
-					$o_dest = $o_sheet->getCell([3, $o_row->getRowIndex()]);
-					
-					$o_group = $o_sheet->getCell([4, $o_row->getRowIndex()]);
-					$o_options = $o_sheet->getCell([5, $o_row->getRowIndex()]);
-					$o_refinery = $o_sheet->getCell([6, $o_row->getRowIndex()]);
-					$o_refinery_options = $o_sheet->getCell([7, $o_row->getRowIndex()]);
-					$o_orig_values = $o_sheet->getCell([8, $o_row->getRowIndex()]);
-					$o_replacement_values = $o_sheet->getCell([9, $o_row->getRowIndex()]);
-					$o_source_desc = $o_sheet->getCell([10, $o_row->getRowIndex()]);
-					$o_notes = $o_sheet->getCell([11, $o_row->getRowIndex()]);
-					
+					$o_source = $fn_get_cell($o_sheet, [2, $o_row->getRowIndex()]);
+					$o_dest = $fn_get_cell($o_sheet, [3, $o_row->getRowIndex()]);
+
+					$o_group = $fn_get_cell($o_sheet, [4, $o_row->getRowIndex()]);
+					$o_options = $fn_get_cell($o_sheet, [5, $o_row->getRowIndex()]);
+					$o_refinery = $fn_get_cell($o_sheet, [6, $o_row->getRowIndex()]);
+					$o_refinery_options = $fn_get_cell($o_sheet, [7, $o_row->getRowIndex()]);
+					$o_orig_values = $fn_get_cell($o_sheet, [8, $o_row->getRowIndex()]);
+					$o_replacement_values = $fn_get_cell($o_sheet, [9, $o_row->getRowIndex()]);
+					$o_source_desc = $fn_get_cell($o_sheet, [10, $o_row->getRowIndex()]);
+					$o_notes = $fn_get_cell($o_sheet, [11, $o_row->getRowIndex()]);
+
 					if (!($vs_group = trim((string)$o_group->getValue()))) {
 						$vs_group = '_group_'.md5((string)$o_source->getValue()."_{$vn_row}");
 					}
-					
+
 					$vs_source = trim((string)$o_source->getValue());
-					
+
 					if ($vs_mode == 'constant') {
 						$vs_source = "_CONSTANT_:{$vn_row_num}:{$vs_source}";
 					}
 					$vs_destination = trim((string)$o_dest->getValue());
-					
-					if (!$vs_source) { 
+
+					if (!$vs_source) {
 						$pa_errors[] = _t("Warning: skipped mapping at row %1 because source was not defined", $vn_row_num);
 						if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:%1] Skipped mapping at row %2 because source was not defined", $ps_source, $vn_row_num)); }
 						continue(2);
 					}
-					if (!$vs_destination) { 
+					if (!$vs_destination) {
 						$pa_errors[] = _t("Warning: skipped mapping at row %1 because destination was not defined", $vn_row_num);
 						if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:%1] Skipped mapping at row %2 because destination was not defined", $ps_source, $vn_row_num)); }
 						continue(2);
 					}
-					
+
 					$va_options = null;
-					if ($vs_options_json = (string)$o_options->getValue()) { 
+					if ($vs_options_json = (string)$o_options->getValue()) {
 						if (is_null($va_options = @json_decode(caRepairJson($vs_options_json), true))) {
 							// Error while json decode
 							$pa_errors[] = _t("Warning: invalid json in \"options\" column at line %4  for group %1/source %2. Json was: %3", $vs_group, $vs_source, $vs_options_json, $vn_row_num);
@@ -916,30 +923,30 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							return null;
 						}
 					}
-                    $vs_refinery = $va_refinery_ci_map[strtolower(trim((string)$o_refinery->getValue()))] ?? null;
-                
-                    $va_refinery_options = null;
-                    if ($vs_refinery && ($vs_refinery_options_json = (string)$o_refinery_options->getValue())) {
-                        if (!in_array($vs_refinery, $va_refineries)) {
-                            $pa_errors[] = _t("Warning: refinery %1 does not exist", $vs_refinery)."\n";
-                            if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:%1] Invalid options for group %2/source %3", $ps_source, $vs_group, $vs_source)); }
-                        } else {
-                            // Test whether the JSON is valid
-                            if (is_null($va_refinery_options = json_decode(caRepairJson($vs_refinery_options_json), true))) {
-                                // Error while json decode
-                                $pa_errors[] = _t("invalid json for refinery options at line %4 for group %1/source %2 = %3", $vs_group, $vs_source, $vs_refinery_options_json, $vn_row_num);
-                                if ($o_log) { $o_log->logError( _t("[loadImporterFromFile:%1] invalid json for refinery options at line %5 for group %2/source %3 = %4", $ps_source, $vs_group, $vs_source, $vs_refinery_options_json, $vn_row_num)); }
-                                return null;
-                            }
-                        }
-                    }
-					
+					$vs_refinery = $va_refinery_ci_map[strtolower(trim((string)$o_refinery->getValue()))] ?? null;
+
+					$va_refinery_options = null;
+					if ($vs_refinery && ($vs_refinery_options_json = (string)$o_refinery_options->getValue())) {
+						if (!in_array($vs_refinery, $va_refineries)) {
+							$pa_errors[] = _t("Warning: refinery %1 does not exist", $vs_refinery)."\n";
+							if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:%1] Invalid options for group %2/source %3", $ps_source, $vs_group, $vs_source)); }
+						} else {
+							// Test whether the JSON is valid
+							if (is_null($va_refinery_options = json_decode(caRepairJson($vs_refinery_options_json), true))) {
+								// Error while json decode
+								$pa_errors[] = _t("invalid json for refinery options at line %4 for group %1/source %2 = %3", $vs_group, $vs_source, $vs_refinery_options_json, $vn_row_num);
+								if ($o_log) { $o_log->logError( _t("[loadImporterFromFile:%1] invalid json for refinery options at line %5 for group %2/source %3 = %4", $ps_source, $vs_group, $vs_source, $vs_refinery_options_json, $vn_row_num)); }
+								return null;
+							}
+						}
+					}
+
 					$va_original_values = $va_replacement_values = array();
 					if ($va_options && is_array($va_options) && isset($va_options['transformValuesUsingWorksheet']) && $va_options['transformValuesUsingWorksheet']) {
 						if ($o_opt_sheet = $o_excel->getSheetByName($va_options['transformValuesUsingWorksheet'])) {
 							foreach ($o_opt_sheet->getRowIterator() as $o_sheet_row) {
-								if (!$vs_original_value = trim(mb_strtolower((string)$o_opt_sheet->getCell([1, $o_sheet_row->getRowIndex()])))) { continue; }
-								$vs_replacement_value = trim((string)$o_opt_sheet->getCell([2, $o_sheet_row->getRowIndex()]));
+								if (!$vs_original_value = trim(mb_strtolower((string)$fn_get_cell($o_opt_sheet, [1, $o_sheet_row->getRowIndex()])->getValue()))) { continue; }
+								$vs_replacement_value = trim((string)$fn_get_cell($o_opt_sheet, [2, $o_sheet_row->getRowIndex()])->getValue());
 								$va_original_values[] = $vs_original_value;
 								$va_replacement_values[] = $vs_replacement_value;
 							}
@@ -968,7 +975,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							}
 						}
 					}
-					
+
 					$va_mapping[$vs_group][$vs_source][] = array(
 						'destination' => $vs_destination,
 						'options' => $va_options,
@@ -981,9 +988,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					);
 					break;
 				case 'setting':
-					$o_setting_name = $o_sheet->getCell([2, $o_row->getRowIndex()]);
-					$o_setting_value = $o_sheet->getCell([3, $o_row->getRowIndex()]);
-					
+					$o_setting_name = $fn_get_cell($o_sheet, [2, $o_row->getRowIndex()]);
+					$o_setting_value = $fn_get_cell($o_sheet, [3, $o_row->getRowIndex()]);
+
 					switch($vs_setting_name = (string)$o_setting_name->getValue()) {
 						case 'inputTypes':		// older mapping worksheets use "inputTypes" instead of the preferred "inputFormats"
 						case 'inputFormats':
@@ -1000,9 +1007,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					}
 					break;
 				case 'rule':
-					$o_rule_trigger = $o_sheet->getCell([2, $o_row->getRowIndex()]);
-					$o_rule_action = $o_sheet->getCell([3, $o_row->getRowIndex()]);
-					
+					$o_rule_trigger = $fn_get_cell($o_sheet, [2, $o_row->getRowIndex()]);
+					$o_rule_action = $fn_get_cell($o_sheet, [3, $o_row->getRowIndex()]);
+
 					$vs_action_string = (string)$o_rule_action->getValue();
 					if (!($va_actions = json_decode($vs_action_string, true))) {
 						$va_actions = [];
@@ -1016,26 +1023,26 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						'trigger' => (string)$o_rule_trigger->getValue(),
 						'actions' => $va_actions
 					);
-					
+
 					break;
 				case 'environment':
-					$o_source = $o_sheet->getCell([2, $o_row->getRowIndex()]);
-					$o_env_var = $o_sheet->getCell([3, $o_row->getRowIndex()]);
-					$o_options = $o_sheet->getCell([5, $o_row->getRowIndex()]);
-					
+					$o_source = $fn_get_cell($o_sheet, [2, $o_row->getRowIndex()]);
+					$o_env_var = $fn_get_cell($o_sheet, [3, $o_row->getRowIndex()]);
+					$o_options = $fn_get_cell($o_sheet, [5, $o_row->getRowIndex()]);
+
 					$va_options = array();
-					if ($vs_options_json = (string)$o_options->getValue()) { 
+					if ($vs_options_json = (string)$o_options->getValue()) {
 						json_decode($vs_options_json, TRUE);
 						if(json_last_error()){
 							// try encode newlines
-							$vs_options_json = preg_replace("![\r\n]!", "\\\\n", $vs_options_json);	
+							$vs_options_json = preg_replace("![\r\n]!", "\\\\n", $vs_options_json);
 						}
 						if (is_null($va_options = @json_decode($vs_options_json, true))) {
 							$pa_errors[] = _t("Warning: invalid options for environment %1.", (string)$o_source->getValue());
 							if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:environment %1] Invalid options for environment value %1. Options were: %2.", (string)$o_source->getValue(), $vs_options_json)); }
 						}
 					}
-					
+
 					$va_environment[] = array(
 						'name' => (string)$o_env_var->getValue(),
 						'value' => (string)$o_source->getValue(),
@@ -1045,9 +1052,9 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 			}
 			$vn_row++;
 		}
-		
+
 		// Do checks on mapping
-		if (!$va_settings['code']) { 
+		if (!$va_settings['code']) {
 			$pa_errors[] = _t("You must set a code for your mapping!");
 			if ($o_log) { $o_log->logError(_t("[loadImporterFromFile:%1] You must set a code for your mapping!", $ps_source)); }
 			return null;
@@ -1059,23 +1066,23 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 			if ($o_log) { $o_log->logError(_t("[loadImporterFromFile:%1] It looks like this is a mapping for the data export framework and you're trying to add it as import mapping!", $ps_source)); }
 			return null;
 		}
-		
+
 		// If no formats then default to everything
 		if (!isset($va_settings['inputFormats']) || !is_array($va_settings['inputFormats']) || !sizeof($va_settings['inputFormats'])) {
 			$va_settings['inputFormats'] = array_values(ca_data_importers::getAvailableInputFormats());
 		}
-		
+
 		if (!($t_instance = Datamodel::getInstance($va_settings['table']))) {
 			$pa_errors[] = _t("Mapping target table %1 is invalid\n", $va_settings['table']);
 			if ($o_log) {  $o_log->logError(_t("[loadImporterFromFile:%1] Mapping target table %2 is invalid\n", $ps_source, $va_settings['table'])); }
 			return null;
 		}
-		
+
 		if (!$va_settings['name']) { $va_settings['name'] = $va_settings['code']; }
-		
-		
+
+
 		$t_importer = new ca_data_importers();
-		
+
 		// Remove any existing mapping
 		if ($t_importer->load(array('importer_code' => $va_settings['code']))) {
 			if ((!(bool)$t_importer->get('deleted'))) { $is_new = false; }
@@ -1086,12 +1093,12 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 				return null;
 			}
 		}
-		
+
 		// Create new mapping
 		$t_importer->set('importer_code', $va_settings['code']);
 		$t_importer->set('table_num', $t_instance->tableNum());
 		$t_importer->set('rules', array('rules' => $va_rules, 'environment' => $va_environment));
-		
+
 		unset($va_settings['code']);
 		unset($va_settings['table']);
 		foreach($va_settings as $vs_k => $vs_v) {
@@ -1101,55 +1108,55 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 			$t_importer->setSetting('sourceUrl', urldecode($source_url));
 		}
 		$t_importer->insert();
-		
+
 		if ($t_importer->numErrors()) {
 			$pa_errors[] = _t("Error creating mapping: %1", join("; ", $t_importer->getErrors()))."\n";
 			if ($o_log) { $o_log->logError(_t("[loadImporterFromFile:%1] Error creating mapping: %2", $ps_source, join("; ", $t_importer->getErrors()))); }
 			return null;
 		}
-		
-		
+
+
 		$t_importer->addLabel(array('name' => $va_settings['name']), $vn_locale_id, null, true);
-		
+
 		if ($t_importer->numErrors()) {
 			$pa_errors[] = _t("Error creating mapping name: %1", join("; ", $t_importer->getErrors()))."\n";
 			if ($o_log) {  $o_log->logError(_t("[loadImporterFromFile:%1] Error creating mapping: %2", $ps_source, join("; ", $t_importer->getErrors()))); }
 			return null;
 		}
-		
+
 		$t_importer->set('worksheet', $ps_source);
 		$t_importer->update();
-		
+
 		if ($t_importer->numErrors()) {
 			$pa_errors[] = _t("Could not save worksheet for future download: %1", join("; ", $t_importer->getErrors()))."\n";
 			if ($o_log) {  $o_log->logError(_t("[loadImporterFromFile:%1] Error saving worksheet for future download: %2", $ps_source, join("; ", $t_importer->getErrors()))); }
 		}
-		
+
 		foreach($va_mapping as $vs_group => $va_mappings_for_group) {
 			$vs_group_dest = ca_data_importers::_getGroupDestinationFromItems($va_mappings_for_group);
-			if (!$vs_group_dest) { 
+			if (!$vs_group_dest) {
 				$va_item = array_shift(array_shift($va_mappings_for_group));
 				$pa_errors[] = _t("Skipped items for %1 because no common grouping could be found", $va_item['destination'])."\n";
 				if ($o_log) { $o_log->logWarn(_t("[loadImporterFromFile:%1] Skipped items for %2 because no common grouping could be found", $ps_source, $va_item['destination'])); }
 				continue;
 			}
-			
+
 			$t_group = $t_importer->addGroup($vs_group, $vs_group_dest, array(), array('returnInstance' => true));
 			if(!$t_group) {
 				$pa_errors[] = _t("There was an error when adding group %1", $vs_group);
 				if ($o_log) { $o_log->logError(_t("[loadImporterFromFile:%1] There was an error when adding group %2", $ps_source, $vs_group)); }
 				return null;
 			}
-			
+
 			// Add items
 			foreach($va_mappings_for_group as $vs_source => $va_mappings_for_source) {
 				foreach($va_mappings_for_source as $va_row) {
 					$va_item_settings = array();
 					$va_item_settings['refineries'] = array($va_row['refinery']);
-				
+
 					$va_item_settings['original_values'] = $va_row['original_values'];
 					$va_item_settings['replacement_values'] = $va_row['replacement_values'];
-				
+
 					if (is_array($va_row['options'])) {
 						foreach($va_row['options'] as $vs_k => $vs_v) {
 							if ($vs_k == 'restrictToRelationshipTypes') { $vs_k = 'filterToRelationshipTypes'; }	// "restrictToRelationshipTypes" is now "filterToRelationshipTypes" but we want to support old mappings so we translate here
@@ -1161,18 +1168,18 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 							$va_item_settings[$va_row['refinery'].'_'.$vs_k] = $vs_v;
 						}
 					}
-					
+
 					$t_group->addItem($vs_source, $va_row['destination'], $va_item_settings, array('returnInstance' => true));
 				}
 			}
 		}
-		
+
 		if(sizeof($pa_errors)) {
 			foreach($pa_errors as $vs_error) {
 				$t_importer->postError(1100, $vs_error, 'ca_data_importers::loadImporterFromFile');
 			}
 		}
-		
+
 		return $t_importer;
 	}
 	# ------------------------------------------------------


### PR DESCRIPTION
Importer worksheet uploads failed with the following error returned by
UploadImporters:

Fatal error: Uncaught TypeError:
PhpOffice\PhpSpreadsheet\Worksheet\Worksheet::getCell():
Argument :  ($coordinate) must be of type string, array given

The importer loader used calls like:

$o_sheet->getCell([1, $row])

This worked with older PhpSpreadsheet behavior, where array-style
coordinates were accepted. The currently installed version requires
A1-style string coordinates (for example "A1") instead of arrays.

To keep the change low-risk, a small local helper was added inside
loadImporterFromFile() to convert array coordinates to A1 notation
before calling getCell().

No importer logic was changed; the patch only normalizes cell
coordinates for compatibility with newer PhpSpreadsheet versions.