### PR TITLE
Ticket[KULTMMS-1334]: git commit -m "Fix incorrect BCE decade range normalization in browse facet

### DIFF
--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -1846,6 +1846,19 @@ class BrowseEngine extends BaseFindEngine {
 									if ($vn_row_id !== 'null') {
 										if (!$o_tep->parse($vn_row_id)) { continue; } // invalid date?
 										$va_dates = $o_tep->getHistoricTimestamps();
+
+										// normalize broken BCE decade ranges
+										if (
+											($vs_normalization === 'decades')
+											&& isset($va_dates['start'], $va_dates['end'])
+											&& ((float)$va_dates['start'] < 0)
+											&& ((float)$va_dates['end'] > 1000)
+										) {
+											$vn_decade = abs((int)$va_dates['start']);
+
+											$va_dates['start'] = -1 * ($vn_decade + 9);
+											$va_dates['end'] = -1 * $vn_decade;
+										}
 										
 										$tmp = explode('.', $va_dates['start']);
 										if (substr($tmp[1], 0, 10) == '0101000000') { // rewrite start date to encompass circa dates


### PR DESCRIPTION
This change fixes incorrect filtering for BCE decade values in normalized date browse facets.

In some cases, TimeExpressionParser returned an open-ended upper bound for BCE decade values (for example: start=-30, end=2021...), causing browse queries to match an excessively large result set.

The fix normalizes invalid BCE decade ranges after parsing and limits them to the expected decade interval.

Scope is intentionally narrow:
- only affects decades normalization
- only applies to BCE ranges with invalid upper bounds
- does not affect CE parsing or SQL generation logic