### PR TITLE
Feat/repeatable template exporter

### DIFF
--- a/app/models/ca_data_exporters.php
+++ b/app/models/ca_data_exporters.php
@@ -1532,13 +1532,8 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 					'text' => trim($matches[1]),
 					'element' => $element,
 				];
-			} else if($template) {
-				$proc_template = caProcessTemplateForIDs($template, $table_num, [$record_id], []);
-				$item_info[] = [
-					'text' => $proc_template,
-					'element' => $element,
-				];
-			} else if(in_array($source, ["relationship_type_id", "relationship_type_code", "relationship_typename"])) {
+			}
+			else if(in_array($source, ["relationship_type_id", "relationship_type_code", "relationship_typename"])) {
 				// Relationship type
 				if(isset($options[$source]) && strlen($options[$source])>0) {							
 					$o_log->logDebug(_t("Source refers to relationship type information. Value for this mapping is '%1'", $options[$source]));
@@ -1553,12 +1548,18 @@ class ca_data_exporters extends BundlableLabelableBaseModelWithAttributes {
 				}
 			} else {
 				// Values
-				$values = $t_instance->get($source, array_merge(
-					$get_options, 
-					['returnAsArray' => true]
-				));
-				$values_raw = $return_raw_data ? $t_instance->get($source, ['returnAsArray' => true]) : [];
-				
+				if($template) {//string or array
+					$values = caProcessTemplateForIDs($template, $table_num, [$record_id], []);
+					$delimiter = $settings['delimiter'] ?? null;
+					if($is_repeat && $delimiter) $values = explode($delimiter, $values);
+				}else {
+					$values = $t_instance->get($source, array_merge(
+						$get_options,
+						['returnAsArray' => true]
+					));
+					$values_raw = $return_raw_data ? $t_instance->get($source, ['returnAsArray' => true]) : [];
+				}
+
 				// TODO: handle this more centrally?
 				if($omit_if_empty) {
 					$values = array_filter($values, 'strlen');


### PR DESCRIPTION
When using a template in the exporter that logic workflow path terminates with returning the processed template value, not passing the option to repeat_element_for_multiple_values.
It would be nice to have the repeat_element_for_multiple_values though, and this change would allow that on a chosen delimiter (hiking on the $values array).
Having the delimiter as part of the settings does not require parsing the delimiter from the template and allows for more creative exploding (for instance with nested units).

Direct templating can be more performant than switching "context" for relations, but templating loses the option of repetition. That was the use-case that triggered this evaluation.

There appear two paths for the use of "template" in the processExporterItem function, for this POC I only touched the pathway with source (not clear why that would be different, having source or not - source itself is not used on templating).

I'm not sure if and/or what needs to be done to have other @attributes added to these elements from other mapping rows, as with the original repeatable values; since this follows the $values I think it should be the same..

For instance:
<img width="1480" height="109" alt="image" src="https://github.com/user-attachments/assets/39716ae8-19f4-4de9-a167-1d3762a1383b" />

Results:
<img width="430" height="115" alt="image" src="https://github.com/user-attachments/assets/0c4fb4b3-1158-437e-8d46-3cc335c41567" />


languages is the original repeatable from the multivalue source, languageo "fails" repeating through template (just returning the delimited values), languages and languagez became repeatable with minimal and (_very specialistic_) template renders.

The change should be safe, not using the repeat_element_for_multiple_values and delimiter settings will behave as currently (as in the example languageo not having the delimiter)