### PR TITLE
Ticket[KULTMMS-2726]: Fix malformed direct relative_to joins in browse facets

### DIFF
--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -8212,7 +8212,8 @@ if (!($va_facet_info['show_all_when_first_facet'] ?? null) || ($this->numCriteri
 			";
 		} else { // path of length 2, i.e. direct relationship like ca_objects.lot_id = ca_object_lots.lot_id ==> join relative_to and browse target tables directly
 			$va_rel_info = Datamodel::getRelationships($ps_relative_to_table, $t_rel_item->tableName());
-			$va_relative_to_join[] = "INNER JOIN {$ps_relative_to_table} ON {$ps_relative_to_table}.{$va_rel_info[$t_rel_item->tableName()][$ps_relative_to_table][1][1]} = {$t_rel_item->tableName()}.{$va_rel_info[$ps_relative_to_table][$t_rel_item->tableName()][1][1]}";
+			$vn_rel_index = isset($va_rel_info[$t_rel_item->tableName()][$ps_relative_to_table][1]) ? 1 : 0;
+			$va_relative_to_join[] = "INNER JOIN {$ps_relative_to_table} ON {$ps_relative_to_table}.{$va_rel_info[$t_rel_item->tableName()][$ps_relative_to_table][$vn_rel_index][1]} = {$t_rel_item->tableName()}.{$va_rel_info[$ps_relative_to_table][$t_rel_item->tableName()][$vn_rel_index][1]}";
 		}
 
 		return array(


### PR DESCRIPTION
BrowseEngine::_getRelativeExecuteSQLData() assumed that direct
relationship metadata returned by Datamodel::getRelationships()
always exists at index [1].

For path-of-length-2 relationships (direct FK relations such as
ca_objects.lot_id -> ca_object_lots.lot_id), relationship metadata
may instead only exist at index [0].

Using [1][1] unconditionally therefore produced malformed JOIN clauses
with missing field names, resulting in invalid SQL such as:

INNER JOIN ca_object_lots ON ca_object_lots. = ca_objects.

and:

INNER JOIN ca_objects_x_collections ON ca_objects.o...

This caused configuration errors in several browse and refine-search
workflows involving relative_to facets and metadata joins, including:

- Objects > Simple Search > Refine Search > Acquisition Months
- Object lots browse with combined acquisition year and collection filters
- Related browse queries using direct relationship paths

The fix now falls back to relationship index [0] when index [1]
is not available, preserving existing behavior while correctly handling
direct FK relationship metadata.

This restores valid JOIN generation for relative_to browse facets and
prevents malformed SQL in metadata-based browse filtering.