### PR TITLE
Ticket[KULTMMS-2726]: Add missing caGetInformationServiceMirrorListInformation() helper to browseHelpers.php

### DIFF
--- a/app/helpers/browseHelpers.php
+++ b/app/helpers/browseHelpers.php
@@ -317,3 +317,31 @@ function caGetBrowseForType($table, $type=null, ?array $options=null) : ?string 
 	return null;
 }
 # ---------------------------------------
+/**
+ *
+ *
+ *
+ */
+function caGetInformationServiceMirrorListInformation($t_element) {
+	if (!$t_element) {
+		return false;
+	}
+
+	$va_settings = $t_element->getSettings();
+
+	// direct list mirror
+	if (isset($va_settings['list']) && (int)$va_settings['list'] > 0) {
+		return [
+			'list' => (int)$va_settings['list']
+		];
+	}
+
+	// common CA list_id pattern
+	if (isset($va_settings['list_id']) && (int)$va_settings['list_id'] > 0) {
+		return [
+			'list' => (int)$va_settings['list_id']
+		];
+	}
+
+	return false;
+}


### PR DESCRIPTION
Add missing caGetInformationServiceMirrorListInformation() helper to browseHelpers.php

BrowseEngine.php calls caGetInformationServiceMirrorListInformation()
during browse facet label resolution, but the helper function was not
defined in app/helpers/browseHelpers.php.

This caused browse facets to fail with the following fatal error:

"Fatal error: Uncaught Error: Call to undefined function
caGetInformationServiceMirrorListInformation()"

when loading attribute/list-based browse facets.

Adds the missing helper implementation and restores proper browse
facet rendering for affected deployments.