### PR TITLE
Feat/user history housekeeping

### DIFF
--- a/app/lib/ResultContext.php
+++ b/app/lib/ResultContext.php
@@ -1071,7 +1071,7 @@ class ResultContext {
 	 */ 
 	public function setSearchHistory($pn_hits) {
 		if ($pn_hits > 0) {
-			$va_history = $this->getSearchHistory();
+			$va_history = array_slice($this->getSearchHistory(),-99);
 			
 			if ($vs_search = $this->getSearchExpression()) {
 				$va_history[$vs_search] = array(


### PR DESCRIPTION
As discussed in https://support.collectiveaccess.org/d/302313-user-search-history-on-profile/5

some user profiles from very active and long exisiting users tend to grow abnormally large history arrays. One user had almost 4mb vars flirting with the default mysql max allowed packets setting (was how we discovered this "issue" - user had fails and log folder flooded with logs). While this can be handled with larger mysql settings, these arrays are used to repopulate the search history dropdown, and very large lists are hardly user friendly (and the counts risk to be outdated).

This fix, trimming the history array to max 100 previous searches brought down all scoped history arrays organically (types, subtypes,..) and the user profile back to about 0.5mb.

The 100 (-99 +1) is now a constant, could be a configurable (conf or user prefs) - some users might even prefer less than a handful since they can also decide to keep saved searches (currently without the option to manage that old list too).