### PR TITLE
early return timestamps when no user logs

### DIFF
--- a/app/lib/ApplicationChangeLog.php
+++ b/app/lib/ApplicationChangeLog.php
@@ -702,9 +702,11 @@ class ApplicationChangeLog {
 		}
 		
 		// Add user info
-		$log_ids = array_map(function($v) { 
-			return $v['log_id'] ?? null;
-		}, $timestamps);
+	    $log_ids = array_filter(array_map(function($v) {
+		    return $v['log_id'] ?? null;
+	    }, $timestamps));
+
+	    if(empty($log_ids)) { return $timestamps; }
 		
 		$qr_res = $o_db->query("
 				SELECT wcl.log_id, wu.user_id, wu.fname, wu.lname, wu.email


### PR DESCRIPTION
we got a (fatal) error when the log_ids are empty, where mysql errors on "wcl.log_id IN ()", not correct syntax for the IN clause.

Can the $timestamps array be early returned before doing the user tampering ?