### PR TITLE
This change removes several hardcoded date formatting implementations and aligns date rendering with the configured system-wide date settings.

### DIFF
--- a/app/lib/Attributes/Values/DateRangeAttributeValue.php
+++ b/app/lib/Attributes/Values/DateRangeAttributeValue.php
@@ -336,7 +336,10 @@ class DateRangeAttributeValue extends AttributeValue implements IAttributeValue 
 				$vs_date_format = $o_date_config->get('dateFormat');
 			}
 		}
-
+		if ((bool)$va_settings['useDatePicker']) {
+			$vs_date_format = 'delimited';
+		}
+		
 		$vs_cache_key = caMakeCacheKeyFromOptions($pa_options, $vs_date_format.$this->opn_start_date.$this->opn_end_date);
 
 		// pull from cache

--- a/app/lib/Attributes/Values/DateRangeAttributeValue.php
+++ b/app/lib/Attributes/Values/DateRangeAttributeValue.php
@@ -336,10 +336,7 @@ class DateRangeAttributeValue extends AttributeValue implements IAttributeValue 
 				$vs_date_format = $o_date_config->get('dateFormat');
 			}
 		}
-		if ((bool)$va_settings['useDatePicker']) {
-			$vs_date_format = 'delimited';
-		}
-		
+
 		$vs_cache_key = caMakeCacheKeyFromOptions($pa_options, $vs_date_format.$this->opn_start_date.$this->opn_end_date);
 
 		// pull from cache

--- a/app/widgets/lastLogins/views/main_html.php
+++ b/app/widgets/lastLogins/views/main_html.php
@@ -44,7 +44,7 @@
 <?php
 	foreach($va_login_list as $vn_i => $va_login) {
 		print "<tr>";
-		print "<td>".date("n/d/y, g:iA T", $va_login['date_time'])."</td>";
+		print "<td>".caGetLocalizedDate($va_login['date_time'], ['timeOmit' => false])."</td>";
 		print "<td>".$va_login['fname'].' '.$va_login['lname'].' ('.$va_login['username'].")</td>";
 		if($show_ips) { print "<td>".$va_login['ip']."</td>"; }
 		print "</tr>\n";

--- a/themes/default/views/batch/metadataimport/importer_list_html.php
+++ b/themes/default/views/batch/metadataimport/importer_list_html.php
@@ -124,7 +124,7 @@ if (!$this->request->isAjax()) {
 					}
 ?>				</td>
 				<td>
-					<?= caGetLocalizedDate($importer['last_modified_on'], array('timeOmit' => false, 'dateFormat' => 'delimited')); ?>
+					<?= caGetLocalizedDate($importer['last_modified_on'], ['timeOmit' => false]); ?>
 				</td>
 				<td class="listtableEditDelete">
 					<?= caNavButton($this->request, __CA_NAV_ICON_GO__, _t("Import data"), '', 'batch', 'MetadataImport', 'Run', array('importer_id' => $importer['importer_id']), array(), array('icon_position' => __CA_NAV_ICON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)); ?>

--- a/themes/default/views/manage/export/exporter_list_html.php
+++ b/themes/default/views/manage/export/exporter_list_html.php
@@ -96,7 +96,7 @@ if (!$this->request->isAjax()) {
 					<?= $exporter['exporter_type']; ?>
 				</td>
 				<td>
-					<?= caGetLocalizedDate($exporter['last_modified_on'], array('dateFormat' => 'delimited')); ?>
+					<?= caGetLocalizedDate($exporter['last_modified_on'], ['timeOmit' => false]); ?>
 				</td>
 				<td>
 					<?= caNavButton($this->request, __CA_NAV_ICON_DELETE__, _t("Delete"), '', 'manage', 'MetadataExport', 'Delete', array('exporter_id' => $exporter['exporter_id']), array(), array('icon_position' => __CA_NAV_ICON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)); ?>

--- a/themes/default/views/manage/set_list_html.php
+++ b/themes/default/views/manage/set_list_html.php
@@ -185,7 +185,7 @@ if (!$this->request->isAjax()) {
 					<div><?= $t_set->getChoiceListValue('access', $set['access']); ?></div>
 				</td>
 				<td>
-					<div><?= caGetLocalizedDate($set['created'], ['timeOmit' => true, 'dateFormat' => 'delimited']); ?></div>
+					<div><?= caGetLocalizedDate($set['created'], ['timeOmit' => true]); ?></div>
 				</td>
 				<td class="listtableEditDelete">
 					<?= caNavButton($this->request, __CA_NAV_ICON_EDIT__, _t("Edit"), '', 'manage/sets', 'SetEditor', 'Edit', array('set_id' => $set['set_id']), array(), array('icon_position' => __CA_NAV_ICON_ICON_POS_LEFT__, 'use_class' => 'list-button', 'no_background' => true, 'dont_show_content' => true)); ?>


### PR DESCRIPTION
Changes include:
- Use datetime.conf as the primary source for date display formatting.
- Replace hardcoded date() calls with localized date formatting helpers.
- Remove explicit dateFormat overrides in views where the system configuration should be respected.

This ensures consistent date presentation throughout the application and allows administrators to centrally control formatting via `datetime.conf`.