### PR TITLE
update the caGetHTMLPurifier to check for dir

### DIFF
--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -5071,6 +5071,15 @@ function caFileIsIncludable($ps_file) {
 	function caGetHTMLPurifier(?array $options=null) : HTMLPurifier {
 		$config = HTMLPurifier_Config::createDefault();
 		$config->set('URI.DisableExternalResources', !Configuration::load()->get('purify_allow_external_references'));
+		$serializer_path = Configuration::load()->get('purify_serializer_path');
+		# Check if path exists, if not make dir and set owner:group to same as ca tmp dir
+		if(!file_exists($serializer_path)) { 
+			$tempdir_info = stat(Configuration::load()->get('ca_temp_dir'));
+			mkdir($serializer_path, 0770, true);
+			chown($serializer_path, $tempdir_info['uid']);
+			chgrp($serializer_path, $tempdir_info['gid']);
+			clearstatcache();
+		}
 		$config->set('Cache.SerializerPath', Configuration::load()->get('purify_serializer_path'));
 		return new HTMLPurifier($config); 
 	}

--- a/app/lib/Utils/CLIUtils/Maintenance.php
+++ b/app/lib/Utils/CLIUtils/Maintenance.php
@@ -1062,12 +1062,12 @@ trait CLIUtilsMaintenance {
 		if (in_array($cache, ['all', 'app'])) {
 			CLIUtils::addMessage(_t('Clearing application caches...'));
 			if (is_writable($config->get('taskqueue_tmp_directory'))) {
-				$tempdir_info = stat($config->get('taskqueue_tmp_directory'));
+			#	$tempdir_info = stat($config->get('taskqueue_tmp_directory'));
 				caRemoveDirectory($config->get('taskqueue_tmp_directory'), false);
-				mkdir($config->get('purify_serializer_path'), $tempdir_info['mode']);
-				chown($config->get('purify_serializer_path'), $tempdir_info['uid']);
-				chgrp($config->get('purify_serializer_path'), $tempdir_info['gid']);
-				clearstatcache();
+			#	mkdir($config->get('purify_serializer_path'), $tempdir_info['mode']);
+			#	chown($config->get('purify_serializer_path'), $tempdir_info['uid']);
+			#	chgrp($config->get('purify_serializer_path'), $tempdir_info['gid']);
+			#	clearstatcache();
 			} else {
 				CLIUtils::addError(_t('Skipping clearing of application cache because it is not writable'));
 			}


### PR DESCRIPTION
If the directory doesn't exist, create the directory and set the owner/group to that of the CA tmp directory

This should fix the issue reported at https://support.collectiveaccess.org/d/302330-repeated-htmlpurifier-warnings-during-installation-profile-update 