### PR TITLE
follow redirects for aat service

### DIFF
--- a/app/lib/Plugins/InformationService/BaseGettyLODServicePlugin.php
+++ b/app/lib/Plugins/InformationService/BaseGettyLODServicePlugin.php
@@ -100,6 +100,8 @@ abstract class BaseGettyLODServicePlugin extends BaseInformationServicePlugin {
 			"https://vocab.getty.edu/sparql.json?query={$ps_query}" );
 		$pa_options[ CURLOPT_CONNECTTIMEOUT ] = caGetOption( CURLOPT_CONNECTTIMEOUT, $pa_options, 2 );
 		$pa_options[ CURLOPT_RETURNTRANSFER ] = caGetOption( CURLOPT_RETURNTRANSFER, $pa_options, 1 );
+		$pa_options[ CURLOPT_FOLLOWLOCATION ] = caGetOption( CURLOPT_FOLLOWLOCATION, $pa_options, true );
+		$pa_options[ CURLOPT_MAXREDIRS ] = caGetOption( CURLOPT_MAXREDIRS, $pa_options, 5 );
 		$pa_options[ CURLOPT_USERAGENT ]      = caGetOption( CURLOPT_USERAGENT, $pa_options,
 			'CollectiveAccess web service lookup' );
 


### PR DESCRIPTION
AAT failed today because of 301 permanent redirect to the output that curl does not follow by default.

adding 

curl_setopt($o_curl, CURLOPT_FOLLOWLOCATION, true);
curl_setopt($o_curl, CURLOPT_MAXREDIRS, 5);

solved this for our 1.7.x installation(s) but this fix should do the same for the new version (our main fcous is the new version but the above is the plain syntax for 1.7).


The old endpoint then works as is, but maybe we should also investigate what their plans are with the current endpoint ??
