### PR TITLE
Update JWT token key length requirement in config

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -3486,7 +3486,7 @@ allow_transcription = 1
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    
                                     
 # Key used to generate JSON web tokens (JWT) for authentication with GraphQL-based API services
-# Set this to a random string of letters and numbers.
+# Set this to a random string of minimum 32 characters of letters and numbers.
 graphql_services_jwt_token_key = blah
 
 # Interval before JWT will require refresh, in seconds


### PR DESCRIPTION
firebase/JWT now checks the length of the key and throws an error is it is less than 32 characters long.  Make note of this for users wishing to use the graphQL API

Due to: https://github.com/googleapis/php-jwt/issues/605