### PR TITLE
Bump version webonyx/graphql-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "phpoffice/phpword": "~1.4",
     "phpunit/phpunit": "^11.0",
     "srmklive/flysystem-dropbox-v2": ">=1.0.0",
-    "webonyx/graphql-php": "^14.1",
+    "webonyx/graphql-php": "^15",
     "ext-iconv": "*",
     "ext-simplexml": "*",
     "phpseclib/phpseclib": ">=2.0.47",


### PR DESCRIPTION
Bumping version to 15 to solve security vulnerabilities reported in composer:
```
Found 3 security vulnerability advisories affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | webonyx/graphql-php                                                              |
| CVE               | NO CVE                                                                           |
| Title             | webonyx/graphql-php has unbounded recursion in parser that causes stack overflow |
|                   | on crafted nested input                                                          |
| URL               | https://github.com/advisories/GHSA-r7cg-qjjm-xhqq                                |
| Affected versions | <=15.32.2                                                                        |
| Reported at       | 2026-05-05T17:24:57+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | webonyx/graphql-php                                                              |
| CVE               | NO CVE                                                                           |
| Title             | webonyx/graphql-php has quadratic validation cost in OverlappingFieldsCanBeMerge |
|                   | d via inline fragments                                                           |
| URL               | https://github.com/advisories/GHSA-fc86-6rv6-2jpm                                |
| Affected versions | <15.32.2                                                                         |
| Reported at       | 2026-05-04T22:22:09+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | webonyx/graphql-php                                                              |
| CVE               | CVE-2026-40476                                                                   |
| Title             | graphql-php is affected by a Denial of Service via quadratic complexity in Overl |
|                   | appingFieldsCanBeMerged validation                                               |
| URL               | https://github.com/advisories/GHSA-68jq-c3rv-pcrr                                |
| Affected versions | <=15.31.4                                                                        |
| Reported at       | 2026-04-14T01:05:05+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```