### PR TITLE
Fix metadata import progress display for processOnly refinery imports

### DIFF
--- a/themes/default/views/batch/metadataimport/batch_results_html.php
+++ b/themes/default/views/batch/metadataimport/batch_results_html.php
@@ -84,9 +84,9 @@
 		if ($pn_number_of_files <= 1) { print "jQuery('#batchProcessingTableProgressGroup').hide();"; }
 		print "jQuery('#progressbarFiles').progressbar('value',{$pn_file_percentage}); jQuery('#batchProcessingFileCount').html('{$ps_file_message}');";
 		print "jQuery('#progressbar').progressbar('value',{$pn_percentage}); jQuery('#batchProcessingRowProgressGroup').html('{$ps_message}');";
-		print "jQuery('#batchProcessingElapsedTime').html('".caFormatInterval($pn_elapsed_time)."/".sprintf("%4.2f mb", ($pn_memory_used/ 1048576))."');"; 
-		print "jQuery('#batchProcessingCounts').html('".addslashes(_t("%1 processed; %2 errors", $pn_num_processed, $pn_num_errors))."');"; 
-		
+		print "jQuery('#batchProcessingElapsedTime').html('".caFormatInterval($pn_elapsed_time)."/".sprintf("%4.2f mb", ($pn_memory_used/ 1048576))."');";
+		$pn_num_processed = max((int)$pn_num_processed, (int)$pn_rows_complete);
+		print "jQuery('#batchProcessingCounts').html('".addslashes(_t("%1 processed; %2 errors", $pn_num_processed, $pn_num_errors))."');";
 		print "</script>";
 		caFlushOutput();
 	}


### PR DESCRIPTION
When using processOnly refineries (e.g. listItemIndentedHierarchyBuilder in processOnly mode), metadata imports successfully process rows and create list items, but the progress display shows "0 processed".

The reason is that num_processed remains 0 for these imports, while rows_complete correctly reflects the number of processed rows.

This change updates the progress display to use rows_complete as a fallback when num_processed is 0, ensuring the UI reflects actual import progress.

Users expect to see the actual processing progress regardless of whether records are imported directly or processed through a processOnly refinery.

This is a display-only change and does not affect import behavior or processing logic.
