### PR TITLE
bump version guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "elasticsearch/elasticsearch": "~7.0",
     "ezyang/htmlpurifier": "~4.9",
     "guzzlehttp/guzzle": "^7.9",
-    "guzzlehttp/psr7": "2.8.*",
+    "guzzlehttp/psr7": "^2.0",
     "james-heinrich/getid3": "^1.9.20",
     "joshralph/password-policy": "~0.2",
     "knplabs/github-api": "^3.14",


### PR DESCRIPTION
Upping version to any version 2 to keep up with security fixes.

**This needs to be tested and reviewed!**

Prompted by composer security audit:
```
+-------------------+----------------------------------------------------------------------------------+
| Package           | guzzlehttp/psr7                                                                  |
| CVE               | CVE-2026-48998                                                                   |
| Title             | guzzlehttp/psr7 has Host Confusion via Authority Reinterpretation                |
| URL               | https://github.com/advisories/GHSA-34xg-wgjx-8xph                                |
| Affected versions | <2.10.2                                                                          |
| Reported at       | 2026-06-11T13:04:53+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | guzzlehttp/psr7                                                                  |
| CVE               | CVE-2026-49214                                                                   |
| Title             | guzzlehttp/psr7 has CRLF Injection via URI Host Component                        |
| URL               | https://github.com/advisories/GHSA-hq7v-mx3g-29hw                                |
| Affected versions | <2.10.2                                                                          |
| Reported at       | 2026-06-11T13:04:47+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```