### PR TITLE
Persist changes made by direct editing and fill handle operations

### DIFF
--- a/assets/ca/ca.tableview.js
+++ b/assets/ca/ca.tableview.js
@@ -271,7 +271,7 @@ var caUI = caUI || {};
 					return cellProperties;
 				},
 				afterChange: function (change, source) {
-					if (source === 'edit') { // only save edits
+                    if (source === 'edit' || source === 'autofill') { // only save edits
 						for(var i in change) {
 							var r = change[i][0];
 							var ht = jQuery(that.container + " ." + that.gridClassName).data('handsontable');


### PR DESCRIPTION
Previously, only changes with the source "edit" were persisted. However, changes made by dragging the Handsontable fill handle use the "autofill" source. As a result, copied values appeared correctly in the table, giving the impression that they had been applied, but they were never persisted and were lost after reloading the page.

This change treats "autofill" changes the same as manual edits by passing each affected cell through the existing save queue. As a result, values entered manually and values applied using the fill handle are now saved consistently.