### PR TITLE
Ticket[KULTMMS-2727]: Prevent duplicate currency symbols in formatted currency values

### DIFF
--- a/app/lib/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/Attributes/Values/CurrencyAttributeValue.php
@@ -241,7 +241,7 @@ class CurrencyAttributeValue extends AttributeValue implements IAttributeValue {
 		if(substr($vs_decimal_with_placeholder,0,2)=="¤") { // '¤' has length 2
 			$vs_decimal_with_placeholder = preg_replace("!¤[^\d]*!u", ($cur_spec_add_space ? '% ' : '%'), $vs_decimal_with_placeholder);
 		} elseif(substr($vs_decimal_with_placeholder, -2)=="¤") { // placeholder at the end
-			$vs_decimal_with_placeholder = preg_replace("![^\d\,\.]!", "", $vs_decimal_with_placeholder).($cur_spec_add_space ? ' %' : '%')."%";
+			$vs_decimal_with_placeholder = preg_replace("![^\d\,\.]!", "", $vs_decimal_with_placeholder).($cur_spec_add_space ? ' %' : '%');
 		}
 
 		// insert currency which is not locale-dependent in our case


### PR DESCRIPTION
This fixes a regression introduced in commit 83bc8187 ("Don't put space between currency symbol and quantity").

For currency symbols that are displayed without a separating space (such as `€`), the placeholder logic appends two placeholders instead of one in the end-placeholder branch. Since `str_replace()` replaces every placeholder, formatted values are rendered with duplicated currency symbols, for example:
```
236,57€€
instead of:
236,57€
```


If such a value is edited and saved again, `parseValue()` interprets `€€` as the currency specifier, causing the validation error:

> Currency specified for <field> does not appear to be valid

As a result, the value can no longer be saved correctly.

This change preserves the intended formatting introduced by 83bc8187 (no space for symbols such as `€`, `$`, `£` and `¥`) while ensuring that only a single currency placeholder is appended.


**An image to explain the bug:**

<img width="1304" height="915" alt="grafik" src="https://github.com/user-attachments/assets/55ec2e79-37c2-4699-8c34-a4dc15922d52" />


