### PR TITLE
bugfix/currency-variable-typo

### DIFF
--- a/app/lib/Attributes/Values/CurrencyAttributeValue.php
+++ b/app/lib/Attributes/Values/CurrencyAttributeValue.php
@@ -220,7 +220,7 @@ class CurrencyAttributeValue extends AttributeValue implements IAttributeValue {
 			if(!in_array($cur_spec, ['$', "£", "¥", "€"])) { 
 				$cur_spec .= ' ';
 			}
-			return $cur_spac.$this->opn_value;
+			return $cur_spec.$this->opn_value;
 		}
 		
 		$o_locale = $_locale ? $_locale : new Zend_Locale(__CA_DEFAULT_LOCALE__);


### PR DESCRIPTION
This fixes a typo introduced in commit 83bc8187.

The variable `$cur_spac` should be `$cur_spec`. While this code path is currently not exercised in the reported issue, correcting the variable name avoids referencing an undefined variable and keeps the implementation consistent.