### PR TITLE
Ticket[KULTMMS-2732]: The generated query for the `contains` operator was inconsistent with the query parser.

### DIFF
--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -129,7 +129,8 @@ var caUI = caUI || {};
 				case 'begins_with':
 					return prefix + escapeValue('^' + ruleSet.value, true);
 				case 'contains':
-					return prefix + escapeValue(ruleSet.value, true);
+                    // Generate wildcard queries for "contains" to match the parser behavior.
+                    return prefix + escapeValue(ruleSet.value, false, '*', '*');
 				case 'ends_with':
 					return prefix + escapeValue('$' + ruleSet.value, true);
 				case 'less':


### PR DESCRIPTION
The `contains` operator in the Query Builder did not behave as expected. Instead of performing a contains search, it generated a quoted phrase search.

For example, the Query Builder generated:

`ca_object_lots.idno_stub:"2022"`

which did not return the expected results.

This change generates wildcard queries instead:

`ca_object_lots.idno_stub:*2022*`

which matches the parser behavior and returns the same results as the corresponding SQL query:

```
SELECT COUNT(*)
FROM ca_object_lots
WHERE idno_stub LIKE '%2022%'
  AND deleted = 0;
```

Both the SQL query and the generated search now return the same results(585).

After Change :

<img width="1274" height="1262" alt="grafik" src="https://github.com/user-attachments/assets/c34ef594-629f-443b-b3a8-0fb604f07562" />

<img width="1381" height="802" alt="grafik" src="https://github.com/user-attachments/assets/97cd7cda-e383-4a25-8c69-95e50e885c63" />




