### PR TITLE
Ticket[KULTMMS-1372]: Align download results label in search tools

### DIFF
--- a/themes/default/views/find/Search/search_tools_html.php
+++ b/themes/default/views/find/Search/search_tools_html.php
@@ -73,7 +73,7 @@ $table = $t_subject->tableName();
 	}
 ?>
 	<div class="col">
-		<?= _t("Download results using"); ?>: <br/>
+		<?= _t("Download results as"); ?>: <br/>
 		<?= caFormTag($this->request, 'export', 'caExportForm', $this->request->getModulePath().'/'.$this->request->getController(), 'post', 'multipart/form-data', '_top', array('noCSRFToken' => false, 'disableUnsavedChangesWarning' => true)); ?>
 <?php
 			$options = [];


### PR DESCRIPTION
The search tools templates currently use inconsistent wording for the download section.

This change updates the remaining template from:

- "Download results using"

to:

- "Download results as"

to match the wording already used in the other search tool templates.

The corresponding translation in `messages.po` already uses "Download results as", so this change also aligns the template with the existing translation.

No functional changes.


<img width="1560" height="909" alt="image" src="https://github.com/user-attachments/assets/0d84a195-a517-4d98-8c4c-bbd1c5617b41" />
