### PR TITLE
fix variable name conflict for object count

### DIFF
--- a/app/models/ca_acl.php
+++ b/app/models/ca_acl.php
@@ -523,7 +523,7 @@ class ca_acl extends BaseModel {
 					if(!($t_coll = ca_collections::findAsInstance(['collection_id' => $qr_sub_records->get('ca_collections.collection_id')]))) { continue; }
 					
 					$object_ids = $t_coll->getRelatedItems('ca_objects', ['restrictToRelationshipTypes' => $rel_types, 'returnAs' => 'ids', 'limit' => 50000]);
-					$c = sizeof($object_ids ?? []);
+					$relatedObjectsCount = sizeof($object_ids ?? []);
 					
 					
 					$access_by_id = $t_object->getFieldValuesForIDs($object_ids, ['access']);
@@ -548,7 +548,7 @@ class ca_acl extends BaseModel {
 					if($is_root || (bool)$t_coll->get('acl_inherit_from_parent')) {
 						$object_ids = $t_coll->getRelatedItems('ca_objects', ['restrictToRelationshipTypes' => $rel_types, 'returnAs' => 'ids', 'limit' => 50000, 'criteria' => ['ca_objects.acl_inherit_from_ca_collections']]);
 						$statistics['inheritingRelatedObjectCount'] += sizeof($object_ids ?? []);
-						$statistics['potentialInheritingRelatedObjectCount'] += $c;
+						$statistics['potentialInheritingRelatedObjectCount'] += $relatedObjectsCount;
 						
 						$statistics['inheritingObjectRepresentationCount'] += ca_acl::_getRepresentationCount($db, $object_ids, ['aclInheritance' => true]);
 					}


### PR DESCRIPTION
acl inherit ui showed problematic inherit counts

<img width="389" height="127" alt="image" src="https://github.com/user-attachments/assets/04894f5f-3a44-4528-9020-f385079b4e42" />

where 138 is the inherited objects with acl_inherit_from_parent inheritingRelatedObjectCount, and 69 was supposed to be potentialInheritingRelatedObjectCount but that abundantly available $c from the object count got overwritten by the last loop in the represenationAccess count https://github.com/collectiveaccess/providence/blob/7f4f48f74398deacd57505c1fdcb88bf92f2f0d6/app/models/ca_acl.php#L551


probably the easiest is to give the main $c a proper name, and let the array loop placeholder $c be 