### PR TITLE
Ticket[KULTMMS-1340]: Fix numeric sorting by item count in set list

### DIFF
--- a/app/controllers/manage/SetController.php
+++ b/app/controllers/manage/SetController.php
@@ -151,11 +151,16 @@ class SetController extends ActionController {
 				$va_set_list[$id]['can_delete'] = $this->UserCanDeleteSet($va_set['user_id']);
 			
 				# --- order the set
-				if(!in_array($vs_sort, array("status", "access"))){
-					$va_set_list_sorted[$va_set[$vs_sort]." ".$id] = $va_set;
-				}else{
-					$va_set_list_sorted[$t_set->getChoiceListValue($vs_sort, $va_set[$vs_sort])." ".$id] = $va_set;
+				if ($vs_sort === 'item_count') {
+					// Pad numeric values so string-key sorting preserves numeric order.
+					$vs_sort_key = sprintf('%010d %d', (int)$va_set[$vs_sort], $id);
+				} elseif (!in_array($vs_sort, array("status", "access"))) {
+					$vs_sort_key = $va_set[$vs_sort]." ".$id;
+				} else {
+					$vs_sort_key = $t_set->getChoiceListValue($vs_sort, $va_set[$vs_sort])." ".$id;
 				}
+
+				$va_set_list_sorted[$vs_sort_key] = $va_set;
 				$va_set_ids[] = $id;
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes incorrect sorting when ordering sets by the **Item count** column.

### Previous behavior

The sort key was built directly from the `item_count` value:

```php
$va_set_list_sorted[$va_set[$vs_sort] . " " . $id] = $va_set;
```

Because the keys were strings and sorted using `ksort()`, the values were ordered lexicographically instead of numerically.

Example:

```text
1
10
100
1000
2
20
200
9
90
900
```

### New behavior

When sorting by `item_count`, the numeric value is now padded before constructing the string sort key:

```php
$vs_sort_key = sprintf('%010d %d', (int)$va_set[$vs_sort], $id);
```

This preserves the existing `ksort()` implementation while ensuring correct numeric ordering.

Example:

```text
1
2
9
10
20
90
100
200
900
1000
```

Sorting behavior for all other columns remains unchanged.

The result: 
<img width="956" height="1180" alt="grafik" src="https://github.com/user-attachments/assets/17c4089c-2ecb-40e7-ac97-2d99ff26777d" />
<img width="977" height="1241" alt="grafik" src="https://github.com/user-attachments/assets/a7b2e0ff-46a2-49fd-8257-40811f8b5951" />
