### PR TITLE
Ticket[KULTMMS-2958] Remove leftover debug output from substring search

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -768,7 +768,6 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 								$anchor_sql = '';
 								$word_op = 'LIKE';
 								$word = ($w == 0) ? "%{$word}%" : "{$word}%";
-								print "[$w] $word<br>\n";
 							}
 							break;
 						case 'START':


### PR DESCRIPTION
Removes a leftover debug print from `SqlSearch2`.

When `use_substring_search_for_contains_searches` is enabled, the debug statement outputs the processed search terms directly into the page, for example:

[0] %d%
[1] 20%

This removes the debug output without changing the substring search behavior.