### PR TITLE
Modify pdfminer_app path in configuration

### DIFF
--- a/app/conf/external_applications.conf
+++ b/app/conf/external_applications.conf
@@ -45,7 +45,7 @@ meshlabserver_app = [/usr/bin/meshlabserver, /usr/local/bin/meshlabserver]
 youtube-dl_app = [/usr/local/bin/youtube-dl, /usr/bin/youtube-dl, /usr/local/bin/yt-dlp, /usr/bin/yt-dlp]]
 
 # Path to pdfminer executable (https://pdfminersix.readthedocs.io)
-pdfminer_app = [/usr/local/bin/pdf2txt.py, /opt/homebrew/bin/pdf2txt.py]
+pdfminer_app = [/usr/bin/pdf2txt, /usr/local/bin/pdf2txt.py, /opt/homebrew/bin/pdf2txt.py]
 
 # Path to curl-impersonate client (https://github.com/lwthiker/curl-impersonate)
 # If present, will be used for http/https connections when downloading content


### PR DESCRIPTION
Ubuntu 24.04 installed pdfminer into /usr/bin/pdf2txt