### PR TITLE
Fix/fatal empty search logs

### DIFF
--- a/themes/default/views/logs/search_html.php
+++ b/themes/default/views/logs/search_html.php
@@ -76,7 +76,7 @@
 		</thead>
 		<tbody>
 <?php
-	if (sizeof($va_search_list)) {
+	if (sizeof($va_search_list ?? [])) {
 		foreach($va_search_list as $va_search) {
 ?>
 			<tr>


### PR DESCRIPTION
search log filtering UI can throw fatal error when the search list is null, this makes the search_list countable on null
(not entirely transparent what the search_list (should) populate with from SearchController; on $ps_search ? https://github.com/collectiveaccess/providence/blob/0892124fa16ec840487fc5aa2bc8f68bf6a31234/app/controllers/logs/SearchController.php#L49)