### PR TITLE
Ticket[KULTMMS-2398]: Use generic download icon for set exports

### DIFF
--- a/app/helpers/printHelpers.php
+++ b/app/helpers/printHelpers.php
@@ -806,7 +806,7 @@ function caEditorPrintSetItemsControls($view) {
 	// Generate print options overlay
 	$buf = $view->render('set_download_options_html.php');    
 	$buf .= "<div id='printButton'>
-		<a href='#' onclick='return caShowSummaryDownloadOptionsPanel();'>".caNavIcon(__CA_NAV_ICON_PDF__, 2)."</a>
+		<a href='#' onclick='return caShowSummaryDownloadOptionsPanel();'>".caNavIcon(__CA_NAV_ICON_DOWNLOAD__, 2)."</a>
 			<script type='text/javascript'>
 					function caShowSummaryDownloadOptionsPanel() {
 						caSummaryDownloadOptionsPanel.showPanel();


### PR DESCRIPTION
Set exports now support multiple formats, including PDF and XLSX.

Replace the PDF-specific icon in the set editor with the generic download icon to better reflect the available export options.

No changes to the export functionality.


### Result
<img width="1027" height="1009" alt="grafik" src="https://github.com/user-attachments/assets/582abcea-9102-48f8-bdf2-e8b2ba906cc1" />
