### PR TITLE
Allow resetting result display on new searches to avoid expensive persisted displays

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -1100,6 +1100,16 @@ ca_objects_include_result_sorts = {
 #ca_objects_reset_sort_on_new_search = ca_objects.idno_sort
 #ca_objects_reset_sort_on_new_browse = ca_objects.idno_sort
 
+# Reset the result display when starting a new object search.
+# This prevents a previously selected, potentially expensive display
+# from being reused automatically for a new search.
+# If not configured, the previously selected display is preserved.
+#
+# <table_name>_reset_display_on_new_search = <display_code>
+#
+# Example:
+# ca_objects_reset_display_on_new_search = <display_code>
+
 # -----------------------------------
 # Caching of sort field lists
 # -----------------------------------

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -103,6 +103,10 @@ class BaseSearchController extends BaseRefineableSearchController {
 			$this->opo_result_context->setCurrentSort($default_sort);
 			$this->opo_result_context->setCurrentSortDirection('ASC');
 		}
+
+		if ($vb_is_new_search && ($default_display = $this->request->config->get($this->ops_tablename.'_reset_display_on_new_search'))) {
+			$this->opo_result_context->setCurrentBundleDisplay($default_display);
+		}
 		
 		if (!($vs_sort 	= $this->opo_result_context->getCurrentSort())) { 
 			$va_tmp = array_keys($this->opa_sorts);


### PR DESCRIPTION
This change adds a table-specific configuration option to reset the selected result display when starting a new search.

The currently selected result display is persisted in the ResultContext. As a result, a previously selected display can automatically be reused for a new search.

This can cause significant search result rendering delays when the persisted display contains many bundles or relationship-based fields. In our tests, the search execution itself was fast, while rendering a large persisted display was responsible for most of the response time.

The new option allows a lightweight default display to be selected automatically for new searches, while users can still switch to any other display afterwards.

The implementation follows the existing table-specific pattern used by:

<table_name>_reset_sort_on_new_search

and adds:

<table_name>_reset_display_on_new_search

The option is fully backward-compatible. If it is not configured, existing behavior remains unchanged.