### PR TITLE
Ticket[KULTMMS-2953]: Apply default result display before initializing new search results

### DIFF
--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -65,6 +65,11 @@ class BaseSearchController extends BaseRefineableSearchController {
 			$this->opo_result_context->setSearchExpression($pa_options['saved_search']['search']);
 			$this->opo_result_context->isNewSearch(true);
 		}
+
+		if ($this->opo_result_context->searchExpressionHasChanged() && ($default_display = $this->request->config->get($this->ops_tablename.'_reset_display_on_new_search'))) {
+			$this->opo_result_context->setCurrentBundleDisplay($default_display);
+		}
+
 		parent::Index($pa_options);
 		
 		AssetLoadManager::register('hierBrowser');
@@ -104,10 +109,6 @@ class BaseSearchController extends BaseRefineableSearchController {
 			$this->opo_result_context->setCurrentSortDirection('ASC');
 		}
 
-		if ($vb_is_new_search && ($default_display = $this->request->config->get($this->ops_tablename.'_reset_display_on_new_search'))) {
-			$this->opo_result_context->setCurrentBundleDisplay($default_display);
-		}
-		
 		if (!($vs_sort 	= $this->opo_result_context->getCurrentSort())) { 
 			$va_tmp = array_keys($this->opa_sorts);
 			$vs_sort = array_shift($va_tmp);


### PR DESCRIPTION
In the previous implementation of *_reset_display_on_new_search, the configured display was reset after parent::Index() had already initialized the current result display.

As a result, on the first new search — especially after login or when another display had previously been selected — the old display could still be rendered. The configured default display only became effective on a subsequent request.

This change checks whether the search expression has actually changed before parent::Index() and applies the configured display at that point:

```
if (
    $this->opo_result_context->searchExpressionHasChanged()
    &&
    ($default_display = $this->request->config->get(
        $this->ops_tablename.'_reset_display_on_new_search'
    ))
) {
    $this->opo_result_context->setCurrentBundleDisplay($default_display);
}
```

This ensures that BaseFindController initializes the result view with the correct configured display on the first new search request, while preserving the user's selected display for requests where the search expression has not changed.

This also avoids forcing the reset on ordinary result navigation or display changes.

